### PR TITLE
docs: address design findings (reuse, modules, config, streaming, PAR/FAPI, metrics)

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -98,8 +98,8 @@ implementing it.
 | ADR | Decision
 
 | link:adr/0001-java25-runtime-baseline.adoc[ADR-0001]
-| Run the container/native image on the Java 25 runtime for full virtual-thread benefit
-  while keeping source compatibility at Java 21. *(Status: proposed.)*
+| Compile *and* run on Java 25 (the LTS) for full virtual-thread benefit; CI build/test matrix
+  covers Java 25 + 26 (add 27 at GA). Java 21 is not a target. *(Status: accepted.)*
 
 | link:adr/0002-initial-scope.adoc[ADR-0002]
 | Initial scope: gRPC + GraphQL (with HTTP/2 + WebSocket) ship from the start, HTTP/3 deferred;
@@ -112,6 +112,14 @@ implementing it.
 | link:adr/0004-topology-indirection.adoc[ADR-0004]
 | Configuration layout: portable endpoint files reference `base_url` aliases resolved by
   `topology.properties`; a single URL per alias, overridable by `TOPOLOGY_<ALIAS>` env vars.
+
+| link:adr/0005-module-structure.adoc[ADR-0005]
+| One Quarkus module for now (no separate core module yet); keep the framework-agnostic seam
+  clean by package layout + an arch-gate, so a core module is cheap to extract later.
+
+| link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006]
+| Stream data-plane bodies with backpressure; use the `HttpResult<T>` materialize-the-body
+  pattern on the control plane only. `max_body_bytes` is a streaming counter, not a buffer.
 |===
 
 == Reading Order

--- a/doc/adr/0005-module-structure.adoc
+++ b/doc/adr/0005-module-structure.adoc
@@ -1,0 +1,100 @@
+= ADR-0005 -- Module Structure: One Quarkus Module Now, Framework-Agnostic Core Seam Kept Clean
+:toc:
+:toclevels: 2
+
+== Status
+
+Accepted.
+
+== Context
+
+API Sheriff's production code currently lives in a single deployable Quarkus module
+(`api-sheriff`), alongside the `integration-tests` and `benchmarks` coordinator modules. As the
+request pipeline (link:../plan/03-request-pipeline.adoc[Plan 03]) lands, that module gains a
+substantial body of logic that is *not* inherently Quarkus-specific: the immutable
+configuration model and validators (link:../plan/02-configuration-management.adoc[Plan 02]),
+the event/counter system, the route table and matchers, the forward policy, and the boot-time
+assembly of per-route runtime objects. Only a thin outer layer is genuinely framework-bound:
+the CDI producers/observers, the Vert.x HTTP edge, the MicroProfile-config plumbing, and the
+Micrometer/SmallRye-Health wiring.
+
+This raises the question the CUI ecosystem has already answered once: should the
+framework-agnostic logic be extracted into a separate *plain-Java core module*, with a thin
+`-quarkus` binding module on top -- the exact split `token-sheriff-validation` /
+`token-sheriff-validation-quarkus` and `token-sheriff-client` / `token-sheriff-client-quarkus`
+use (`CLIENT-21`: the engine is pure Java, framework bindings sit outside it)?
+
+The heaviest framework-agnostic logic API Sheriff relies on -- offline JWT validation and the
+entire OIDC confidential-client flow -- *already* lives in those upstream pure-Java modules.
+API Sheriff *consumes* them; it does not re-implement them. So the pure-core principle is
+already honoured for the hard parts. What remains in the `api-sheriff` module is mostly config
+modelling plus framework glue.
+
+== Decision
+
+*Keep a single `api-sheriff` Quarkus module for the initial releases. Do not extract a
+separate core module yet. Instead, enforce a clean framework-agnostic seam by package
+discipline inside the one module, so extraction is cheap if and when a real second consumer
+appears.*
+
+Concretely:
+
+* *No core module now.* There is exactly one deployable (the gateway) and exactly one consumer
+  of the framework-agnostic logic (that same deployable). A second Maven module would add a
+  reactor node, a published artifact, and a dependency edge for *zero* current reuse -- cost
+  without payoff. The Static-mode gateway is one process; the pure-Java engines it needs are
+  already separate upstream modules.
+* *Keep the seam clean by package layout.* Framework-agnostic code lives in packages that
+  *must not* import Quarkus, CDI (`jakarta.enterprise.*`, `jakarta.inject.*`),
+  MicroProfile Config, Vert.x, or Micrometer -- e.g. `de.cuioss.sheriff.api.config.model`,
+  `...config.validation`, `...events`, `...routing`, `...forward`, `...pipeline`. These types
+  take their collaborators through *constructor parameters*, never field/CDI injection, and are
+  assembled once at boot (see link:../plan/03-request-pipeline.adoc[Plan 03]'s `RouteRuntime`).
+* *Confine framework wiring to an edge layer.* CDI producers/observers, the Vert.x route
+  handler, config-source plumbing, health/metrics binding, and the RFC 9457 exception edge live
+  in dedicated packages (e.g. `...quarkus`, `...edge`) that *may* depend on the framework and
+  that construct the framework-agnostic objects and hand them their dependencies.
+* *Enforce the boundary mechanically.* An ArchUnit rule (the Java arch-gate) asserts that the
+  framework-agnostic packages carry no import of `io.quarkus..`, `io.vertx..`,
+  `jakarta.enterprise..`, `jakarta.inject..`, `org.eclipse.microprofile..`, or
+  `io.micrometer..`. This is the single-module substitute for the compile-time guarantee a
+  separate module would give, and it is what makes a later extraction mechanical rather than
+  archaeological.
+
+== Consequences
+
+Positive:
+
+* No premature module proliferation: one reactor node, one artifact, one place to build and
+  reason about, matching the actual number of consumers (one).
+* The framework-agnostic core stays genuinely framework-agnostic -- enforced by the arch-gate,
+  not by hope -- so the day a second consumer appears (a non-Quarkus embedding, a shared
+  offline config-lint/validate CLI, a native-image constraint that forces separation, or a
+  reusable test harness) the extraction is a package-to-module move, not a detangling project.
+* Consistent with the CUI precedent already in play: the *pure-Java engines* are separate
+  modules upstream; API Sheriff's own code is predominantly config + framework glue, which is
+  the part that least benefits from its own module.
+
+Negative / to watch:
+
+* The boundary is enforced by an arch-gate rule rather than by module compilation, so it is
+  only as strong as that rule -- the rule must be present and part of the quality gate from the
+  first pipeline PR (Plan 03), or the seam silently erodes.
+* If the framework-agnostic surface grows large and stable, the argument for a real module
+  strengthens; this ADR is explicitly a *"not yet"*, not a *"never"*.
+
+== Revisit When
+
+* A *second consumer* of the framework-agnostic logic materialises (a non-Quarkus host, a
+  standalone `validate`/`lint` CLI for offline config checking, a portal/embedding adapter, or
+  a shared cross-project test harness).
+* Native-image or dependency constraints make the single-module layout costly.
+* The arch-gate boundary proves insufficient in practice (repeated violations, or a need for
+  the compile-time guarantee only a module split provides).
+
+== References
+
+* link:../architecture.adoc#_authentication_layer[Architecture -- Authentication Layer] -- the
+  engine/BFF seam and the pure-Java engine modules API Sheriff consumes.
+* `TokenSheriff/doc/client` `CLIENT-21` -- framework-agnostic engine, framework bindings outside
+  it (the precedent this ADR mirrors at package granularity).

--- a/doc/adr/0006-body-streaming-vs-httpresult.adoc
+++ b/doc/adr/0006-body-streaming-vs-httpresult.adoc
@@ -1,0 +1,126 @@
+= ADR-0006 -- Stream Data-Plane Bodies; Use `HttpResult<T>` Only on the Control Plane
+:toc:
+:toclevels: 2
+
+== Status
+
+Accepted.
+
+== Context
+
+`cui-http` offers two shapes for a downstream call:
+
+* the *async/streaming* client surface (`HttpHandler`, `ResilientHttpAdapter`,
+  `ETagAwareHttpAdapter`, JDK `HttpClient`), and
+* the `HttpResult<T>` *result object* -- a sealed `Success`/`Failure` that carries the
+  *fully-materialized, deserialized* response body as an in-memory `T`, plus status, ETag, an
+  `HttpErrorCategory`, and optional fallback content
+  (link:../technical_aspects.adoc#_httpresult_pattern[Technical Aspects -- HttpResult]).
+
+`HttpResult<T>` is excellent where the response is *small, bounded, and wanted as an object*.
+It is the wrong shape for the *proxy data plane*, where the gateway forwards arbitrary client
+traffic: large responses, file downloads, Server-Sent Events, chunked/long-lived streams, and
+(later) WebSocket upgrades. Materializing such a body into `HttpResult<byte[]>` /
+`HttpResult<String>` means holding the *whole* body in heap/direct memory before a single byte
+reaches the client.
+
+Plan 01's interim proxy already exhibits the hazard: it reads the upstream response with
+`HttpResponse.BodyHandlers.ofByteArray()` (whole body buffered) -- acceptable for a throwaway
+scaffold, unacceptable for the real pipeline.
+
+=== What the competitors do (research)
+
+Every mainstream high-performance proxy *streams* the proxied body by default, with bounded
+buffers and backpressure; full in-memory materialization is off-by-default, opt-in, or the
+documented cause of OOM / latency / broken streaming.
+
+[cols="1,3"]
+|===
+| Proxy | Body handling on the proxy path
+
+| *nginx*
+| `proxy_buffering on` by default but *bounded* -- buffers spill to a temp file
+  (`proxy_max_temp_file_size`), never unbounded RAM; `proxy_buffering off` streams
+  synchronously and is the documented fix for SSE.
+
+| *Envoy*
+| Streams by default ("proxy arbitrarily large bodies" when filters are streaming); full-body
+  buffering is an opt-in filter that returns `500` past its limit. Backpressure via *watermark
+  buffers* + `readDisable`/HTTP-2 flow-control windows; "all buffer limits are soft limits".
+
+| *Traefik / Go `httputil.ReverseProxy`*
+| Streams through `io.CopyBuffer` (32 KB window); `FlushInterval` auto-overridden to
+  immediate flush for streaming responses (`text/event-stream` / `Content-Length: -1`). Full
+  buffering is a separate opt-in middleware.
+
+| *HAProxy*
+| Streams through a bounded per-connection buffer (`tune.bufsize`); whole-body buffering is
+  opt-in (`option http-buffer-request`); switches to a byte tunnel on `101`/`CONNECT`.
+
+| *Spring Cloud Gateway* (JVM, reactive Netty)
+| Streams a `Flux<DataBuffer>` end-to-end by default. The moment a filter materializes the body
+  (`ModifyResponseBodyGatewayFilterFactory`) it is the documented source of
+  `OutOfDirectMemoryError`, broken SSE, direct-memory leaks, and cgroup OOM-kills on large
+  bodies.
+
+| *Vert.x* (our runtime)
+| The recommended primitive is `ReadStream.pipeTo(WriteStream)` / `Pipe`, which does automatic
+  flow control. Vert.x docs warn explicitly that reading faster than writing "could result in
+  the write queue ... growing without bound, eventually causing it to exhaust all available
+  RAM" -- exactly what buffering a proxied body into a `Buffer`/`byte[]`/`String` reintroduces.
+|===
+
+The evidence is unanimous: materializing a *proxied* body is an anti-pattern -- it OOMs under
+concurrency (N concurrent large bodies × whole body in memory), breaks SSE/chunked/infinite
+streams (an object carrying a completed `T` cannot exist until the stream ends), destroys
+backpressure, and forces time-to-first-byte up to time-to-last-byte.
+
+== Decision
+
+*Split the two planes explicitly.*
+
+* *Control plane -- use `HttpResult<T>`.* Small, bounded, single-shot JSON the gateway itself
+  consumes: OIDC discovery, JWKS fetch, the token-endpoint exchange, revocation, userinfo.
+  Here materialization is a *feature* -- a fully-deserialized object, ETag/304 caching
+  (`ETagAwareHttpAdapter`), a typed `HttpErrorCategory`, and fallback content for graceful
+  degradation. These calls live inside `token-sheriff-validation` / `token-sheriff-client`,
+  which already use this shape.
+* *Data plane -- stream, never materialize.* The proxy path forwards request and response
+  bodies as *streams with backpressure*: in Quarkus/Vert.x, pipe the upstream
+  `ReadStream` to the client `WriteStream` (`pipeTo` / `Pipe`), pausing the source when the
+  sink's write queue is full and resuming on drain. The gateway does *not* wrap the proxied
+  body in `HttpResult<byte[]>` / `HttpResult<String>`. `HttpResult` may still be used on the
+  data plane for its *control metadata* (status, error category for the `502`/`503`/`504`
+  mapping) as long as the *body* is a stream, not a materialized `T` -- i.e. never
+  `HttpResult<byte[]>` for the proxied payload.
+* *`max_body_bytes` is a streaming counter, not a buffer.* The per-route body cap
+  (link:../configuration.adoc#_security_filtering[`security_filter.max_body_bytes`]) is enforced
+  by counting bytes as they flow through the pipe and aborting once the cap is exceeded (reject
+  with the input-validation edge; never call the upstream on a request-body breach). The whole
+  body is never held to measure it -- this matches Envoy's soft-limit model and HAProxy's
+  bounded window.
+* *Streaming-specific responses pass through untouched.* SSE (`text/event-stream`), chunked
+  transfer, and long-lived responses are relayed with immediate flush and no buffering;
+  WebSocket upgrades (later plan) become a byte relay after the authenticated handshake. None of
+  these are ever materialized.
+
+== Consequences
+
+* Bounded, predictable memory under concurrency: per-request memory is the pipe window, not the
+  body size, so a thousand concurrent large downloads do not multiply into the heap.
+* SSE / streaming / large downloads work correctly (first byte out immediately; no
+  hold-until-complete), matching every surveyed proxy's default.
+* The `HttpResult<T>` ergonomics are retained exactly where they help -- the small control-plane
+  JSON calls -- without leaking their materialize-the-body cost onto the data plane.
+* Plan 03 replaces the interim `ofByteArray()` buffering proxy with the streaming pipe; the body
+  cap is re-expressed as a streaming counter (see
+  link:../plan/03-request-pipeline.adoc[Plan 03], dispatch/response stages).
+
+== References
+
+* link:../architecture.adoc#_downstream_client[Architecture -- Downstream Client].
+* nginx `proxy_buffering` -- https://nginx.org/en/docs/http/ngx_http_proxy_module.html
+* Envoy flow control -- https://github.com/envoyproxy/envoy/blob/main/source/docs/flow_control.md
+* Go `httputil.ReverseProxy` (streaming, `FlushInterval`) -- https://pkg.go.dev/net/http/httputil#ReverseProxy
+* Spring Cloud Gateway body-materialization OOM -- https://github.com/spring-cloud/spring-cloud-gateway/issues/1404
+* Vert.x `Pipe` (backpressure, unbounded-growth warning) -- https://vertx.io/docs/apidocs/io/vertx/core/streams/Pipe.html

--- a/doc/adr/0006-body-streaming-vs-httpresult.adoc
+++ b/doc/adr/0006-body-streaming-vs-httpresult.adoc
@@ -86,19 +86,24 @@ backpressure, and forces time-to-first-byte up to time-to-last-byte.
   degradation. These calls live inside `token-sheriff-validation` / `token-sheriff-client`,
   which already use this shape.
 * *Data plane -- stream, never materialize.* The proxy path forwards request and response
-  bodies as *streams with backpressure*: in Quarkus/Vert.x, pipe the upstream
-  `ReadStream` to the client `WriteStream` (`pipeTo` / `Pipe`), pausing the source when the
-  sink's write queue is full and resuming on drain. The gateway does *not* wrap the proxied
-  body in `HttpResult<byte[]>` / `HttpResult<String>`. `HttpResult` may still be used on the
-  data plane for its *control metadata* (status, error category for the `502`/`503`/`504`
-  mapping) as long as the *body* is a stream, not a materialized `T` -- i.e. never
-  `HttpResult<byte[]>` for the proxied payload.
+  bodies as *streams with backpressure*, in *both directions*: in Quarkus/Vert.x, pipe the
+  client `ReadStream` to the upstream `WriteStream` (the *request* body) and the upstream
+  `ReadStream` to the client `WriteStream` (the *response* body) via `pipeTo`/`Pipe`, pausing
+  the source when the sink's write queue is full and resuming on drain. The gateway does *not*
+  wrap the proxied body in `HttpResult<byte[]>` / `HttpResult<String>`. `HttpResult` may still be
+  used on the data plane for its *control metadata* (status, error category for the
+  `502`/`503`/`504` mapping) as long as the *body* is a stream, not a materialized `T` -- i.e.
+  never `HttpResult<byte[]>` for the proxied payload.
 * *`max_body_bytes` is a streaming counter, not a buffer.* The per-route body cap
   (link:../configuration.adoc#_security_filtering[`security_filter.max_body_bytes`]) is enforced
-  by counting bytes as they flow through the pipe and aborting once the cap is exceeded (reject
-  with the input-validation edge; never call the upstream on a request-body breach). The whole
-  body is never held to measure it -- this matches Envoy's soft-limit model and HAProxy's
-  bounded window.
+  by counting bytes as they flow through the pipe and aborting once the cap is exceeded; the
+  whole body is never held to measure it (matching Envoy's soft-limit model and HAProxy's
+  bounded window). Two cases: when a request carries a `Content-Length` that already exceeds the
+  cap, it is rejected *before* the upstream connection is opened; for a *chunked / streaming
+  request body with no usable `Content-Length`*, the cap can only be discovered mid-stream -- by
+  then the upstream connection may already be open and some bytes forwarded, so the breach
+  *aborts the in-flight upstream call* (tears down the connection) rather than avoiding it. Both
+  paths reject via the input-validation edge and never complete the forward.
 * *Streaming-specific responses pass through untouched.* SSE (`text/event-stream`), chunked
   transfer, and long-lived responses are relayed with immediate flush and no buffering;
   WebSocket upgrades (later plan) become a byte relay after the authenticated handshake. None of

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -77,6 +77,16 @@ with `404` (deny-by-default). Routes from all endpoint files form one table orde
 most-specific-first; see link:configuration.adoc#_route_ordering[Configuration -- Route ordering]. Routing
 carries no dynamic rule language.
 
+Only routes of *enabled* endpoints enter the table: an endpoint switched off by `enabled: false`
+or `ENDPOINT_<ID>_ENABLED=false` contributes nothing (its paths fall through to `404`), which
+lets one config set be shipped across environments and toggled per environment (see
+link:configuration.adoc#_endpoint_identity[Configuration -- `endpoint`]). Orthogonally, a coarse
+*positive verb allowlist* -- `allowed_methods`, global with wholesale per-endpoint override and
+no inheritance -- gates which HTTP methods an endpoint serves at all: a routed request whose
+method is outside the matched route's effective set is rejected `405` with an `Allow` header,
+above and beyond the per-route `match.methods` matcher (see
+link:configuration.adoc#_allowed_methods[Configuration -- `allowed_methods`]).
+
 === Authentication Layer
 
 The active authentication strategy depends on the variant:
@@ -166,6 +176,20 @@ Upstream calls use `cui-http`:
 The adapters are `CompletableFuture`-based; under the virtual-thread model the gateway may
 also call the blocking JDK `send()` from a virtual-thread-per-request worker.
 
+*Two planes, two body shapes* (link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006]). The
+`HttpResult<T>` *materialize-the-body* pattern is used on the *control plane* only -- the small,
+bounded JSON calls the gateway itself makes (OIDC discovery, JWKS, token exchange, revocation),
+where a deserialized object, ETag/304 caching, a typed error category, and fallback content are
+exactly what is wanted. On the *data plane* -- proxying arbitrary client traffic, including large
+responses, downloads, SSE, chunked and long-lived streams -- the gateway *streams* request and
+response bodies with backpressure (Vert.x `ReadStream.pipeTo`/`Pipe`, pausing the source when
+the sink's write queue is full) and *never* materializes the proxied body into
+`HttpResult<byte[]>`/`HttpResult<String>`. Buffering a proxied body is the documented OOM /
+broken-SSE / lost-backpressure anti-pattern every mainstream proxy avoids by default; the
+`security_filter.max_body_bytes` cap is enforced as a *streaming byte counter*, not by holding
+the body. `HttpResult`'s control metadata (status, `HttpErrorCategory`) may still drive the
+`502`/`503`/`504` mapping as long as the body itself stays a stream.
+
 [[_event_system]]
 == Event System
 
@@ -213,6 +237,7 @@ names the category but leaks no internal detail. The consolidated status mapping
 | `401` | Missing/invalid bearer token; invalid or expired session on a non-navigation request. Unauthenticated *navigation* requests (those accepting `text/html`) on `session` routes are redirected into the login flow instead -- content negotiation, not configuration (see link:configuration.adoc#_auth[Configuration -- `auth`]). Gateway `401`s carry `WWW-Authenticate` (`Bearer` per RFC 6750 on bearer routes). | `AUTHENTICATION`
 | `403` | Valid credentials lacking a required scope; failed CSRF origin check | `AUTHORIZATION`
 | `404` | No route matched (deny-by-default routing); reserved-for-passthrough `Host` on a terminated connection; disabled endpoint (e.g. back-channel logout in cookie mode) | `INPUT_VALIDATION`
+| `405` | Request method not in the matched route's *effective* `allowed_methods` verb allowlist (global default or endpoint override); the response carries an `Allow` header listing the permitted set | `INPUT_VALIDATION`
 | `429` | Rate limit exceeded -- *reserved*; the feature is deferred | --
 | `502` | Upstream connection failure / invalid upstream response | `UPSTREAM`
 | `503` | Circuit breaker open -- the upstream was not called (`Retry-After` hints at `reset_ms`) | `UPSTREAM`
@@ -233,7 +258,13 @@ The manifest requires *paths, errors, and average timing*. These map to:
 | Metric | Meaning
 
 | `sheriff_requests_total{route,method,status_family}`
-| Counter of requests per route, method, and status family -- the "paths" view.
+| Counter of requests per route, method, and status family -- the "paths" view. Because
+  `status_family` labels each count (`2xx`/`3xx`/`4xx`/`5xx`), *how often each resource was
+  called successfully* is a direct query: `sheriff_requests_total{status_family="2xx"}` per
+  `route` (and, if wanted, a `sum by (route)` for a total-calls-per-resource view). The
+  `REQUEST_FORWARDED` success event in the link:#_event_system[event system] is the same signal
+  at the counter layer. Route cardinality is bounded (route id is a config-fixed label;
+  unmatched requests share the fixed `"<no-route>"` value), so this is safe to keep always on.
 
 | `sheriff_request_duration_seconds{route}` (timer)
 | Latency distribution per route; the timer's mean gives "average timing", and quantiles/
@@ -308,9 +339,70 @@ The gateway targets a virtual-thread-per-request model:
   instance is created at startup and shared.
 
 To get the full benefit -- specifically JEP 491 (JDK 24+), which removes carrier-thread
-pinning on `synchronized` blocks -- the container/native image is to run on the Java 25
-runtime, per link:adr/0001-java25-runtime-baseline.adoc[ADR-0001] (status: proposed). Source compatibility remains at
-Java 21 (`maven.compiler.release=21`).
+pinning on `synchronized` blocks -- API Sheriff *compiles and runs on Java 25* (the LTS),
+per link:adr/0001-java25-runtime-baseline.adoc[ADR-0001] (`maven.compiler.release=25`; the
+container/native runtime is the JDK 25 line). The CI build/test matrix additionally exercises
+the next GA release (Java 26, then 27 at GA) as a forward-compatibility guard. Java 21 is not a
+target for this project.
+
+[[_performance_object_reuse]]
+== Performance: Boot-Time Assembly and Object Reuse
+
+The gateway is on a hot path -- every request pays for whatever it constructs. The design rule
+is therefore *assemble the expensive objects once at boot and share the immutable instances
+across all requests*; request-time work allocates as little as possible and touches no shared
+mutable state. This is where the throughput comes from, and it is safe precisely *because* the
+shared objects are immutable.
+
+*Reused, shared, immutable (constructed once at startup):*
+
+[cols="1,3"]
+|===
+| Object | Reuse rule
+
+| Inbound security pipelines + `SecurityConfiguration`
+| Immutable and thread-safe once built. One `SecurityConfiguration` and its pipeline set per
+  *distinct profile / `security_filter` shape* -- *deduplicated*, so the many routes that share
+  a profile share one pipeline instance rather than each compiling its own. Built at boot,
+  referenced by every matching route's `RouteRuntime`.
+
+| `HttpHandler` (downstream client) + its connection pool
+| Immutable and thread-safe after construction. One `HttpHandler` per *distinct upstream target
+  tuple* (resolved host + connect/read timeouts + TLS context) -- *deduplicated across routes*,
+  so N routes to the same backend with the same timeouts share one handler and one pooled JDK
+  `HttpClient`/connection pool, rather than opening N pools. This is the single biggest "reuse a
+  large object" lever.
+
+| `TokenValidator`
+| A single shared, cache-backed, thread-safe instance created at startup (already the rule --
+  see Threading Model); never per-request.
+
+| `ForwardedHeaderResolver`
+| Immutable, thread-safe, transport-agnostic; one instance wired from the `forwarded` config,
+  reused for every request.
+
+| `RouteTable` / per-route `RouteRuntime`
+| Assembled once at boot (matchers, effective auth, effective `allowed_methods`, filter
+  pipelines, forward sets, upstream client chain, circuit breaker, protocol processor). The
+  request path *looks up* an immutable `RouteRuntime`; it compiles nothing.
+
+| Event counters (`GatewayEventCounter`, cui-http `SecurityEventCounter`)
+| Shared, lock-free (`ConcurrentHashMap` + `AtomicLong`); safe to increment concurrently.
+|===
+
+*Per-request, never shared (lives on the request's virtual-thread stack):* the resolved
+forwarding result (`ResolvedForwarding`), the validated token (`AccessTokenContent`), the
+matched route reference, and the streamed request/response bodies. None of this is stored back
+into a shared object.
+
+*Why reuse does not compromise security.* The shared objects carry *configuration*, not
+*request state*: they are immutable and hold nothing derived from a specific client, token, or
+body. Because there is no shared mutable per-request state, there is no cross-request bleed --
+one request can never observe or inherit another's identity, headers, or body through a reused
+pipeline, handler, or resolver. The circuit breaker is the one shared object with mutable state,
+and it is deliberately *per-node, per-route* aggregate health only (failure counts/timers), never
+per-client data. Reuse is thus a throughput win with no confidentiality or integrity cost -- the
+immutability that makes the objects shareable is the same property that makes them safe to share.
 
 == Library Dependencies (Design Intent)
 

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -116,6 +116,13 @@ security_headers:                  # response-header middleware (global default)
 security_defaults:                 # default inbound filter profile; overridable per route
   profile: strict                  # default | strict | lenient  (maps to cui-http presets)
 
+allowed_methods: [GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS]   # positive HTTP-verb allowlist
+                                   #   (global default). An endpoint may REPLACE this wholesale
+                                   #   (no inheritance -- see endpoint.allowed_methods). A routed
+                                   #   request whose method is not in the EFFECTIVE list is
+                                   #   rejected 405. TRACE and CONNECT are never permitted and
+                                   #   cannot be listed. Omit => the standard set shown here.
+
 forwarded:                         # resolved by cui-http (de.cuioss.http.forwarded)
   trusted_proxies: [10.0.0.5/32, 10.0.0.6/32]   # MANDATORY; the exact proxy addresses --
                                    #   keep as narrow as possible; empty => forwarding
@@ -176,10 +183,19 @@ from the topology at startup.
 ----
 # endpoints/app1.yaml
 endpoint:
-  id: app1
+  id: app1                         # unique endpoint name (mandatory); a duplicate id across
+                                   #   endpoint files fails the boot
+  enabled: true                    # default true. false => this endpoint is inert: its routes
+                                   #   are not added to the table and its base_url alias need
+                                   #   not resolve. Overridable per environment by the env var
+                                   #   ENDPOINT_APP1_ENABLED (wins over the file), the same
+                                   #   indirection topology uses
   base_url: APP1                   # alias; resolved from topology.properties / env
   auth:                            # MANDATORY: default auth posture for every route in
     require: bearer                #   this file; a route may override it (below)
+  allowed_methods: [GET, POST]     # optional per-endpoint verb allowlist; REPLACES the global
+                                   #   gateway.allowed_methods wholesale for this endpoint (no
+                                   #   inheritance, no merge). Omit => the global list applies
   routes:                          # merged into one table across all endpoint files
                                    #   (see "Route ordering"); no match => 404
     - id: orders-api
@@ -294,6 +310,15 @@ Deny-by-default extends to omitted configuration:
   block *replaces* the endpoint default wholesale (no field merging). An endpoint file without
   an `auth` block fails the boot.
 
+| `enabled` (endpoint level)
+| The endpoint is *active* (`enabled: true`). Set `false` -- or the env override
+  `ENDPOINT_<ID>_ENABLED=false` -- to make the endpoint inert (see
+  link:#_endpoint_identity[`endpoint`]).
+
+| `allowed_methods` (endpoint level)
+| The *global* `gateway.allowed_methods` applies (which itself defaults to the standard verb
+  set when omitted). No inheritance/merge -- see link:#_allowed_methods[`allowed_methods`].
+
 | `security_filter`
 | The global `security_defaults.profile` applies with the preset's limits.
 
@@ -349,6 +374,40 @@ referenced by an endpoint file that resolves to neither is a *boot failure*.
   link:adr/0004-topology-indirection.adoc[ADR-0004].
 
 == Field Reference
+
+[[_endpoint_identity]]
+=== `endpoint` (identity and enablement)
+
+Every `endpoints/*.yaml` file declares exactly one `endpoint` block. Its identity and
+enablement fields:
+
+[cols="1,3"]
+|===
+| Field | Meaning
+
+| `id`
+| The endpoint's *unique name* (mandatory). It labels the endpoint in logs and metrics and is
+  the key for the `enabled` env override (below). *`id` must be unique across all endpoint
+  files* -- two endpoints sharing an `id` (in one file or across files) *fail the boot*. This
+  is distinct from, and additional to, route-`id` uniqueness. Pattern: `[a-z][a-z0-9-]*`.
+
+| `enabled`
+| Whether this endpoint is active. *Defaults to `true`*. When `false`, the endpoint is *inert*:
+  its routes are *not* merged into the route table (requests to those paths get the ordinary
+  `404`), it does not participate in route disjointness / passthrough-collision checks, and its
+  `base_url` alias *need not resolve* -- so an endpoint whose backend is absent in a given
+  environment can be shipped in the config set and simply switched off there. A disabled
+  endpoint is still *schema-validated* (typos are caught), it is just not activated. Overridable
+  per environment by the environment variable *`ENDPOINT_<ID>_ENABLED`* (`true`/`false`), which
+  *wins over the file value* -- the same file-plus-env-override indirection
+  link:#_topology[topology] uses. `<ID>` is the upper-cased `id` with hyphens mapped to
+  underscores (endpoint `order-api` -> `ENDPOINT_ORDER_API_ENABLED`).
+|===
+
+The endpoint's other fields are documented under their own headings: `base_url`
+(link:#_topology[Topology] / link:adr/0004-topology-indirection.adoc[ADR-0004]), `auth`
+(link:#_auth[`auth`]), `allowed_methods` (link:#_allowed_methods[`allowed_methods`]), and
+`routes` (link:#_route_ordering[Route ordering] + the per-route field headings).
 
 === `tls`
 
@@ -733,6 +792,38 @@ The global inbound-filter baseline: `profile` selects the `cui-http` preset
 `lenient` -> `lenient()`) applied to every route that does not declare its own
 `security_filter` block. Per-route `security_filter` settings override this baseline.
 
+[[_allowed_methods]]
+=== `allowed_methods`
+
+A *positive allowlist of HTTP verbs*, declarable at two scopes -- `gateway.yaml` (global) and
+per `endpoint` -- with *explicit no-inheritance semantics*. It is a coarse, defence-in-depth
+verb gate that sits *above* the per-route `match.methods` matcher: `match.methods` selects which
+route serves a verb; `allowed_methods` decides whether the gateway will serve the verb *at all*
+for that endpoint.
+
+*Resolution (no inheritance).* Each route's *effective* `allowed_methods` is materialized once
+at boot:
+
+* the *endpoint's* `allowed_methods` if the endpoint declares one -- it *replaces* the global
+  list wholesale for that endpoint (no merge, no union, no intersection -- exactly the
+  wholesale-replace rule the `auth` block uses); else
+* the *global* `gateway.allowed_methods` if declared; else
+* the standard set `{GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS}`.
+
+Because the endpoint list *replaces* rather than narrows, an endpoint may permit a verb the
+global default omits (global `[GET, POST, PUT]`, endpoint `[PUT, DELETE, HEAD]` -> that
+endpoint serves `DELETE`/`HEAD` and *not* `GET`/`POST`; other endpoints keep the global list).
+
+*Runtime.* After route selection, a request whose method is not in the matched route's
+effective `allowed_methods` is rejected with `405 Method Not Allowed` and an `Allow` header
+listing the effective set (`INPUT_VALIDATION` event); the upstream is never called. `TRACE` and
+`CONNECT` are *never* permitted -- they are not proxyable through the data plane and cannot
+appear in any `allowed_methods` list (listing either fails the boot).
+
+*Boot validation.* Every method named in a route's `match.methods` must be a member of that
+route's effective `allowed_methods`; a route that matches a verb its endpoint forbids is a
+contradiction and *fails the boot* (fail-fast, rather than a route that can never fire).
+
 [[_forwarded_headers]]
 === `forwarded`
 
@@ -834,9 +925,15 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 == Configuration Validation Rules (summary)
 
 * `version` must be a known value.
+* Every `endpoint.id` is unique across all endpoint files (in one file or across files); a
+  duplicate endpoint `id` fails the boot.
 * Every route has a unique `id` (across all endpoint files) and a resolvable `endpoint.base_url`.
-* Every `base_url` alias resolves via `TOPOLOGY_<ALIAS>` or `topology.properties` to a well-formed
-  URL; otherwise boot fails.
+* An endpoint is *enabled* unless `enabled: false` (file) or `ENDPOINT_<ID>_ENABLED=false` (env,
+  which wins). A *disabled* endpoint is schema-validated but otherwise inert: its routes are not
+  merged into the table, its `base_url` alias is *exempt* from the resolution requirement below,
+  and it takes no part in the disjointness / passthrough-collision checks.
+* Every `base_url` alias *of an enabled endpoint* resolves via `TOPOLOGY_<ALIAS>` or
+  `topology.properties` to a well-formed URL; otherwise boot fails.
 * Every endpoint file declares an `auth` block (the default posture for its routes); omitting
   it fails the boot. Routes may override it per route (see "Defaults for omitted blocks").
 * A route whose *effective* auth is `require: bearer` requires a `token_validation` block with
@@ -845,6 +942,13 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 * Any two routes with an identical `match.path_prefix` -- same file or not -- must be statically
   disjoint (both declare different `host` values, or non-overlapping `methods`, or same-name
   header matchers with different exact values); otherwise the boot fails (see "Route ordering").
+* `allowed_methods` (global or endpoint) may list only `GET`, `HEAD`, `POST`, `PUT`, `PATCH`,
+  `DELETE`, `OPTIONS`; listing `TRACE` or `CONNECT` fails the boot. An endpoint `allowed_methods`
+  *replaces* the global list wholesale (no inheritance).
+* Every method in a route's `match.methods` must be a member of that route's *effective*
+  `allowed_methods` (the endpoint's list if declared, else the global list, else the standard
+  set); a route matching a verb its endpoint forbids fails the boot (see
+  link:#_allowed_methods[`allowed_methods`]).
 * A route whose `match.host` equals (case-insensitively) a key in `tls.passthrough_sni`
   fails the boot -- the route and the passthrough declaration contradict each other
   (see the `tls` field reference).

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -820,9 +820,14 @@ listing the effective set (`INPUT_VALIDATION` event); the upstream is never call
 `CONNECT` are *never* permitted -- they are not proxyable through the data plane and cannot
 appear in any `allowed_methods` list (listing either fails the boot).
 
-*Boot validation.* Every method named in a route's `match.methods` must be a member of that
-route's effective `allowed_methods`; a route that matches a verb its endpoint forbids is a
-contradiction and *fails the boot* (fail-fast, rather than a route that can never fire).
+*Boot validation.* The check applies only to *explicitly declared* `match.methods`: every method
+*listed* in a route's `match.methods` must be a member of that route's effective
+`allowed_methods` -- a route that matches a verb its endpoint forbids is a contradiction and
+*fails the boot* (fail-fast, rather than a route that can never fire). A route that *omits*
+`match.methods` (so it would match all methods) does *not* fail the boot against a narrower
+`allowed_methods`; it simply serves the effective set and the verb gate returns `405` at runtime
+for the rest. So `allowed_methods` is the way to blanket-restrict verbs across an endpoint's
+routes without restating `match.methods` on each.
 
 [[_forwarded_headers]]
 === `forwarded`

--- a/doc/features-analysis.adoc
+++ b/doc/features-analysis.adoc
@@ -197,6 +197,26 @@ architecture makes it uniquely able to close all three.
   `realip` / Kong issues cited in ADR-0003's references) and "Forwarded header sabotage".
   See link:adr/0003-forwarded-headers.adoc[ADR-0003].
 
+| *PAR-driven, FAPI-2.0-aligned confidential-client flow*
+| A *major* differentiator. API Sheriff drives the authorization-code flow through *Pushed
+  Authorization Requests* (PAR, RFC 9126) -- pushing the authorization parameters over the back
+  channel and redirecting with the returned `request_uri`, so parameters are never exposed or
+  tamperable in the browser -- as part of a FAPI-2.0-aligned confidential-client posture (PKCE
+  `S256`, exact `redirect_uri`, `iss` mix-up defence, sender-constrained tokens). This is
+  delivered by the `token-sheriff-client` engine (`CLIENT-10` PAR, `CLIENT-11`
+  sender-constraint; the authoritative surface is `TokenSheriff/doc/client`), which API Sheriff
+  consumes. *Competitor reality (verified):* three of the six evaluated gateways
+  (KrakenD, Tyk, Gravitee-APIM) are not OIDC relying parties in the data plane at all -- they
+  only *validate* pre-issued JWTs. The two that genuinely act as an RP in OSS (APISIX's
+  `openid-connect`, community Traefik plugins) run a plain PKCE code flow and expose *no* PAR and
+  claim *no* FAPI 2.0. The only product shipping PAR inside its RP is *Kong, Enterprise-only*,
+  and it markets generic "FAPI" (1.0-era), not FAPI 2.0. A first-class, *OSS*, PAR-initiating,
+  FAPI-2.0-aligned RP/BFF is therefore genuinely uncovered. (Do not conflate sides: many IdPs
+  and Gravitee's separate *Access Management* product support PAR/FAPI as the *authorization
+  server* -- the opposite side of the wire; the differentiator claimed here is the *client/RP*
+  side, pushing to the `pushed_authorization_request_endpoint` and driving the redirect.) See
+  link:variants/02-bff-session.adoc[Variant 2] / link:variants/03-bff-cookie.adoc[Variant 3].
+
 | *RFC 9470 step-up authentication*
 | No gateway parses an upstream `WWW-Authenticate` challenge to trigger re-authorization.
   Because API Sheriff is the OIDC relying party holding the session, it can intercept a
@@ -231,6 +251,7 @@ Secondary differentiators worth claiming:
 | Immutable static config | Yes | Standalone mode | file provider | Yes (native)
 | OIDC RP + cookie mediation | Yes | Yes | EE only | No
 | Transparent token refresh | Yes | Yes | EE only | M2M only
+| PAR-initiating FAPI 2.0 RP | *Yes* | No | No | No
 | Offline JWT validation | Yes | Yes | Partial | Yes
 | Zero-trust forwarding | Yes | No | No | Yes
 | Path allowlist + param limits | Yes | Partial | No | Partial

--- a/doc/plan/02-configuration-management.adoc
+++ b/doc/plan/02-configuration-management.adoc
@@ -95,20 +95,26 @@ deliverables do not change, only the implementation of the structural half.
 
 === D3 -- Configuration object model
 
-Immutable records (Java 21) under `de.cuioss.sheriff.api.config.model`:
+Immutable Java records under `de.cuioss.sheriff.api.config.model`:
 
 * `GatewayConfig` (root aggregate) -- `TlsConfig`, `SecurityHeadersConfig`,
   `SecurityDefaultsConfig`, `ForwardedConfig`, `TokenValidationConfig` (+`IssuerConfig`
   mirror), `OidcConfig` (parsed and validated now; consumed by later BFF plans), `Metadata`.
-* `EndpointConfig` -- `id`, `baseUrlAlias`, mandatory `AuthConfig`, `List<RouteConfig>`.
+* `EndpointConfig` -- `id` (the unique endpoint name), `enabled` (default `true`),
+  `baseUrlAlias`, mandatory `AuthConfig`, optional `allowedMethods` (verb allowlist), and
+  `List<RouteConfig>`.
 * `RouteConfig` -- `MatchConfig`, `AuthConfig` (nullable = inherit endpoint),
   `SecurityFilterConfig`, `ForwardConfig`, `UpstreamConfig`, reserved `RateLimitConfig`,
   `protocol` enum.
 * `ResolvedTopology` -- alias -> `ResolvedUpstream{scheme, host, port, basePath}`
   (decompose-once, ADR-0004).
 * `RouteTable` -- the merged, disjointness-checked, longest-prefix-ordered immutable table
-  with the *effective auth* (endpoint default or wholesale route override) materialized per
-  route, so downstream pipeline code never re-implements inheritance.
+  with the *effective auth* (endpoint default or wholesale route override) *and effective
+  `allowedMethods`* (endpoint list, else global, else the standard set -- no inheritance)
+  materialized per route, so downstream pipeline code never re-implements inheritance. Only
+  routes of *enabled* endpoints are included; a disabled endpoint (`enabled: false` or
+  `ENDPOINT_<ID>_ENABLED=false`) contributes no rows and is exempt from alias resolution and
+  disjointness checks.
 
 Empty collections over null; `Optional` for optional scalar returns; Lombok only where records
 don't fit. Every package gets `package-info.java`.
@@ -125,15 +131,19 @@ SHERIFF_CONFIG_DIR for the container)
 2. schema-validate each YAML document (D1/D2)          -> collect ALL errors
 3. bind to records (D3)
 4. resolve ${ENV_VAR} secret references                -> missing env var = boot error
-5. resolve topology aliases (env TOPOLOGY_<ALIAS> wins over file), decompose URLs
-6. cross-validation (ConfigValidator: the full rule list from configuration.adoc
+5. resolve endpoint enablement (env ENDPOINT_<ID>_ENABLED wins over file `enabled`);
+   drop disabled endpoints before the checks that only concern live routes
+6. resolve topology aliases (env TOPOLOGY_<ALIAS> wins over file), decompose URLs
+   -- only for ENABLED endpoints' aliases
+7. cross-validation (ConfigValidator: the full rule list from configuration.adoc
    "Configuration Validation Rules (summary)")         -> collect ALL errors
-7. build RouteTable (merge, disjointness check, longest-prefix ordering,
-   effective-auth materialization; weakening overrides logged as boot-log WARNs)
-8. freeze -> GatewayConfig + RouteTable exposed as @ApplicationScoped CDI beans
+8. build RouteTable (enabled endpoints only; merge, disjointness check, longest-prefix
+   ordering, effective-auth + effective-allowed_methods materialization; weakening
+   overrides logged as boot-log WARNs)
+9. freeze -> GatewayConfig + RouteTable exposed as @ApplicationScoped CDI beans
 ----
 
-* Failure semantics: any error in steps 1-7 -> log every collected violation with
+* Failure semantics: any error in steps 1-8 -> log every collected violation with
   file/pointer context, then *fail startup* (throw from the CDI producer / startup observer;
   Quarkus exits non-zero). Never serve traffic on partial config.
 * `CONFIG_LOADED` INFO LogRecord (with `metadata.config_version` audit stamp) on success;
@@ -160,15 +170,23 @@ SHERIFF_CONFIG_DIR for the container)
   file/JSON-Pointer context.
 . *Topology resolution* -- properties parsing, env override precedence, URL decomposition;
   unit tests incl. malformed URL, missing alias, env-wins-over-file.
+. *Endpoint enablement* -- resolve the `enabled` flag with `ENDPOINT_<ID>_ENABLED` env
+  precedence (mirrors topology resolution: env wins over file, default `true`); disabled
+  endpoints are dropped before route-table assembly and exempt from alias resolution; unit
+  tests incl. env-disables-file-enabled, env-enables-file-disabled, disabled-endpoint-alias-
+  need-not-resolve.
 . *ConfigValidator* -- one small rule class per bullet of the validation-rules summary in
   `configuration.adoc`, each with parameterized tests (valid + violating fixtures):
-  route-id uniqueness, alias resolution, endpoint-auth mandatory, effective-auth ->
-  `token_validation`/`oidc` presence, same-prefix disjointness (host/methods/header value),
-  passthrough-SNI vs `match.host` collision, passthrough alias base-path rule, trusted-proxies
-  presence + trust-all rejection, whole-second timeouts, `${ENV_VAR}`-only secrets,
-  cookie/server session-mode conditionals, CORS wildcard+credentials rejection.
-. *RouteTable* -- merge/ordering/disjointness + effective-auth materialization; property-based
-  tests with `@GeneratorsSource` for prefix/host/method permutations.
+  endpoint-id uniqueness, route-id uniqueness, alias resolution (enabled endpoints only),
+  endpoint-auth mandatory, effective-auth -> `token_validation`/`oidc` presence, same-prefix
+  disjointness (host/methods/header value), `allowed_methods` TRACE/CONNECT rejection +
+  `match.methods` within the effective `allowed_methods`, passthrough-SNI vs `match.host` collision,
+  passthrough alias base-path rule, trusted-proxies presence + trust-all rejection,
+  whole-second timeouts, `${ENV_VAR}`-only secrets, cookie/server session-mode conditionals,
+  CORS wildcard+credentials rejection.
+. *RouteTable* -- merge/ordering/disjointness + effective-auth + effective-`allowed_methods`
+  materialization (enabled endpoints only); property-based tests with `@GeneratorsSource` for
+  prefix/host/method permutations.
 . *CDI wiring* -- producer, startup observer, fail-fast test (`QuarkusUnitTest` with broken
   config asserting startup failure), `CONFIG_LOADED` log assertion via
   `cui-test-juli-logger`.

--- a/doc/plan/03-request-pipeline.adoc
+++ b/doc/plan/03-request-pipeline.adoc
@@ -123,9 +123,11 @@ inbound request (virtual thread)
        re-run only when they differ from the stage-1 defaults
      - allowed_paths whitelist on the VALIDATED, NORMALIZED path (gateway code,
        {name} = exactly one segment)
-     - max_body_bytes cap enforced as a STREAMING byte counter while piping the
-       body (gateway code; cui-http has no body pipeline) -- the body is never
-       buffered to measure it (ADR-0006)                                     [stage 3]
+     - max_body_bytes: FAST-REJECT here when a Content-Length already exceeds the
+       cap (no body read yet); the actual STREAMING byte counter runs at dispatch
+       (stage 6) for chunked / no-Content-Length bodies. Gateway code; the counter
+       lives in the framework EDGE layer (it needs the Vert.x stream), the core
+       pipeline only carries the limit -- ADR-0005 boundary, ADR-0006      [stage 3]
   4. AUTHENTICATION (effective auth):
      - require: none    -> pass
      - require: bearer  -> TokenValidator.createAccessToken(
@@ -143,7 +145,9 @@ inbound request (virtual thread)
   6. DISPATCH: upstream URL = resolved(base_url) + upstream.path + remainder
      + allowed query; shared per-upstream-tuple HttpHandler (timeouts) wrapped
      in ResilientHttpAdapter (retry, idempotent-only) wrapped in the gateway
-     circuit breaker; request body STREAMED to the upstream (never buffered);
+     circuit breaker; request body STREAMED to the upstream (never buffered),
+     the max_body_bytes streaming counter enforcing here -- a breach mid-stream
+     ABORTS the in-flight upstream call (400, INPUT_VALIDATION);
      failure mapping per the error contract
      (502 / 503 breaker-open + Retry-After / 504 timeout)                    [stage 6]
   7. RESPONSE: status + upstream headers (hop-by-hop headers stripped) + body

--- a/doc/plan/03-request-pipeline.adoc
+++ b/doc/plan/03-request-pipeline.adoc
@@ -26,6 +26,13 @@ the event system, metrics, structured logging, and the RFC 9457 error contract.
   `token_validation`, `match`, `forward`, `upstream`, `forwarded`, `security_headers`.
 . link:../adr/0003-forwarded-headers.adoc[ADR-0003] -- forwarding-header posture; note the
   *gateway-side immediate-TCP-peer gate* is API Sheriff code, not the resolver's.
+. link:../adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006] -- stream data-plane bodies
+  (never materialize the proxied body into `HttpResult<byte[]>`); `max_body_bytes` as a
+  streaming counter. Governs the dispatch/response stages.
+. link:../architecture.adoc#_performance_object_reuse[Architecture -- Object Reuse] +
+  link:../adr/0005-module-structure.adoc[ADR-0005] -- assemble heavy objects once at boot and
+  share the immutable instances (dedup `SecurityConfiguration`/`HttpHandler`); keep the
+  framework-agnostic pipeline packages free of CDI/Vert.x imports (arch-gate).
 . link:../technical_aspects.adoc[Technical Aspects] -- the concrete `cui-http` and
   `token-sheriff-validation` APIs (pipelines, `SecurityConfiguration`,
   `ForwardedHeaderResolver`/`ResolvedForwarding`, `HttpHandler`/`HttpResult`,
@@ -92,9 +99,9 @@ in this plan (config accepted by Plan 02's schema, route load fails with a clear
 
 === D3 -- Pipeline stages and their fixed order
 
-Assembled once at boot per route into an immutable `RouteRuntime` (compiled matchers, filter
-pipelines, forward policy sets, upstream client chain, scope list, protocol processor);
-request-time work touches no mutable shared state.
+Assembled once at boot per route into an immutable `RouteRuntime` (compiled matchers, the
+effective `allowed_methods` verb set, filter pipelines, forward policy sets, upstream client
+chain, scope list, protocol processor); request-time work touches no mutable shared state.
 
 ----
 inbound request (virtual thread)
@@ -108,13 +115,17 @@ inbound request (virtual thread)
      violation -> 400 problem+json, INPUT_VALIDATION event                   [stage 1]
   2. ROUTE SELECTION: RouteTable candidate match (path prefix AND methods AND
      host AND headers), longest prefix wins; no candidate -> 404             [stage 2]
+  2b. VERB GATE: matched route's effective allowed_methods (endpoint list, else
+      global, else standard set -- materialized at boot); method outside it ->
+      405 + Allow header, INPUT_VALIDATION event                             [stage 2b]
   3. THOROUGH CHECKS (route's optional `security_filter`, cui-http):
      - per-route SecurityConfiguration (profile + explicit overrides) pipelines,
        re-run only when they differ from the stage-1 defaults
      - allowed_paths whitelist on the VALIDATED, NORMALIZED path (gateway code,
        {name} = exactly one segment)
-     - max_body_bytes cap enforced while reading the body (gateway code;
-       cui-http has no body pipeline)                                        [stage 3]
+     - max_body_bytes cap enforced as a STREAMING byte counter while piping the
+       body (gateway code; cui-http has no body pipeline) -- the body is never
+       buffered to measure it (ADR-0006)                                     [stage 3]
   4. AUTHENTICATION (effective auth):
      - require: none    -> pass
      - require: bearer  -> TokenValidator.createAccessToken(
@@ -130,12 +141,14 @@ inbound request (virtual thread)
        emit: both); inbound forwarding headers never propagated
      - inbound Authorization stripped unless explicitly allow-listed         [stage 5]
   6. DISPATCH: upstream URL = resolved(base_url) + upstream.path + remainder
-     + allowed query; per-route HttpHandler (timeouts) wrapped in
-     ResilientHttpAdapter (retry, idempotent-only) wrapped in the gateway
-     circuit breaker; failure mapping per the error contract
+     + allowed query; shared per-upstream-tuple HttpHandler (timeouts) wrapped
+     in ResilientHttpAdapter (retry, idempotent-only) wrapped in the gateway
+     circuit breaker; request body STREAMED to the upstream (never buffered);
+     failure mapping per the error contract
      (502 / 503 breaker-open + Retry-After / 504 timeout)                    [stage 6]
   7. RESPONSE: status + upstream headers (hop-by-hop headers stripped) + body
-     streamed back; security response headers from stage 0 applied
+     STREAMED back with backpressure (Vert.x pipeTo; never materialized into an
+     HttpResult<byte[]>, ADR-0006); security response headers from stage 0 applied
 ----
 
 Every rejection path returns `application/problem+json` per the
@@ -174,13 +187,19 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 . *Event system + error edge* (D4) -- pure unit-tested base package first; problem+json
   rendering tests for every row of the error-contract table.
 . *RouteRuntime assembly* -- boot-time compilation of `RouteTable` into runtime objects:
-  matchers, per-route `SecurityConfiguration`/pipelines, forward sets, `HttpHandler` +
-  `ResilientHttpAdapter` chain, circuit breaker, protocol processor lookup, weakening-override
-  boot WARNs. Boot-time rejection of `grpc`/`websocket`/`session` (this plan's scope guard).
-. *Stages 0-3* -- security headers + CORS preflight, basic pipelines, route selection,
-  thorough checks, allowed_paths matcher, body cap. Unit tests use the cui-http *attack
-  databases* (`OWASPTop10AttackDatabase`, CVE databases, plus the legitimate-pattern
-  databases for false-positive guarding) via `@GeneratorsSource`-style parameterized tests.
+  matchers, the effective `allowed_methods` verb set, per-route `SecurityConfiguration`/pipelines,
+  forward sets, `HttpHandler` + `ResilientHttpAdapter` chain, circuit breaker, protocol processor
+  lookup, weakening-override boot WARNs. *Deduplicate shared heavy objects* per
+  link:../architecture.adoc#_performance_object_reuse[Architecture -- Object Reuse]: one
+  `SecurityConfiguration`/pipeline set per distinct profile shape, one `HttpHandler` (+ pooled
+  client) per distinct upstream-target tuple -- routes sharing a shape/target share the instance,
+  not a copy. Boot-time rejection of `grpc`/`websocket`/`session` (this plan's scope guard).
+. *Stages 0-3* -- security headers + CORS preflight, basic pipelines, route selection, the
+  `allowed_methods` verb gate (stage 2b -> 405 + `Allow`), thorough checks, allowed_paths
+  matcher, body cap. Unit tests use the cui-http *attack databases* (`OWASPTop10AttackDatabase`,
+  CVE databases, plus the legitimate-pattern databases for false-positive guarding) via
+  `@GeneratorsSource`-style parameterized tests; add a verb-gate test (method outside the
+  effective set -> 405 with the correct `Allow` set, upstream never called).
 . *Stage 4* -- TokenValidator producer wiring from `token_validation` config (single shared
   validator at startup), bearer extraction, scope enforcement; tests with
   `token-sheriff-validation`'s `generators` test-jar key material; JWKS over
@@ -188,9 +207,12 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 . *Stage 5* -- forward-policy filtering; TCP-peer gate + resolver wiring + regeneration
   (assert: spoofed inbound `X-Forwarded-For` from a non-trusted peer is ignored; chains are
   regenerated, never appended).
-. *Stage 6 + 7* -- dispatch, hop-by-hop header stripping, streaming, circuit breaker
-  (unit-test state machine: closed -> open after N failures -> half-open after reset_ms),
-  timeout/retry mapping to 504/502/503.
+. *Stage 6 + 7* -- dispatch, hop-by-hop header stripping, *body streaming with backpressure*
+  (Vert.x `ReadStream.pipeTo`/`Pipe` in both directions -- no `HttpResult<byte[]>`
+  materialization of the proxied body, per ADR-0006), circuit breaker (unit-test state machine:
+  closed -> open after N failures -> half-open after reset_ms), timeout/retry mapping to
+  504/502/503. Tests: assert a large response streams (first byte before last, bounded memory)
+  and that `max_body_bytes` aborts mid-stream without buffering the whole body.
 . *Vert.x edge* -- catch-all route, virtual-thread dispatch, wire stages; delete the Plan 01
   placeholder resource/tests.
 . *Metrics + readiness* (D4/D5) -- meter binding, health checks; assert metric presence in

--- a/doc/technical_aspects.adoc
+++ b/doc/technical_aspects.adoc
@@ -34,6 +34,14 @@ Usage follows exhaustive pattern matching (switch expressions) or simple `isSucc
 The `map()` method transforms content while preserving metadata.
 Failures may carry fallback content for graceful degradation with cached data.
 
+NOTE: `HttpResult<T>` *materializes the whole body* into the in-memory `T`. That is exactly
+right for the *control plane* -- the small, bounded JSON calls the gateway makes itself (OIDC
+discovery, JWKS, token exchange, revocation) -- but it is *not* used for the *data plane*:
+proxied client bodies (large responses, downloads, SSE, chunked/long-lived streams) are
+*streamed* with backpressure and never buffered into an `HttpResult<byte[]>`/`HttpResult<String>`.
+The boundary, and the competitor evidence behind it, is
+link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006].
+
 == HTTP Security Validation
 
 Library: **cui-http** (security module)


### PR DESCRIPTION
Adapts the design docs and Plans 02/03 for the reviewed findings. Design-doc-only; disjoint from the Java-baseline PR (`chore/plan-01-java25-baseline`).

## Findings addressed
- **Object reuse / performance** — new Architecture §*"Performance: Boot-Time Assembly and Object Reuse"*: dedup one `SecurityConfiguration`/pipeline set per profile shape and one `HttpHandler`/pool per upstream tuple (shared, not per-route copies); the security guarantee (immutable config, no shared per-request state ⇒ no cross-request bleed). Wired into Plan 03 `RouteRuntime` assembly.
- **Modules** — **ADR-0005**: keep one Quarkus module now (no separate core module yet); enforce the framework-agnostic seam by package layout + arch-gate so extraction is cheap later. Decision: *not yet, not never*.
- **Config** (`configuration.adoc` + Plan 02/03):
  - unique `endpoint.id` — duplicate **fails boot**;
  - endpoint **`enabled`** flag (default `true`), env-overridable **`ENDPOINT_<ID>_ENABLED`** exactly like `TOPOLOGY_<ALIAS>`; disabled endpoints are inert (no routes, alias need not resolve);
  - **`allowed_methods`** positive verb allowlist, global + per-endpoint, **explicit no-inheritance** (endpoint replaces global wholesale); runtime **405 + `Allow`** (new error-contract row); boot-fails on TRACE/CONNECT and on `match.methods` outside the effective set.
- **HttpResult streaming boundary** — **ADR-0006**: `HttpResult<T>` on the control plane only; data plane **streams** with backpressure; `max_body_bytes` is a streaming counter, not a buffer. Grounded in competitor analysis (nginx / Envoy / Traefik-Go / HAProxy / Spring Cloud Gateway / Vert.x). Architecture *Downstream Client* + `technical_aspects` note.
- **PAR / FAPI 2.0** — `features-analysis` differentiator + matrix row. Verified: no OSS competitor initiates PAR as an RP; only **Kong Enterprise** (generic "FAPI", not 2.0); KrakenD/Tyk/Gravitee-APIM aren't RPs at all. Delivered via `token-sheriff-client` `CLIENT-10`.
- **Metrics** — made explicit that `sheriff_requests_total{status_family="2xx"}` per `route` is the direct "how often was each resource called successfully" view.

## New files
`doc/adr/0005-module-structure.adoc`, `doc/adr/0006-body-streaming-vs-httpresult.adoc`.

All touched AsciiDoc passes `asciidoctor --failure-level=WARN` clean.