### PR TITLE
chore(steward): add automatic-review finalize step to marshal.json

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -92,6 +92,17 @@
         "default:create-pr": {},
         "default:ci-verify": {},
         "default:architecture-refresh": {},
+        "plan-marshall:automatic-review": {
+          "enabled_bots": "coderabbit,sourcery,gemini",
+          "review_bot_buffer_seconds": 180,
+          "review_completion_poll_timeout_seconds": 600,
+          "re_review_on_loopback": false,
+          "re_review_on_branch_cleanup": true,
+          "re_review_await_timeout_seconds": 600,
+          "re_review_on_timeout": "ask",
+          "review_rate_window_await": false,
+          "review_rate_window_timeout_seconds": 3600
+        },
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
@@ -218,7 +229,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1101",
+    "provisioned_version": "0.1.1102",
     "config_seed_fingerprint": "d30886a0"
   }
 }


### PR DESCRIPTION
## What

Adds the `plan-marshall:automatic-review` finalize step to `phase-6-finalize.steps` in `.plan/marshal.json`, and re-stamps provisioning `0.1.1101 → 0.1.1102`.

## Why

`automatic-review` (order 30, `default_on: true`) drives the CI PR-comment review-bot triage pipeline (CodeRabbit / Sourcery / Gemini). It was **missing** from this project's finalize steps.

It is a **`bundle:skill`** step — opt-in by presence — not a `default:`-prefixed built-in (it was promoted from a former built-in workflow doc). The missing-default detector and `sync-defaults` only cover `source: built-in` steps, so the generic Re-Run Remediation Pass (landed in #58) could neither detect nor seed it. On GitHub plans the manifest composer's `bot_enforcement_guard` re-adds it at runtime, but it was never operator-visible or configurable in `marshal.json`. This change makes it explicit and tunable.

## Details

- Inserted at its canonical order-30 slot (after `architecture-refresh`, before `sonar-roundtrip`); `steps-sort` confirms `reordered: false`.
- Seeded with full configurable defaults, `enabled_bots="coderabbit,sourcery,gemini"`.
- `sync-defaults` re-stamp only bumped `provisioned_version` to `0.1.1102`; no config keys added.

> Note: only Gemini is currently configured on this repo. With all three bots enabled, finalize will wait on CodeRabbit/Sourcery reviews that won't arrive (bounded by their poll timeouts). Narrow `enabled_bots` to `gemini` if those waits are undesirable.