### PR TITLE
chore: enable merge queue and refresh plan-marshall config

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -59,7 +59,8 @@
       "per_envelope_budget_tokens": "400K",
       "verification_steps": {
         "default:verify:quality-gate": {},
-        "default:verify:module-tests": {}
+        "default:verify:module-tests": {},
+        "default:verify:coverage": {}
       },
       "effort": {
         "default": "level-4",
@@ -96,11 +97,23 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": false,
+          "use_merge_queue": true,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},
-        "default:archive-plan": {}
+        "default:archive-plan": {},
+        "default:finalize-step-security-audit": {
+          "security_audit": "auto"
+        },
+        "default:architecture-refresh": {},
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2
+        },
+        "default:finalize-step-print-phase-breakdown": {},
+        "default:pre-submission-self-review": {
+          "self_review": "auto",
+          "drop_review_on_scope_gate": false
+        }
       },
       "effort": {
         "default": "level-3",
@@ -202,7 +215,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1088",
-    "config_seed_fingerprint": "afa68648"
+    "provisioned_version": "0.1.1090",
+    "config_seed_fingerprint": "dde4bc0c"
   }
 }


### PR DESCRIPTION
## Summary

- **Merge queue enabled for real this time**: `maven.yml` and `integration-tests.yml` gain `merge_group:` triggers so the required checks (`build / conclusion`, `integration-tests / conclusion`) run on merge-queue refs. The cuioss-organization reusable workflows (v0.9.0) already handle `merge_group` events (paths-filter and Sonar are skipped there by design). The `plan-marshall-merge-queue` ruleset has been re-created and `use_merge_queue=true` persisted.
- **marshal.json refresh** (provisioned version 0.1.1090): `sync-defaults` back-filled the newly-added default finalize steps — `finalize-step-security-audit`, `pre-submission-self-review`, `architecture-refresh`, `finalize-step-preference-emitter`, `finalize-step-print-phase-breakdown` — plus the `coverage` verification step; canonical key order normalized.

This PR itself merges through the new queue — the merge-group ref contains these workflow changes, so it doubles as the end-to-end verification.

## Verification

- `./mvnw verify -Ppre-commit` — green
- `./mvnw clean install` — green