### PR TITLE
chore: set up plan-marshall project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 # Benchmark data directories - these contain sample/test data
 benchmarking/doc/data/
 benchmarking/doc/templates/data/
+
+# Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
+.plan/*
+!.plan/marshal.json
+!.plan/project-architecture/

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,208 @@
+{
+  "extension_defaults": {
+    "build.maven.profiles.skip": "native,quick,jfr"
+  },
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "finding_raw_input_max_bytes": 65536,
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto",
+      "auto_route_recipe": true,
+      "auto_route_recipe_threshold": 0.6,
+      "lane_selection": "ask",
+      "lane_prune_thresholds": {
+        "confidence_complete": 95,
+        "linear_change_max_deliverables": 1
+      }
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "q_gate_validation": "once",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "q_gate_validation": "once",
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": [
+        "default:verify:compile",
+        "default:verify:module-tests"
+      ],
+      "cost_size_token_table": {
+        "XS": "5K",
+        "S": "25K",
+        "M": "60K",
+        "L": "130K",
+        "XL": "260K",
+        "XXL": "520K"
+      },
+      "per_envelope_budget_tokens": "400K",
+      "verification_steps": {
+        "default:verify:quality-gate": {},
+        "default:verify:module-tests": {}
+      },
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "finalize_without_asking": true,
+      "loop_back_without_asking": false,
+      "qgate": "auto",
+      "checks_wait_timeout_seconds": 600,
+      "steps": {
+        "default:finalize-step-sync-baseline": {
+          "auto_rebase_threshold": "no_overlap_only"
+        },
+        "default:pre-push-quality-gate": {},
+        "default:finalize-step-simplify": {
+          "simplify": "auto"
+        },
+        "default:push": {},
+        "default:create-pr": {},
+        "default:ci-verify": {},
+        "default:sonar-roundtrip": {
+          "touched_file_cleanup": "new_code_only",
+          "do_transition": false,
+          "ce_wait_timeout_seconds": 600
+        },
+        "default:lessons-capture": {},
+        "default:branch-cleanup": {
+          "pr_merge_strategy": "squash",
+          "final_merge_without_asking": false,
+          "auto_rebase_threshold": "no_overlap_only",
+          "merge_queue_wait_budget_seconds": 1800,
+          "merge_hold_window": "full_window_release_at_waits",
+          "merge_hold_budget_seconds": 3600,
+          "use_merge_queue": true,
+          "admin_merge_on_stuck_state": false
+        },
+        "default:record-metrics": {},
+        "default:archive-plan": {}
+      },
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "*/src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ]
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-sonar",
+      "category": "other",
+      "description": "SonarCloud/SonarQube code analysis platform",
+      "url": "https://sonarcloud.io"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/API-Sheriff.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": []
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "java-cui": {
+      "bundle": "pm-dev-java-cui"
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "integration_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    },
+    "provisioned_version": "0.1.1088",
+    "config_seed_fingerprint": "afa68648"
+  }
+}

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -96,7 +96,7 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": true,
+          "use_merge_queue": false,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,16 @@
+{
+  "description": "API Sheriff is a security-focused, lightweight API Gateway built on Quarkus and Java virtual threads \u2014 a purpose-built reverse proxy providing cui-http inbound security filtering, offline bearer-token validation, and (in later variants) OIDC confidential-client BFF token mediation. Pre-1.0: the current code delivers a minimal pass-through proxy plus the build/IT/benchmark harness; configuration management and the full request pipeline follow the plans under doc/plan/.",
+  "description_reasoning": "source: doc/README.adoc introduction + root pom description + doc/plan/README.adoc plan sequence",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "api-sheriff": {},
+    "api-sheriff-parent": {},
+    "benchmarks": {},
+    "documentation": {},
+    "integration-tests": {}
+  },
+  "name": "API-Sheriff"
+}

--- a/.plan/project-architecture/api-sheriff-parent/enriched.json
+++ b/.plan/project-architecture/api-sheriff-parent/enriched.json
@@ -1,0 +1,92 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "api-sheriff",
+    "integration-tests",
+    "benchmarks"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "aggregator over the three child modules",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "packaging=pom at repository root, aggregates 3 child modules",
+  "responsibility": "Maven aggregator and parent POM for the API Sheriff multi-module build. Inherits de.cuioss:cui-java-parent, pins the Quarkus BOM and shared plugin/dependency management, and defines the coverage profile plus module ordering (api-sheriff, integration-tests, benchmarks).",
+  "responsibility_reasoning": "root pom.xml packaging=pom, parent cui-java-parent, module list and pom description",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Maven parent/aggregator POM; java-cui: inherits cui-java-parent, CUI build conventions",
+  "tips": []
+}

--- a/.plan/project-architecture/api-sheriff/enriched.json
+++ b/.plan/project-architecture/api-sheriff/enriched.json
@@ -1,0 +1,163 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "io.quarkus:quarkus-resteasy-jackson",
+    "io.quarkus:quarkus-arc",
+    "io.quarkus:quarkus-micrometer-registry-prometheus",
+    "io.quarkus:quarkus-smallrye-health",
+    "de.cuioss:cui-java-tools",
+    "org.projectlombok:lombok"
+  ],
+  "key_dependencies_reasoning": "Quarkus runtime stack (REST, CDI, metrics, health) plus CUI logging (CuiLogger/LogRecord) and Lombok per CUI standards; cui-http and token-sheriff-validation join in Plans 02/03",
+  "key_packages": {
+    "de.cuioss.sheriff.api": {
+      "description": "Application root: ApiSheriff marker/config holder and ApiSheriffApplication Quarkus entry point."
+    },
+    "de.cuioss.sheriff.api.gateway": {
+      "description": "Gateway REST surface (GatewayResource placeholder endpoint); will host the request-pipeline edge per Plan 03."
+    },
+    "de.cuioss.sheriff.api.gateway.proxy": {
+      "description": "Plan-01 minimal pass-through proxy: ProxyRoute (catch-all forwarding with hop-by-hop stripping, 502 handling, multi-value headers), ProxyConfiguration (path-prefix/upstream-url properties), ProxyLogMessages LogRecords."
+    },
+    "de.cuioss.sheriff.api.quarkus": {
+      "description": "CDI wiring: ApiSheriffProducer exposing application-scoped beans to the Quarkus container."
+    }
+  },
+  "purpose": "runtime",
+  "purpose_reasoning": "Quarkus application with ApiSheriffApplication entry point, packaging=jar, deployable container image",
+  "responsibility": "The deployable Quarkus gateway application. Currently hosts the Plan-01 minimal pass-through proxy (ProxyRoute with hop-by-hop header stripping, forwarding hardening, 404 deny-by-default), CDI producers, and REST scaffolding; grows into the full security pipeline (cui-http filtering, route table, token validation) per doc/plan/02+03. Ships JVM and native (Mandrel) images.",
+  "responsibility_reasoning": "source analysis of de.cuioss.sheriff.api.gateway.proxy + package-info.java files + doc/plan/01-base-implementation.adoc",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        {
+          "description": "CDI patterns including constructor injection, scopes, producers, and Quarkus configuration",
+          "skill": "pm-dev-java:java-cdi"
+        },
+        {
+          "description": "Java code maintenance standards including prioritization, refactoring triggers, and compliance",
+          "skill": "pm-dev-java:java-maintenance"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-http"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        {
+          "description": "Maven integration testing with Failsafe plugin, IT naming conventions, and profiles",
+          "skill": "pm-dev-java:junit-integration"
+        },
+        {
+          "description": "Weld Testing standards for CDI unit testing with @EnableAutoWeld and auto-discovery patterns",
+          "skill": "pm-dev-java:junit-weld-testing"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-testing",
+        "pm-dev-java-cui:cui-http-testing"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Quarkus application using CDI producers and Lombok \u2014 all optionals apply; java-cui: CUI standards (CuiLogger/LogRecord); cui-http and cui-testing/cui-http-testing used from Plans 02/03 onward",
+  "tips": []
+}

--- a/.plan/project-architecture/benchmarks/enriched.json
+++ b/.plan/project-architecture/benchmarks/enriched.json
@@ -1,0 +1,95 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "de.cuioss:benchmarking-common",
+    "de.cuioss:cui-java-tools"
+  ],
+  "key_dependencies_reasoning": "benchmarking-common provides the WRK result publication pipeline",
+  "key_packages": {
+    "de.cuioss.sheriff.api.wrk.benchmark": {
+      "description": "WrkResultPostProcessor converts raw wrk output into the benchmarking-common publication format; GatewayEndpointBenchmarkTest drives the wrk scripts."
+    }
+  },
+  "purpose": "benchmark",
+  "purpose_reasoning": "WRK benchmark harness, benchmark Maven profile, no production code",
+  "responsibility": "WRK-based HTTP load benchmarks for the gateway. Wraps wrk scripts (health, proxied-static route) run against the docker-compose stack via the benchmark profile, and post-processes results with WrkResultPostProcessor (benchmarking-common) for publication to GitHub Pages.",
+  "responsibility_reasoning": "benchmarks/README.adoc + wrk-scripts inventory + benchmark profile",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Maven module with Java post-processor and JUnit tests; java-cui: cui-java-tools/CuiLogger used in WrkResultPostProcessor",
+  "tips": []
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,44 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "library",
+  "purpose_reasoning": "documentation-only virtual module (build_system=documentation); no code \u2014 closest available classification",
+  "responsibility": "Design documentation: architecture, configuration model, deployment variants, ADRs 0001-0004, competitive feature analysis, and the sequenced implementation plans under doc/plan/ that drive development.",
+  "responsibility_reasoning": "doc/README.adoc index read in full",
+  "skills_by_profile": {
+    "documentation": {
+      "defaults": [
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        },
+        {
+          "description": "Manage Architectural Decision Records with CRUD operations and AsciiDoc formatting",
+          "skill": "plan-marshall:manage-adr"
+        },
+        {
+          "description": "Manage Interface specifications with CRUD operations and AsciiDoc formatting",
+          "skill": "pm-documents:manage-interface"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "documentation: AsciiDoc design docs under doc/ incl. 4 ADRs (manage-adr optional applies)",
+  "tips": []
+}

--- a/.plan/project-architecture/integration-tests/enriched.json
+++ b/.plan/project-architecture/integration-tests/enriched.json
@@ -1,0 +1,152 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "api-sheriff"
+  ],
+  "key_dependencies": [
+    "io.rest-assured:rest-assured",
+    "org.awaitility:awaitility"
+  ],
+  "key_dependencies_reasoning": "ITs run against the api-sheriff native container; REST Assured + Awaitility drive/await the dockerized stack",
+  "key_packages": {
+    "de.cuioss.sheriff.api.integration": {
+      "description": "IT suite: BaseIntegrationTest (stack lifecycle/awaiting), ApiSheriffIntegrationIT (health), ProxyIntegrationIT (pass-through proxy against go-httpbin)."
+    }
+  },
+  "purpose": "integration-tests",
+  "purpose_reasoning": "only failsafe IT sources, integration-tests profile, docker infrastructure",
+  "responsibility": "Integration test coordinator: builds the native gateway container and orchestrates the docker-compose stack (gateway, Keycloak, go-httpbin, nginx-static, Prometheus) via the integration-tests profile, running IT suites (proxy pass-through, health) with REST Assured and Awaitility.",
+  "responsibility_reasoning": "module pom description, docker-compose.yml services, ProxyIntegrationIT/BaseIntegrationTest sources",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        {
+          "description": "CDI patterns including constructor injection, scopes, producers, and Quarkus configuration",
+          "skill": "pm-dev-java:java-cdi"
+        },
+        {
+          "description": "Java code maintenance standards including prioritization, refactoring triggers, and compliance",
+          "skill": "pm-dev-java:java-maintenance"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-http"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        {
+          "description": "Maven integration testing with Failsafe plugin, IT naming conventions, and profiles",
+          "skill": "pm-dev-java:junit-integration"
+        },
+        {
+          "description": "Weld Testing standards for CDI unit testing with @EnableAutoWeld and auto-discovery patterns",
+          "skill": "pm-dev-java:junit-weld-testing"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-testing",
+        "pm-dev-java-cui:cui-http-testing"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        {
+          "description": "JSpecify null safety annotations with @NullMarked, @Nullable, and package-level configuration",
+          "skill": "pm-dev-java:java-null-safety"
+        },
+        {
+          "description": "Lombok patterns including @Delegate, @Builder, @Value, @Data, @UtilityClass for reducing boilerplate",
+          "skill": "pm-dev-java:java-lombok"
+        },
+        {
+          "description": "Quarkus-specific CDI standards with testing, native image support, and GraalVM reflection configuration",
+          "skill": "pm-dev-java:java-quarkus"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Failsafe IT module \u2014 junit-integration optional applies; java-cui: cui-test-juli-logger used; cui-http-testing applies for attack-database ITs (Plan 03)",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,27 +13,27 @@ Multi-module Maven project:
 - `integration-tests/` — Integration test coordinator (Docker infrastructure, IT suites, scripts)
 - `benchmarks/` — WRK HTTP load testing benchmarks
 
-## Build Commands
+## Development Notes
+
+### Build Commands
+
+Never hard-code build tool commands (`mvn`, `./mvnw`) — invoke builds via the canonical executor commands below:
+
+- Compile: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "compile"`
+- Quality gate: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`
+- Full verify: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`
+- Coverage: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pcoverage"`
+- Module tests (api-sheriff): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -am"` — only on api-sheriff
+- Module tests (benchmarks): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl benchmarks -am"` — only on benchmarks
+- Module tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl integration-tests -am"` — only on integration-tests
+- Integration tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-tests -am"` — only on integration-tests
+- Benchmark (benchmarks): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pbenchmark -pl benchmarks -am"` — only on benchmarks
+- Use a 10-minute Bash timeout (600000ms) for build invocations
+- Analyze each build's TOON result: `status`, `errors[N]{file,line,message,category}`, `log_file`
+
+Special builds without a canonical command:
 
 ```bash
-# Full build with tests
-./mvnw clean install
-
-# Build without tests
-./mvnw clean install -DskipTests
-
-# Single module
-./mvnw clean install -pl <module-name>
-
-# Single test
-./mvnw test -Dtest=ClassName#methodName
-
-# Integration tests
-./mvnw clean verify -Pintegration-tests -pl integration-tests -am
-
-# Integration benchmarks (WRK)
-./mvnw clean verify -pl benchmarks -Pbenchmark
-
 # Build native executable
 ./mvnw clean install -Pnative -pl api-sheriff -am -DskipTests
 
@@ -43,16 +43,10 @@ docker build -f api-sheriff/src/main/docker/Dockerfile.native -t api-sheriff:lat
 
 ### Pre-Commit Process
 
-**CRITICAL** — run before every commit:
+**CRITICAL** — run before every commit; both must pass with zero errors/warnings:
 
-1. Quality verification (fix ALL errors/warnings):
-   ```bash
-   ./mvnw -Ppre-commit clean verify -DskipTests
-   ```
-2. Full verification (must pass completely):
-   ```bash
-   ./mvnw clean install
-   ```
+1. Quality gate (canonical `quality-gate` command above)
+2. Full verify (canonical `verify` command above)
 
 ## Pre-1.0 Rules (HIGHEST PRIORITY)
 
@@ -128,3 +122,12 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
    - Every comment MUST get a reply (reason for fix or reason for not fixing) and MUST be resolved
 7. Do **NOT** enable auto-merge unless explicitly instructed. Wait for user approval.
 8. Return to main: `git checkout main && git pull`
+
+## Temporary Files
+
+Use `.plan/temp/` for ALL temporary and generated files (covered by `Write(.plan/**)` permission — avoids permission prompts).
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
## Summary

Sets up the plan-marshall planning system for this repository (first-run wizard output):

- **`.plan/marshal.json`** — project configuration: skill domains (general-dev, java, java-cui, documentation), active profiles (implementation, module_testing, integration_testing, quality), providers (git, github, sonar), file-to-build map, phase-5 verification steps (quality-gate, module-tests), phase-6 finalize pipeline (full preset incl. Sonar roundtrip and pre-push quality gate), GitHub merge-queue opt-in, review gates.
- **`.plan/project-architecture/`** — discovered and enriched architecture metadata for all 5 modules (responsibilities, purposes, key packages, dependencies, skills-by-profile).
- **`CLAUDE.md`** — build commands section replaced with canonical executor commands (per steward setup); native/docker builds kept as special cases; temporary-files and tool-usage notes added.
- **`.gitignore`** — managed `.plan/` block: runtime state ignored, `marshal.json` and `project-architecture/` tracked.

No production code changes.

## Verification

- `./mvnw verify -Ppre-commit` — green
- `./mvnw clean install` — green