### PR TITLE
chore(steward): land steward-maintained marshal.json artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -78,12 +78,20 @@
           "auto_rebase_threshold": "no_overlap_only"
         },
         "default:pre-push-quality-gate": {},
+        "default:pre-submission-self-review": {
+          "self_review": "auto",
+          "drop_review_on_scope_gate": false
+        },
         "default:finalize-step-simplify": {
           "simplify": "auto"
+        },
+        "default:finalize-step-security-audit": {
+          "security_audit": "auto"
         },
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
+        "default:architecture-refresh": {},
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
@@ -98,22 +106,15 @@
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
           "use_merge_queue": true,
-          "admin_merge_on_stuck_state": false
+          "admin_merge_on_stuck_state": false,
+          "pre_merge_comment_barrier": "fail_into_loopback"
         },
-        "default:record-metrics": {},
-        "default:archive-plan": {},
-        "default:finalize-step-security-audit": {
-          "security_audit": "auto"
-        },
-        "default:architecture-refresh": {},
         "default:finalize-step-preference-emitter": {
           "preference_min_recurrence": 2
         },
+        "default:record-metrics": {},
         "default:finalize-step-print-phase-breakdown": {},
-        "default:pre-submission-self-review": {
-          "self_review": "auto",
-          "drop_review_on_scope_gate": false
-        }
+        "default:archive-plan": {}
       },
       "effort": {
         "default": "level-3",
@@ -154,7 +155,9 @@
       "feature/",
       "fix/",
       "chore/"
-    ]
+    ],
+    "pr_strategy": "compact",
+    "pr_compact_max_changed_files": 150
   },
   "providers": [
     {
@@ -215,7 +218,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1090",
-    "config_seed_fingerprint": "dde4bc0c"
+    "provisioned_version": "0.1.1101",
+    "config_seed_fingerprint": "d30886a0"
   }
 }


### PR DESCRIPTION
## Summary

Lands `marshal.json` changes produced by the `/marshall-steward` menu-mode re-run remediation pass. No source or behavioral code changes.

### Changes

- **Key-order normalization** — canonical top-level key order.
- **Back-filled default config keys** (via `sync-defaults`):
  - `project.pr_strategy: compact`
  - `project.pr_compact_max_changed_files: 150`
  - `phase-6-finalize.steps.default:branch-cleanup.pre_merge_comment_barrier: fail_into_loopback`
- **Finalize-step reordering** — `phase-6-finalize.steps` sorted into canonical frontmatter `order`.
- **Provisioning stamps refreshed** — `provisioned_version` `0.1.1090` → `0.1.1101`, `config_seed_fingerprint` updated.

### Notes

- Labelled `skip-bot-review`. Per the bot skip-label matrix, this fully suppresses only CodeRabbit; Sourcery requires per-repo `.sourcery.yaml` opt-in and Gemini cannot honor the label.
