### PR TITLE
docs: implementation plans for base, configuration, and request pipeline

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -84,6 +84,13 @@ configuration. Each has its own design section:
   `HttpOnly` cookie, decrypted per request. Stateless (manifest Variant A).
 |===
 
+== Implementation Plans
+
+Sequenced plans for building what these documents describe live under
+link:plan/README.adoc[`plan/`]: base implementation, configuration management, and the
+request pipeline. Each plan names the design documents that must be read before
+implementing it.
+
 == Architecture Decisions
 
 [cols="1,3"]

--- a/doc/plan/01-base-implementation.adoc
+++ b/doc/plan/01-base-implementation.adoc
@@ -9,8 +9,9 @@ Turn the existing scaffolding into a verified, clean foundation: a Quarkus modul
 one real gateway thing end-to-end (a minimal pass-through proxy to a routable upstream), an
 integration-test setup that exercises it against a real upstream target container, a
 benchmark that measures proxy overhead, and *all builds green -- locally and on CI*. The
-structure follows the sibling project `/Users/oliver/git/TokenSheriff`; stale scaffolding
-copied from it is removed.
+structure follows the sibling project https://github.com/cuioss/TokenSheriff[TokenSheriff]
+(assumed checked out next to this repository as `../TokenSheriff`); stale scaffolding copied
+from it is removed.
 
 == Required Reading (before implementation)
 
@@ -19,7 +20,7 @@ copied from it is removed.
 . link:../variants/01-base-gateway.adoc[Variant 1] -- the target the minimal proxy grows into.
 . link:../adr/0001-java25-runtime-baseline.adoc[ADR-0001] -- compile at 21, *run* the
   container/native image on a JDK 25 line (Mandrel builder pin).
-. In `/Users/oliver/git/TokenSheriff`: `agents.md` (dev guidelines), the root and
+. In the TokenSheriff checkout (`../TokenSheriff`): `agents.md` (dev guidelines), the root and
   `token-sheriff-quarkus-parent` poms (profile/plugin conventions),
   `token-sheriff-quarkus-integration-tests/` (compose + scripts + IT layout),
   `benchmarking/` (WRK suite, `benchmarking-common` report engine,

--- a/doc/plan/01-base-implementation.adoc
+++ b/doc/plan/01-base-implementation.adoc
@@ -1,0 +1,203 @@
+= Plan 01 -- Base Implementation
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Turn the existing scaffolding into a verified, clean foundation: a Quarkus module that does
+one real gateway thing end-to-end (a minimal pass-through proxy to a routable upstream), an
+integration-test setup that exercises it against a real upstream target container, a
+benchmark that measures proxy overhead, and *all builds green -- locally and on CI*. The
+structure follows the sibling project `/Users/oliver/git/TokenSheriff`; stale scaffolding
+copied from it is removed.
+
+== Required Reading (before implementation)
+
+. link:../README.adoc[Documentation Index] and link:../architecture.adoc[Architecture] --
+  what is being built overall; this plan implements only the outermost shell.
+. link:../variants/01-base-gateway.adoc[Variant 1] -- the target the minimal proxy grows into.
+. link:../adr/0001-java25-runtime-baseline.adoc[ADR-0001] -- compile at 21, *run* the
+  container/native image on a JDK 25 line (Mandrel builder pin).
+. In `/Users/oliver/git/TokenSheriff`: `agents.md` (dev guidelines), the root and
+  `token-sheriff-quarkus-parent` poms (profile/plugin conventions),
+  `token-sheriff-quarkus-integration-tests/` (compose + scripts + IT layout),
+  `benchmarking/` (WRK suite, `benchmarking-common` report engine,
+  `scripts/benchmark-pages.py`), `.github/workflows/` (reusable org workflows).
+
+== Current State (verified inventory)
+
+The three modules (`api-sheriff`, `integration-tests`, `benchmarks`) already exist, cloned
+from TokenSheriff, and the *harness* is functional: root pom (parent
+`cui-java-parent:1.4.5`, Quarkus 3.37.2, Java release 21, `coverage` profile), native
+Dockerfiles (distroless + JFR), docker-compose (Keycloak 26.5.4, Prometheus, wrk),
+start/stop/health scripts, failsafe-wired `integration-tests`/`jfr`/`benchmark`/`quick`
+profiles, a real WRK post-processor (`benchmarking-common:0.8.0`), and CI workflows
+(`maven.yml`, `integration-tests.yml`, `benchmark.yml` publishing to
+`cuioss.github.io/api-sheriff/benchmarks`). The `pre-commit` and coverage machinery come
+from `cui-java-parent`.
+
+The *product* is placeholder: `GatewayResource` serves only hardcoded `/api/health` +
+`/api/info`; there is no proxying, no upstream, and Keycloak is started but unused. Known
+stale leftovers from TokenSheriff: the `jwt-validation` virtual-thread name prefix,
+`benchmark-with-monitoring.sh` (greps for `jwt` containers, references JMH),
+`TestDataGenerator`/`generators` test-jar (unconsumed), `test-jwks.json` + PEM key files
+(unread), and an empty `integration-tests/src/main/resources/application.properties`.
+
+== Design Decisions
+
+=== D1 -- Keep the TokenSheriff-derived structure; align the parent
+
+The module layout, profile shapes, scripts, and CI wiring already mirror TokenSheriff and
+stay. One deliberate delta to close: TokenSheriff builds on `cui-java-parent:1.5.0`,
+API Sheriff on `1.4.5` -- bump to 1.5.0 so both projects share the same `pre-commit` /
+OpenRewrite / coverage behaviour. (Version bump of an existing parent -- call it out in the
+PR; no new dependency.)
+
+Native builds: pin the Mandrel builder to the JDK 25 line
+(`quarkus.native.builder-image=...ubi9-quarkus-mandrel-builder-image:jdk-25`, the pin
+TokenSheriff already uses) per ADR-0001 -- compile target stays 21.
+
+=== D2 -- Upstream target: `go-httpbin` as the routable backend
+
+The gateway needs something to route *to*, in a way tests can assert on. Researched options
+(echo servers, httpbin forks, whoami, grpcbin, GraphQL fakes; maintenance and multi-arch
+status verified as of 2026) condense to:
+
+[cols="1,2,3"]
+|===
+| Role | Container | Why
+
+| *Primary functional upstream*
+| `ghcr.io/mccutchen/go-httpbin` (pin `v2.23.1`, amd64+arm64, ~15 MB, actively maintained)
+| `/anything/*` echoes the *complete received request* (method, path, headers, query, body)
+  as JSON -- ITs assert exactly what the gateway forwarded or stripped. Also provides
+  `/status/{code}`, `/delay/{s}`, `/drip`, SSE, and *WebSocket echo* (`/websocket/echo`) --
+  one container covers HTTP now and WS + cheap fault simulation in later plans.
+
+| *Benchmark upstream*
+| `nginx:alpine` serving a static payload, `access_log off`
+| The de-facto gateway-benchmark idiom (Traefik/KrakenD/APISIX all benchmark against
+  static/minimal backends); saturates far above the gateway so the backend never pollutes
+  the measurement. JSON-serializing echo servers are wrong for benchmarks.
+
+| *Fault injection (Plan 03)*
+| `ghcr.io/shopify/toxiproxy` (pin `2.12.0`) between gateway and upstream
+| L4 toxics (timeout, latency, reset, disable) -- the only option that also faults
+  gRPC/WS/TLS streams; needed for circuit-breaker half-open tests. *Wired in Plan 03*, when
+  the breaker exists; documented here so the compose topology anticipates it.
+
+| *gRPC / GraphQL upstreams (later protocol plans)*
+| tiny in-repo Quarkus echo services under `integration-tests/`
+| `moul/grpcbin` is dead (2021, amd64-only) and GraphQL fakes are stale or heavy
+  (Hasura); GraphQL routing tests need only `POST /anything/graphql` on go-httpbin anyway.
+  A ~50-line reactor-built echo service beats a dead third-party image. *Not in this plan.*
+|===
+
+Keycloak (already present, realm files committed) stays: it becomes the token issuer in
+Plan 03. Testcontainers-based alternatives (dasniko `testcontainers-keycloak`, WireMock
+module, Quarkus `@QuarkusIntegrationTest` resource managers) were evaluated: the existing
+docker-compose approach is kept -- it matches TokenSheriff, gives stable hostnames/certs
+(needed later for SNI passthrough tests), and already has CI wiring. WireMock (JVM-mode unit
+level) may be introduced later where per-stub HTTP pathology is needed; not part of this plan.
+
+All compose images stay digest/tag-pinned (existing convention).
+
+=== D3 -- Minimal proxy: a Vert.x catch-all route, property-configured
+
+One real end-to-end path, deliberately interim but on the final architecture line
+(link:03-request-pipeline.adoc[Plan 03] keeps the edge, replaces the internals):
+
+* A Vert.x route handler (`quarkus-vertx-http`, already present transitively) registered as
+  catch-all on the data plane, executing per-request on a *virtual thread*.
+* One route configured via MicroProfile config properties (interim; replaced by the real
+  config subsystem in link:02-configuration-management.adoc[Plan 02]):
+  `sheriff.proxy.path-prefix` and `sheriff.proxy.upstream-url`.
+* Forwarding: method + path remainder + query + body pass through; hop-by-hop headers
+  stripped; JDK `HttpClient` blocking `send()` on the virtual thread (the `cui-http`
+  handler stack arrives with Plan 03's dependency approval). No security stages yet.
+* Unmatched path -> `404` (deny-by-default from day one).
+* The placeholder `/api/health` + `/api/info` endpoints and their tests remain for now
+  (health is used by scripts/benchmarks); `ApiSheriff`/`GatewayResource` are deleted in
+  Plan 03.
+* Rename the virtual-thread prefix from `jwt-validation` to `api-sheriff`.
+
+No new Maven dependencies are needed for this plan (Vert.x HTTP and JDK HttpClient are
+already available).
+
+== Work Breakdown
+
+. *Baseline verification* -- run and record: `./mvnw -Ppre-commit clean verify -DskipTests`,
+  `./mvnw clean install`, `./mvnw clean verify -Pintegration-tests -pl integration-tests -am`
+  (Docker required), `./mvnw clean verify -pl benchmarks -Pbenchmark`. Fix anything red
+  *before* changing behaviour, so regressions are attributable.
+. *Housekeeping* -- delete `TestDataGenerator` + the `generators` test-jar wiring (or keep
+  the wiring only if Plan 03 will publish real generators -- decide then; delete now),
+  `test-jwks.json`, unused PEM files, the empty stub `application.properties`; fix or delete
+  `benchmark-with-monitoring.sh` (it greps `jwt`/JMH -- delete, it returns with Plan 03's
+  benchmarks if needed); prune unused test dependencies flagged by the build. Pre-1.0 rule:
+  remove, never deprecate.
+. *Parent + native alignment (D1)* -- `cui-java-parent` 1.4.5 -> 1.5.0; Mandrel builder
+  jdk-25 pin; verify native build (`./mvnw clean install -Pnative -pl api-sheriff -am
+  -DskipTests`) and the distroless image still work.
+. *Upstream target (D2)* -- add `go-httpbin` service to
+  `integration-tests/docker-compose.yml` (pinned, healthcheck via `/status/200`, on the
+  `api-sheriff` network, no published host port needed -- the gateway reaches it by service
+  name; publish one for local debugging only if the scripts need it). Extend
+  `start-integration-container.sh` health-wait accordingly.
+. *Minimal proxy (D3)* -- implement the catch-all Vert.x handler + property-based route;
+  unit tests (`@QuarkusTest` + `cui-test-mockwebserver-junit5` as the mock upstream):
+  forwarding of method/path-remainder/query/body, hop-by-hop stripping, 404 on unmatched.
+  CuiLogger + LogRecord for the new INFO/WARN messages; start `doc/LogMessages.adoc`.
+. *Integration tests* -- new IT: request via the gateway's public HTTPS port with the proxy
+  route pointed at `http://go-httpbin:8080/anything`; assert the echoed JSON shows the
+  expected method, remainder path, query, and body, and that an unmatched path yields 404.
+  Keep the existing health/metrics ITs.
+. *Benchmark* -- add `nginx-static` service (compose `benchmark` profile, next to `wrk`);
+  add a `proxied_static_benchmark` WRK script (wrk -> gateway -> nginx) following the
+  existing lua/sh + `=== BENCHMARK METADATA ===` conventions, so the post-processor and
+  pages pipeline pick it up unchanged; keep the two health benchmarks (they now measure
+  baseline overhead vs. proxy overhead).
+. *CI verification* -- push the branch, confirm all three workflows green
+  (`maven.yml`, `integration-tests.yml`, `benchmark.yml` on merge); confirm the benchmark
+  pages deploy includes the new benchmark. No workflow changes expected -- the profiles and
+  module names are unchanged.
+. *Docs* -- short update to the module READMEs where behaviour changed (benchmarks README is
+  currently a stub pointing at OAuthSheriff -- replace with a real one).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-01-base-implementation`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+If the plan has to be split into multiple PRs, this workflow applies to each PR; the build
+must be green after every one.
+
+== Acceptance Criteria
+
+* All four build commands from step 1 pass locally; `maven.yml` and `integration-tests.yml`
+  pass on the PR; `benchmark.yml` passes after merge and publishes three benchmarks
+  (2x health + proxied-static).
+* The proxy IT proves end-to-end forwarding through the native container against
+  go-httpbin, including 404 deny-by-default.
+* Native image builds with the jdk-25 Mandrel pin; parent is 1.5.0.
+* No stale TokenSheriff leftovers remain (grep for `jwt` in module sources/scripts is clean
+  apart from design docs).
+* No OpenRewrite markers; coverage >= 80% on new code.
+
+== Out of Scope
+
+* Real configuration files/schemas (link:02-configuration-management.adoc[Plan 02]).
+* Security filtering, token validation, forward policy, events/metrics/error contract
+  (link:03-request-pipeline.adoc[Plan 03]).
+* gRPC/WebSocket/GraphQL processors, TLS passthrough, mTLS, BFF variants (later plans).
+* Toxiproxy wiring (arrives with the circuit breaker in Plan 03).

--- a/doc/plan/02-configuration-management.adoc
+++ b/doc/plan/02-configuration-management.adoc
@@ -1,0 +1,220 @@
+= Plan 02 -- Configuration Management
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Implement the complete configuration subsystem described in
+link:../configuration.adoc[Configuration Model]: a JSON Schema per config artifact,
+loading and resolution logic (`gateway.yaml`, `endpoints/*.yaml`, `topology.properties`),
+full boot-time validation with fail-fast semantics, and immutable value objects the rest of
+the gateway consumes. At the end of this plan, configuration management is *feature-complete*
+for the initial (Static-mode) scope -- even where the features consuming a given block
+(e.g. `oidc`) are not built yet, the block parses, validates, and freezes.
+
+== Required Reading (before implementation)
+
+Read these documents *in full* before touching code; the validation rules and semantics are
+specified there, not here:
+
+. link:../configuration.adoc[Configuration Model] -- the authoritative schema, field
+  reference, defaults-for-omitted-blocks, route-ordering/disjointness rules, and the
+  link:../configuration.adoc#_configuration_validation_rules_summary[validation-rules summary].
+. link:../adr/0004-topology-indirection.adoc[ADR-0004] -- alias -> URL indirection,
+  `TOPOLOGY_<ALIAS>` env override, decompose-on-read.
+. link:../adr/0002-initial-scope.adoc[ADR-0002] -- Static mode only; `metadata.config_version`
+  is an audit stamp.
+. link:../architecture.adoc[Architecture], section "Configuration Subsystem" -- immutability
+  as a security property, refuse-to-start semantics.
+. link:01-base-implementation.adoc[Plan 01] -- the minimal proxy this plan replaces the
+  hardcoded configuration of.
+
+== Prerequisites
+
+* Plan 01 delivered: modules build locally and on CI; a minimal proxy exists with a
+  *hardcoded/property-based* single route that this plan replaces with real config files.
+
+== Design Decisions
+
+=== D1 -- Schema technology: JSON Schema (draft 2020-12), validated at boot
+
+One schema file per YAML artifact:
+
+[cols="1,2,2"]
+|===
+| Artifact | Schema file | Referenced from
+
+| `gateway.yaml`
+| `api-sheriff/src/main/resources/schema/gateway.schema.json`
+| `# yaml-language-server: $schema=...` header comment in every sample/test config; linked
+  from `configuration.adoc`
+
+| `endpoints/*.yaml`
+| `api-sheriff/src/main/resources/schema/endpoint.schema.json`
+| same mechanism
+
+| `topology.properties`
+| *no schema* -- `.properties` has no schema ecosystem; validated programmatically
+  (alias pattern `[A-Z][A-Z0-9_]*`, value must parse as URL)
+| validation rules documented in `configuration.adoc`
+|===
+
+Schema posture:
+
+* `"additionalProperties": false` everywhere -- unknown keys fail the boot, per
+  link:../configuration.adoc[Configuration Model] ("unknown keys ... fail the boot").
+* The schema encodes *structure and per-field constraints* (types, enums such as
+  `require: none|bearer|session`, `emit: x-forwarded|both`, ranges, required blocks such as
+  `endpoint.auth`). *Cross-cutting rules* (route disjointness, alias resolution,
+  effective-auth -> required blocks, passthrough/host collisions, timeout whole-second rule,
+  trust-all CIDR rejection, `${ENV_VAR}`-only secrets) are code -- a `ConfigValidator` layer
+  that runs after schema validation and reports *all* violations, not just the first.
+* The schema files are also the editor/IDE contract (yaml-language-server) and are linked
+  from the documentation -- one source of truth for structure.
+
+=== D2 -- Parsing/binding stack (requires dependency approval)
+
+Parse YAML with *Jackson* (`jackson-dataformat-yaml`, via the Quarkus-managed Jackson) into a
+tree, validate the tree against the schema with *`com.networknt:json-schema-validator`*, then
+bind to immutable Java records. Rationale: schema violations report JSON-Pointer paths (good
+boot errors), Jackson is already on the classpath (`quarkus-resteasy-jackson`), and the
+networknt validator is a plain library that works in native image.
+
+[IMPORTANT]
+====
+New dependencies -- *require explicit user approval before adding* (CLAUDE.md rule):
+
+* `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` (version from the Quarkus BOM)
+* `com.networknt:json-schema-validator` (schema validation at boot)
+
+Fallback if the networknt dependency is rejected: keep the schema files as documentation/IDE
+artifacts only and express *all* structural rules in the programmatic validator. The plan's
+deliverables do not change, only the implementation of the structural half.
+====
+
+=== D3 -- Configuration object model
+
+Immutable records (Java 21) under `de.cuioss.sheriff.api.config.model`:
+
+* `GatewayConfig` (root aggregate) -- `TlsConfig`, `SecurityHeadersConfig`,
+  `SecurityDefaultsConfig`, `ForwardedConfig`, `TokenValidationConfig` (+`IssuerConfig`
+  mirror), `OidcConfig` (parsed and validated now; consumed by later BFF plans), `Metadata`.
+* `EndpointConfig` -- `id`, `baseUrlAlias`, mandatory `AuthConfig`, `List<RouteConfig>`.
+* `RouteConfig` -- `MatchConfig`, `AuthConfig` (nullable = inherit endpoint),
+  `SecurityFilterConfig`, `ForwardConfig`, `UpstreamConfig`, reserved `RateLimitConfig`,
+  `protocol` enum.
+* `ResolvedTopology` -- alias -> `ResolvedUpstream{scheme, host, port, basePath}`
+  (decompose-once, ADR-0004).
+* `RouteTable` -- the merged, disjointness-checked, longest-prefix-ordered immutable table
+  with the *effective auth* (endpoint default or wholesale route override) materialized per
+  route, so downstream pipeline code never re-implements inheritance.
+
+Empty collections over null; `Optional` for optional scalar returns; Lombok only where records
+don't fit. Every package gets `package-info.java`.
+
+=== D4 -- Loading pipeline and CDI wiring
+
+----
+config dir (property `sheriff.config.dir`, default `conf/`; overridable via
+SHERIFF_CONFIG_DIR for the container)
+  |
+  v
+1. read gateway.yaml, endpoints/*.yaml (sorted, for deterministic error output),
+   topology.properties
+2. schema-validate each YAML document (D1/D2)          -> collect ALL errors
+3. bind to records (D3)
+4. resolve ${ENV_VAR} secret references                -> missing env var = boot error
+5. resolve topology aliases (env TOPOLOGY_<ALIAS> wins over file), decompose URLs
+6. cross-validation (ConfigValidator: the full rule list from configuration.adoc
+   "Configuration Validation Rules (summary)")         -> collect ALL errors
+7. build RouteTable (merge, disjointness check, longest-prefix ordering,
+   effective-auth materialization; weakening overrides logged as boot-log WARNs)
+8. freeze -> GatewayConfig + RouteTable exposed as @ApplicationScoped CDI beans
+----
+
+* Failure semantics: any error in steps 1-7 -> log every collected violation with
+  file/pointer context, then *fail startup* (throw from the CDI producer / startup observer;
+  Quarkus exits non-zero). Never serve traffic on partial config.
+* `CONFIG_LOADED` INFO LogRecord (with `metadata.config_version` audit stamp) on success;
+  validation failures use structured ERROR LogRecords. Document all new records in
+  `doc/LogMessages.adoc` (create it -- CLAUDE.md requires it, it does not exist yet).
+* The producer replaces Plan 01's hardcoded route: the minimal proxy now reads `RouteTable`.
+
+=== D5 -- What "reference the schema" means concretely
+
+* Sample config set under `api-sheriff/src/test/resources/config/valid/` (used by tests) and
+  a runnable example under `integration-tests/src/main/docker/sheriff-config/` (mounted into
+  the container) -- every YAML file carries the `$schema` header comment.
+* `configuration.adoc` gains a short "Schemas" section linking the two schema files as the
+  machine-readable contract (doc change, same PR).
+
+== Work Breakdown
+
+. *Schemas* -- author `gateway.schema.json` + `endpoint.schema.json` mirroring
+  `configuration.adoc` exactly (every field of the two exhibits, enums, required lists,
+  `additionalProperties: false`). Review against the doc field-by-field; the doc governs.
+. *Model records* (D3) + builders where needed; unit tests via `cui-test-value-objects` /
+  `cui-test-generator` contracts.
+. *Loader* -- YAML read + schema validation + binding; error aggregation with
+  file/JSON-Pointer context.
+. *Topology resolution* -- properties parsing, env override precedence, URL decomposition;
+  unit tests incl. malformed URL, missing alias, env-wins-over-file.
+. *ConfigValidator* -- one small rule class per bullet of the validation-rules summary in
+  `configuration.adoc`, each with parameterized tests (valid + violating fixtures):
+  route-id uniqueness, alias resolution, endpoint-auth mandatory, effective-auth ->
+  `token_validation`/`oidc` presence, same-prefix disjointness (host/methods/header value),
+  passthrough-SNI vs `match.host` collision, passthrough alias base-path rule, trusted-proxies
+  presence + trust-all rejection, whole-second timeouts, `${ENV_VAR}`-only secrets,
+  cookie/server session-mode conditionals, CORS wildcard+credentials rejection.
+. *RouteTable* -- merge/ordering/disjointness + effective-auth materialization; property-based
+  tests with `@GeneratorsSource` for prefix/host/method permutations.
+. *CDI wiring* -- producer, startup observer, fail-fast test (`QuarkusUnitTest` with broken
+  config asserting startup failure), `CONFIG_LOADED` log assertion via
+  `cui-test-juli-logger`.
+. *Integration tests* -- mount the example `sheriff-config/` into the container
+  (docker-compose volume), point the minimal proxy route at the Plan 01 upstream target via
+  `topology.properties`; IT asserts (a) gateway boots with the mounted config, (b) the routed
+  request reaches the upstream, (c) readiness (`/q/health/ready`) reflects loaded config. Add
+  one negative script-level check: container with an invalid config exits non-zero.
+. *Docs & cleanup* -- `doc/LogMessages.adoc`, schema references in `configuration.adoc`,
+  remove any remaining Plan 01 hardcoded-route configuration.
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-02-configuration-management`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+If the plan has to be split into multiple PRs, this workflow applies to each PR; the build
+must be green after every one.
+
+== Acceptance Criteria
+
+* Both schema files exist, match `configuration.adoc` field-for-field, and every sample/test
+  YAML references them.
+* All validation rules from the summary section are enforced with at least one negative test
+  each; error output names file + path for every violation in one pass.
+* `GatewayConfig`/`RouteTable` are immutable, CDI-injectable, and consumed by the proxy.
+* Invalid config => non-zero exit, no traffic served (verified by unit-level Quarkus test and
+  container-level negative IT).
+* `./mvnw -Ppre-commit clean verify -DskipTests` and `./mvnw clean install` pass; coverage of
+  the new `config` packages >= 80%.
+* `./mvnw clean verify -Pintegration-tests -pl integration-tests -am` passes locally and via
+  `.github/workflows/integration-tests.yml`.
+
+== Out of Scope
+
+* Consuming `oidc`, `tls.passthrough_sni`, `mtls`, `security_filter`, `forwarded`, or
+  `token_validation` at runtime -- the blocks are *parsed and validated* here; their runtime
+  behaviour is link:03-request-pipeline.adoc[Plan 03] (+ later variant plans).
+* Dynamic configuration / discovery (deferred, ADR-0002).
+* `rate_limit` behaviour (reserved field; accepted and ignored).

--- a/doc/plan/03-request-pipeline.adoc
+++ b/doc/plan/03-request-pipeline.adoc
@@ -1,0 +1,253 @@
+= Plan 03 -- Request Pipeline
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Implement the gateway's data plane for the standard HTTP verbs: the fixed request pipeline
+from link:../architecture.adoc[Architecture] -- inbound `cui-http` security filtering
+(configured by `gateway.yaml`), route selection from the frozen `RouteTable`, per-route
+protocol-processor loading, per-route thorough checks (derived from the optional per-route
+`security_filter` block), offline bearer-token validation via `token-sheriff-validation`,
+zero-trust forward policy with regenerated forwarding headers, upstream dispatch, and
+response return -- together with the cross-cutting spine built as part of the same plan:
+the event system, metrics, structured logging, and the RFC 9457 error contract.
+
+== Required Reading (before implementation)
+
+. link:../architecture.adoc[Architecture] -- *entire document*: component model, inbound
+  security filter wiring, routing, authentication layer, forward policy, downstream client,
+  event system, error contract, metrics, threading model.
+. link:../variants/01-base-gateway.adoc[Variant 1 -- Base Security Gateway] -- request flow,
+  responsibilities, offline validation wiring (incl. the 4-arg `AccessTokenRequest.of(...)`
+  DPoP requirement).
+. link:../configuration.adoc[Configuration Model] -- sections `security_filter`, `auth`,
+  `token_validation`, `match`, `forward`, `upstream`, `forwarded`, `security_headers`.
+. link:../adr/0003-forwarded-headers.adoc[ADR-0003] -- forwarding-header posture; note the
+  *gateway-side immediate-TCP-peer gate* is API Sheriff code, not the resolver's.
+. link:../technical_aspects.adoc[Technical Aspects] -- the concrete `cui-http` and
+  `token-sheriff-validation` APIs (pipelines, `SecurityConfiguration`,
+  `ForwardedHeaderResolver`/`ResolvedForwarding`, `HttpHandler`/`HttpResult`,
+  `TokenValidator`).
+. `cui-http/doc/forwarded-header-resolution.adoc` (in the cui-http repository) -- the
+  authoritative resolver behaviour contract.
+. link:02-configuration-management.adoc[Plan 02] -- the `GatewayConfig`/`RouteTable` model
+  this plan consumes.
+
+== Prerequisites
+
+* Plans 01 and 02 delivered: green builds, config subsystem produces `GatewayConfig` +
+  `RouteTable`.
+
+== Design Decisions
+
+=== D1 -- cui-http 2.1-SNAPSHOT (mandatory)
+
+The `de.cuioss.http.forwarded` package (`ForwardedHeaderResolver`, `ResolvedForwarding`,
+`ForwardedResolverConfig`) exists only in `de.cuioss:cui-http:2.1-SNAPSHOT` -- *verified: it
+is absent from the released 2.0.0 jar*. This plan therefore pins the latest cui-http
+snapshot.
+
+[IMPORTANT]
+====
+Dependency changes -- *require explicit user approval before adding*:
+
+* `de.cuioss:cui-http:2.1-SNAPSHOT` (security pipelines, forwarded resolver, HttpHandler
+  stack). Snapshot risk: CI must resolve it (Sonatype snapshots repository or a version bump
+  to a 2.1 release when available); pin and re-verify before merge.
+* `de.cuioss.sheriff.token:token-sheriff-validation-quarkus:1.0.0-SNAPSHOT` (direct; core
+  `token-sheriff-validation` arrives transitively). Same snapshot caveat -- TokenSheriff is
+  unreleased.
+
+The BFF engine modules (`token-sheriff-client*`) are *not* added here -- they belong to the
+later variant plans.
+====
+
+=== D2 -- Edge implementation: Vert.x route handler, not a JAX-RS resource
+
+The data plane is implemented as a Vert.x HTTP route (`quarkus-vertx-http`, already present
+transitively) -- a catch-all handler registered at low priority so the management endpoints
+(`/q/*` on the management port) and, later, the reserved OIDC paths keep working. Rationale
+over a `@Path("{p:.*}")` RESTEasy resource:
+
+* full control over verbs (all standard verbs incl. `PATCH`/`OPTIONS`/`HEAD` in one handler),
+  raw header multimaps, and streaming request/response bodies without JAX-RS buffering;
+* the natural upgrade path for WebSocket (Vert.x handles the upgrade) and h2 streaming in the
+  later protocol plans;
+* `@RunOnVirtualThread`-equivalent execution: the handler dispatches request processing onto a
+  virtual thread per request (architecture threading model); inbound filtering is synchronous
+  CPU work on that thread.
+
+Plan 01's placeholder `GatewayResource`/`ApiSheriff` and their tests are *removed* in this
+plan (pre-1.0 rule: delete, don't deprecate) once the pipeline serves real routes.
+
+*Protocol processors.* The per-route `protocol` field selects a `ProtocolProcessor`
+(loaded per route at boot, from a small registry keyed by the config enum):
+`HttpProtocolProcessor` is implemented in this plan and carries the standard-verb
+request/response semantics; `graphql` routes explicitly reuse it (POST-over-HTTP per
+architecture doc). `grpc` and `websocket` processors are registered as *boot-time rejections*
+in this plan (config accepted by Plan 02's schema, route load fails with a clear
+"not yet implemented" error) so a later plan can slot them in without pipeline changes.
+
+=== D3 -- Pipeline stages and their fixed order
+
+Assembled once at boot per route into an immutable `RouteRuntime` (compiled matchers, filter
+pipelines, forward policy sets, upstream client chain, scope list, protocol processor);
+request-time work touches no mutable shared state.
+
+----
+inbound request (virtual thread)
+  0. security response headers prepared (security_headers; applied to EVERY response,
+     including rejections); CORS preflight answered here, BEFORE auth
+  1. BASIC CHECKS (gateway.yaml `security_defaults` profile, cui-http):
+     PipelineFactory.createCommonPipelines(config, securityEventCounter)
+       - URLPathValidationPipeline on the raw path
+       - URLParameterValidationPipeline / header pipelines on names+values
+       - RequestCollectionValidator: header/parameter/cookie counts
+     violation -> 400 problem+json, INPUT_VALIDATION event                   [stage 1]
+  2. ROUTE SELECTION: RouteTable candidate match (path prefix AND methods AND
+     host AND headers), longest prefix wins; no candidate -> 404             [stage 2]
+  3. THOROUGH CHECKS (route's optional `security_filter`, cui-http):
+     - per-route SecurityConfiguration (profile + explicit overrides) pipelines,
+       re-run only when they differ from the stage-1 defaults
+     - allowed_paths whitelist on the VALIDATED, NORMALIZED path (gateway code,
+       {name} = exactly one segment)
+     - max_body_bytes cap enforced while reading the body (gateway code;
+       cui-http has no body pipeline)                                        [stage 3]
+  4. AUTHENTICATION (effective auth):
+     - require: none    -> pass
+     - require: bearer  -> TokenValidator.createAccessToken(
+                             AccessTokenRequest.of(token, headers, uri, method))
+                           401 on missing/invalid (+ WWW-Authenticate: Bearer);
+                           providesScopes(required) -> 403 SCOPE_MISSING
+     - require: session -> boot-time rejection in this plan (variant plans)  [stage 4]
+  5. FORWARD POLICY (zero-trust):
+     - headers_allow / query_allow filtering; set_headers appended
+     - forwarded handling: gateway-side TCP-peer gate against
+       forwarded.trusted_proxies FIRST, then ForwardedHeaderResolver.resolve(...),
+       emit regenerated toXForwardedHeaders() (+ toForwardedHeader() when
+       emit: both); inbound forwarding headers never propagated
+     - inbound Authorization stripped unless explicitly allow-listed         [stage 5]
+  6. DISPATCH: upstream URL = resolved(base_url) + upstream.path + remainder
+     + allowed query; per-route HttpHandler (timeouts) wrapped in
+     ResilientHttpAdapter (retry, idempotent-only) wrapped in the gateway
+     circuit breaker; failure mapping per the error contract
+     (502 / 503 breaker-open + Retry-After / 504 timeout)                    [stage 6]
+  7. RESPONSE: status + upstream headers (hop-by-hop headers stripped) + body
+     streamed back; security response headers from stage 0 applied
+----
+
+Every rejection path returns `application/problem+json` per the
+link:../architecture.adoc#_error_contract[error contract] table and never calls the upstream.
+
+=== D4 -- Event system, metrics, logging (built here, low base package)
+
+* `de.cuioss.sheriff.api.events`: `EventCategory` (failure categories per architecture doc),
+  `EventType` (each failure type carries its category and HTTP status; success events carry
+  `null` category), `GatewayEventCounter` (`ConcurrentHashMap<EventType, AtomicLong>`,
+  lock-free, micrometer-free), typed `GatewayException` carrying its `EventType`.
+* Error edge: one exception handler maps `GatewayException` -> status + RFC 9457 body (type
+  named by the category, no internal detail); `TokenValidationException` from the validator is
+  mapped to `TOKEN_INVALID`/`TOKEN_MISSING` equivalents.
+* Metrics (micrometer, management port): the five `sheriff_*` meters from
+  link:../architecture.adoc#_metrics[Architecture -- Metrics]
+  (`requests_total`, `request_duration_seconds`, `errors_total`,
+  `security_events_total` sourced from the shared cui-http `SecurityEventCounter`,
+  `upstream_duration_seconds`). Route label = route id (bounded cardinality; unmatched
+  requests use a fixed `"<no-route>"` label value).
+* Logging: `ApiSheriffLogMessages` DSL-style class (CuiLogger/LogRecord, `%s` only, exception
+  first, INFO 1-99 / WARN 100-199 / ERROR 200-299), documented in `doc/LogMessages.adoc`.
+  Security-relevant WARNs for: filter violations (with failure type, never the raw payload),
+  auth weakening at boot, breaker open/close transitions.
+
+=== D5 -- Readiness
+
+Extend readiness (SmallRye Health, management port) to reflect: config loaded (Plan 02) and,
+when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
+(`token-sheriff-validation-quarkus` ships health checks -- reuse, don't rebuild).
+
+== Work Breakdown
+
+. *Dependencies* (after approval): cui-http 2.1-SNAPSHOT,
+  token-sheriff-validation-quarkus 1.0.0-SNAPSHOT; verify CI snapshot resolution first.
+. *Event system + error edge* (D4) -- pure unit-tested base package first; problem+json
+  rendering tests for every row of the error-contract table.
+. *RouteRuntime assembly* -- boot-time compilation of `RouteTable` into runtime objects:
+  matchers, per-route `SecurityConfiguration`/pipelines, forward sets, `HttpHandler` +
+  `ResilientHttpAdapter` chain, circuit breaker, protocol processor lookup, weakening-override
+  boot WARNs. Boot-time rejection of `grpc`/`websocket`/`session` (this plan's scope guard).
+. *Stages 0-3* -- security headers + CORS preflight, basic pipelines, route selection,
+  thorough checks, allowed_paths matcher, body cap. Unit tests use the cui-http *attack
+  databases* (`OWASPTop10AttackDatabase`, CVE databases, plus the legitimate-pattern
+  databases for false-positive guarding) via `@GeneratorsSource`-style parameterized tests.
+. *Stage 4* -- TokenValidator producer wiring from `token_validation` config (single shared
+  validator at startup), bearer extraction, scope enforcement; tests with
+  `token-sheriff-validation`'s `generators` test-jar key material; JWKS over
+  `cui-test-mockwebserver-junit5`.
+. *Stage 5* -- forward-policy filtering; TCP-peer gate + resolver wiring + regeneration
+  (assert: spoofed inbound `X-Forwarded-For` from a non-trusted peer is ignored; chains are
+  regenerated, never appended).
+. *Stage 6 + 7* -- dispatch, hop-by-hop header stripping, streaming, circuit breaker
+  (unit-test state machine: closed -> open after N failures -> half-open after reset_ms),
+  timeout/retry mapping to 504/502/503.
+. *Vert.x edge* -- catch-all route, virtual-thread dispatch, wire stages; delete the Plan 01
+  placeholder resource/tests.
+. *Metrics + readiness* (D4/D5) -- meter binding, health checks; assert metric presence in
+  unit tests and via the management port in ITs.
+. *Integration tests* -- against the compose stack (upstream echo target + Keycloak from
+  Plan 01, config mount from Plan 02):
+  * happy path per verb (GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS) asserting the echo shows
+    exactly the allow-listed headers/params + regenerated `X-Forwarded-*` and nothing else;
+  * bearer route: real Keycloak token accepted (the `integration` realm finally earns its
+    keep), tampered/expired token -> 401 problem+json, missing scope -> 403;
+  * filter rejection -> 400; unmatched route -> 404; upstream down -> 502; timeout -> 504;
+    breaker -> 503 with Retry-After (fault injection per the infrastructure chosen in
+    Plan 01);
+  * `/q/metrics` shows the `sheriff_*` meters moving.
+. *Benchmarks* -- extend the WRK suite with a bearer-validated proxied route (wrk ->
+  gateway -> echo upstream) alongside Plan 01's plain-proxy benchmark, so validation overhead
+  is measured separately from proxy overhead.
+. *Docs* -- update `doc/LogMessages.adoc`; note any deliberate deviations discovered during
+  implementation back into `architecture.adoc` (the doc governs; deviations need a doc PR,
+  not silent drift).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-03-request-pipeline`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+If the plan has to be split into multiple PRs, this workflow applies to each PR; the build
+must be green after every one.
+
+== Acceptance Criteria
+
+* All pipeline stages implemented and unit-tested; every row of the error-contract table has
+  a test producing exactly that status + problem+json shape.
+* Attack-database parameterized tests pass (no bypass, no false positive from the
+  legitimate-pattern databases).
+* Forwarding: spoof/sabotage tests prove drop-and-regenerate semantics; emitted headers match
+  ADR-0003 for both `emit` modes.
+* Bearer validation works offline against Keycloak-issued tokens in ITs; upstream is never
+  called on any rejection (assert via echo-side request counting).
+* Metrics/eventing surface matches the names in `architecture.adoc`.
+* `./mvnw -Ppre-commit clean verify -DskipTests`, `./mvnw clean install`, integration-tests
+  profile, and the benchmark profile all pass locally and on CI; coverage >= 80% on new
+  packages.
+
+== Out of Scope (explicit)
+
+* `require: session` / OIDC / BFF behaviour (variant plans; engine modules not yet added).
+* WebSocket upgrade and gRPC streaming processors (config-visible, boot-rejected here).
+* TLS `passthrough_sni` L4 relay and `mtls` (separate plan; needs listener-level work).
+* Rate limiting (deferred feature, reserved config).
+* HTTP/3 (ADR-0002).

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -1,0 +1,53 @@
+= API Sheriff -- Implementation Plans
+:toc:
+:toclevels: 2
+
+Sequenced implementation plans deriving from the link:../README.adoc[design documentation].
+Each plan lists its *required reading* -- read those design documents in full before
+implementing; the design docs govern, the plans only sequence the work. Deviations discovered
+during implementation are fixed in the design docs (same PR), never silently in code.
+
+== Plan Sequence
+
+The plans build strictly on one another:
+
+[cols="1,3,3"]
+|===
+| Plan | Delivers | Depends on
+
+| link:01-base-implementation.adoc[01 -- Base Implementation]
+| Verified green builds (local + CI), TokenSheriff-aligned structure, a minimal
+  property-configured pass-through proxy, the `go-httpbin` upstream target in the
+  integration setup, a proxied-route WRK benchmark, stale scaffolding removed.
+| --
+
+| link:02-configuration-management.adoc[02 -- Configuration Management]
+| JSON Schemas for `gateway.yaml` / `endpoints/*.yaml`, the loading/resolution/validation
+  pipeline (topology indirection, fail-fast boot), immutable `GatewayConfig` + `RouteTable`,
+  config mounted into the integration containers.
+| Plan 01
+
+| link:03-request-pipeline.adoc[03 -- Request Pipeline]
+| The data plane for standard HTTP verbs: cui-http inbound filtering (basic + per-route),
+  route selection, protocol-processor loading, offline bearer validation, zero-trust forward
+  policy with regenerated forwarding headers (cui-http 2.1-SNAPSHOT), dispatch with
+  retry/circuit breaker, plus the event system, metrics, logging, and RFC 9457 error edge.
+| Plans 01 + 02
+|===
+
+Later plans (not yet written): WebSocket + gRPC processors, TLS passthrough/mTLS, the two
+BFF variants (`token-sheriff-client`), rate limiting.
+
+== Conventions
+
+* Every plan carries an *Execution Workflow* section -- the same fixed sequence each time:
+  feature branch off `main` -> implement -> `./mvnw -Ppre-commit clean verify -DskipTests` +
+  `./mvnw clean install` (both green) -> commit -> push -> PR -> wait ~5 minutes for the AI
+  reviewers and watch checks -> handle *every* review comment (fix or justified reply, then
+  resolve) -> merge -> `git checkout main && git pull`. Builds must be green after every PR,
+  not only at plan completion.
+* *Dependency approvals*: every new Maven dependency a plan needs is flagged inside the plan
+  with an IMPORTANT block and requires explicit user approval before it is added
+  (CLAUDE.md rule). Snapshot dependencies (`cui-http:2.1-SNAPSHOT`,
+  `token-sheriff-*:1.0.0-SNAPSHOT`) additionally need a CI-resolvability check before merge.
+* Pre-1.0 rules apply throughout: delete instead of deprecate, break freely, keep APIs clean.


### PR DESCRIPTION
## Summary

Adds `doc/plan/` with three sequenced implementation plans derived from the existing design documentation (`architecture.adoc`, `configuration.adoc`, `technical_aspects.adoc`, variants, ADRs), plus an index linked from `doc/README.adoc`.

- **Plan 01 — Base Implementation**: verify all builds locally + CI, align structure with TokenSheriff (`cui-java-parent` 1.5.0, Mandrel jdk-25 builder pin per ADR-0001), add `ghcr.io/mccutchen/go-httpbin` as the routable upstream target in the integration setup, a minimal property-configured Vert.x pass-through proxy, an nginx-backed proxied WRK benchmark, and removal of stale TokenSheriff scaffolding.
- **Plan 02 — Configuration Management**: JSON Schemas (draft 2020-12) for `gateway.yaml` / `endpoints/*.yaml`, the load → schema-validate → bind → topology-resolve → cross-validate → freeze pipeline with fail-fast boot, immutable `GatewayConfig`/`RouteTable` CDI beans, and config mounted into the integration containers.
- **Plan 03 — Request Pipeline**: the staged data plane for standard HTTP verbs (cui-http security filtering, route selection, protocol-processor loading, offline bearer validation, zero-trust forward policy with regenerated forwarding headers, dispatch with retry/circuit breaker) built on `cui-http:2.1-SNAPSHOT` (the only version carrying `de.cuioss.http.forwarded`), together with the event system, metrics, logging, and RFC 9457 error contract.

Each plan contains a required-reading list, design decisions (new dependencies flagged for explicit approval), work breakdown, a fixed execution workflow (branch → build + quality gate → PR → AI review handling → merge), acceptance criteria, and explicit out-of-scope boundaries.

## Notes for review

- Documentation only — no code, build, or CI changes.
- Upstream-target and testcontainer picks in Plan 01 are based on 2026 maintenance/multi-arch research (go-httpbin over dead `moul/grpcbin` / abandoned `kennethreitz/httpbin`; nginx static backend for benchmarks per the Traefik/KrakenD idiom; Toxiproxy deferred to Plan 03).