### PR TITLE
docs: address CodeRabbit findings that failed to post on PR #46

### DIFF
--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -675,8 +675,8 @@ the request path after stripping the matched `match.path_prefix` -- so path para
 the mapping (`/api/orders/42` -> `.../orders/42`), and `upstream.path` *replaces* the matched
 prefix rather than prepending to the full request path. Allowed query parameters
 (`forward.query_allow`) are appended unchanged. `connect_timeout_ms` / `read_timeout_ms`
-map to `cui-http` `HttpHandler` (whose builder takes *whole seconds* -- millisecond values are
-rounded *up* to the next second when wired through it); `retry` maps to `ResilientHttpAdapter` + `RetryConfig`
+map to `cui-http` `HttpHandler` (whose builder takes *whole seconds*; a millisecond value that
+is not a whole second is rejected at boot -- fail-fast rather than silently rounded); `retry` maps to `ResilientHttpAdapter` + `RetryConfig`
 (`idempotent_only` retries idempotent methods only -- GET, HEAD, OPTIONS, PUT, DELETE; never
 POST or PATCH). `circuit_breaker` is a small *gateway-side* component wrapped around the
 downstream call -- stateless, per node; `cui-http` supplies retry and timeouts but no breaker
@@ -755,7 +755,7 @@ the sane emission default) is link:adr/0003-forwarded-headers.adoc[ADR-0003].
   the *immediate TCP peer* is in this list -- a *gateway-side* gate: the transport-agnostic
   resolver consumes only a header accessor and never sees the peer, so this check is API
   Sheriff code, and without it a direct client's spoofed `X-Forwarded-For` would be honored.
-  Never trust-all (`0.0.0.0/0`) -- the canonical footgun -- and keep the list as *narrow* as
+  Never trust-all (`0.0.0.0/0` or its IPv6 twin `::/0`) -- the canonical footgun -- and keep the list as *narrow* as
   possible (the exact proxy addresses, not a whole `/8`): every host inside a listed range
   that can reach the gateway directly can spoof forwarding headers. Each listed proxy must
   also *manage* the `X-Forwarded-*` family (append or strip) -- see the mixed-family
@@ -850,7 +850,9 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 * Every `tls.passthrough_sni` alias resolves via the topology, and the resolved URL carries no
   base-path; otherwise the boot fails.
 * `forwarded.trusted_proxies` must be present (may be empty = forwarding headers are never
-  trusted); a non-empty `0.0.0.0/0` is rejected as unsafe.
+  trusted); the trust-all CIDRs `0.0.0.0/0` *and* `::/0` are rejected as unsafe.
+* `upstream.connect_timeout_ms` / `read_timeout_ms` values wired through the `cui-http`
+  `HttpHandler` must be whole seconds; anything else fails the boot (no silent rounding).
 * Secrets in `oidc` (`client_secret`, the session keys) must be `${ENV_VAR}` references, not
   literals.
 * `session.mode: cookie` requires `session.encryption_key`; `previous_key` is optional and

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -675,8 +675,9 @@ the request path after stripping the matched `match.path_prefix` -- so path para
 the mapping (`/api/orders/42` -> `.../orders/42`), and `upstream.path` *replaces* the matched
 prefix rather than prepending to the full request path. Allowed query parameters
 (`forward.query_allow`) are appended unchanged. `connect_timeout_ms` / `read_timeout_ms`
-map to `cui-http` `HttpHandler` (whose builder takes *whole seconds*; a millisecond value that
-is not a whole second is rejected at boot -- fail-fast rather than silently rounded); `retry` maps to `ResilientHttpAdapter` + `RetryConfig`
+map to `cui-http` `HttpHandler` (whose builder takes *whole seconds*; a value that is not a
+multiple of 1000 ms -- i.e. does not represent a whole number of seconds -- is rejected at
+boot, fail-fast rather than silently rounded); `retry` maps to `ResilientHttpAdapter` + `RetryConfig`
 (`idempotent_only` retries idempotent methods only -- GET, HEAD, OPTIONS, PUT, DELETE; never
 POST or PATCH). `circuit_breaker` is a small *gateway-side* component wrapped around the
 downstream call -- stateless, per node; `cui-http` supplies retry and timeouts but no breaker
@@ -852,7 +853,8 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 * `forwarded.trusted_proxies` must be present (may be empty = forwarding headers are never
   trusted); the trust-all CIDRs `0.0.0.0/0` *and* `::/0` are rejected as unsafe.
 * `upstream.connect_timeout_ms` / `read_timeout_ms` values wired through the `cui-http`
-  `HttpHandler` must be whole seconds; anything else fails the boot (no silent rounding).
+  `HttpHandler` must represent a whole number of seconds (multiples of 1000 ms); anything
+  else fails the boot (no silent rounding).
 * Secrets in `oidc` (`client_secret`, the session keys) must be `${ENV_VAR}` references, not
   literals.
 * `session.mode: cookie` requires `session.encryption_key`; `previous_key` is optional and

--- a/doc/variants/02-bff-session.adoc
+++ b/doc/variants/02-bff-session.adoc
@@ -143,7 +143,9 @@ When the stored access token is within the configured leeway of expiry, the gate
 it through the engine using the stored refresh token (with rotation), transparently during a
 normal API request.
 On refresh-token reuse detection the token family is revoked; on refresh failure the session
-is destroyed and the browser is re-driven through the login flow. See
+is destroyed and the request is handled as unauthenticated -- a *navigation* request is
+re-driven through the login flow, while an API/XHR request receives `401`
+`application/problem+json` (the same content negotiation as `require: session`). See
 link:../configuration.adoc[`oidc.session.refresh`].
 
 == Step-Up Authentication (RFC 9470)

--- a/doc/variants/03-bff-cookie.adoc
+++ b/doc/variants/03-bff-cookie.adoc
@@ -61,7 +61,10 @@ and the gateway holds no per-user state.
   authentication and is rejected.
 
 | Cookie attributes
-| `HttpOnly` (JavaScript cannot read it -- XSS-safe), `Secure`, `SameSite=Lax`, `__Host-` prefix.
+| `HttpOnly` (JavaScript can never *read* the token -- direct exfiltration is prevented, but
+  an XSS payload running on the page can still *issue* authenticated requests, and encryption
+  does not prevent *replay* of a stolen cookie before it expires), `Secure`, `SameSite=Lax`,
+  `__Host-` prefix.
 
 | Key management
 | A single server-side symmetric key, provided by environment indirection
@@ -176,6 +179,8 @@ The only material difference from the link:02-bff-session.adoc[session-based] co
 == Properties
 
 * *Stateless* -- no server-side store; encrypted cookie carries the state.
-* *XSS-safe* -- `HttpOnly` cookie; the token is never accessible to JavaScript.
+* *No token exfiltration via script* -- `HttpOnly` cookie; the token is never readable by
+  JavaScript (XSS on the page can still drive authenticated requests -- hence the fixed CSRF
+  defence and short token lifetimes).
 * *Self-contained* -- instances share only the encryption key.
 * *Full OIDC RP* -- confidential-client login, transparent refresh, RFC 9470 step-up.


### PR DESCRIPTION
## Summary

CodeRabbit's review on #46 reported **14 actionable comments, but GitHub failed to post them as inline threads** ("Inline review comments failed to post"). They were recovered from the review body after #46 merged and triaged here.

## Fixed (live docs)

- `forwarded.trusted_proxies` validation now rejects the IPv6 trust-all `::/0` alongside `0.0.0.0/0`.
- `connect_timeout_ms` / `read_timeout_ms` values that are not whole seconds **fail the boot** when wired through cui-http's whole-second `HttpHandler` builder — fail-fast instead of silent rounding.
- Variant 2 refresh-failure wording aligned with the content-negotiation contract: navigations re-enter the login flow, API/XHR requests get `401` `application/problem+json`.
- Variant 3 no longer calls the `HttpOnly` cookie "XSS-safe": it prevents token *exfiltration*, while XSS can still drive authenticated requests and encryption does not prevent replay of a stolen cookie — both limitations now stated.

## Skipped, with reasons

- *Session exhibit mixes cookie/server fields*: intentional full-schema exhibit, marked by NOTE comments; per-mode examples live in the variant documents.
- *11 findings against `doc/archive/**`* (manifest wording, competitor fact-sheet dates/sources/footnotes): the archive is frozen — `doc/README.adoc` declares it kept for history and no longer edited.