### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -71,27 +71,37 @@
       "max_iterations": 3,
       "finalize_without_asking": true,
       "loop_back_without_asking": false,
-      "qgate": "auto",
       "checks_wait_timeout_seconds": 600,
       "steps": {
         "default:finalize-step-sync-baseline": {
-          "auto_rebase_threshold": "no_overlap_only"
+          "auto_rebase_threshold": "no_overlap_only",
+          "lane": "minimal"
         },
-        "default:pre-push-quality-gate": {},
+        "default:pre-push-quality-gate": {
+          "lane": "minimal"
+        },
         "default:pre-submission-self-review": {
-          "self_review": "auto",
-          "drop_review_on_scope_gate": false
+          "drop_review_on_scope_gate": false,
+          "lane": "auto"
         },
         "default:finalize-step-simplify": {
-          "simplify": "auto"
+          "lane": "auto"
         },
         "default:finalize-step-security-audit": {
-          "security_audit": "auto"
+          "lane": "full"
         },
-        "default:push": {},
-        "default:create-pr": {},
-        "default:ci-verify": {},
-        "default:architecture-refresh": {},
+        "default:architecture-refresh": {
+          "lane": "minimal"
+        },
+        "default:push": {
+          "lane": "minimal"
+        },
+        "default:create-pr": {
+          "lane": "minimal"
+        },
+        "default:ci-verify": {
+          "lane": "minimal"
+        },
         "plan-marshall:automatic-review": {
           "enabled_bots": "coderabbit,sourcery,gemini",
           "review_bot_buffer_seconds": 180,
@@ -101,14 +111,21 @@
           "re_review_await_timeout_seconds": 600,
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
-          "review_rate_window_timeout_seconds": 3600
+          "review_rate_window_timeout_seconds": 3600,
+          "lane": "ask"
         },
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
-          "ce_wait_timeout_seconds": 600
+          "ce_wait_timeout_seconds": 600,
+          "lane": "ask"
         },
-        "default:lessons-capture": {},
+        "default:lessons-capture": {
+          "lane": "minimal"
+        },
+        "default:adr-propose": {
+          "lane": "off"
+        },
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
           "final_merge_without_asking": false,
@@ -118,14 +135,22 @@
           "merge_hold_budget_seconds": 3600,
           "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
-          "pre_merge_comment_barrier": "fail_into_loopback"
+          "pre_merge_comment_barrier": "fail_into_loopback",
+          "lane": "minimal"
         },
         "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2
+          "preference_min_recurrence": 2,
+          "lane": "minimal"
         },
-        "default:record-metrics": {},
-        "default:finalize-step-print-phase-breakdown": {},
-        "default:archive-plan": {}
+        "default:record-metrics": {
+          "lane": "minimal"
+        },
+        "default:finalize-step-print-phase-breakdown": {
+          "lane": "minimal"
+        },
+        "default:archive-plan": {
+          "lane": "minimal"
+        }
       },
       "effort": {
         "default": "level-3",
@@ -229,7 +254,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1102",
-    "config_seed_fingerprint": "d30886a0"
+    "provisioned_version": "0.1.1116",
+    "config_seed_fingerprint": "37df1a33"
   }
 }


### PR DESCRIPTION
## Summary

Reconciles `.plan/marshal.json` from provisioned config seed `0.1.1102` to the installed seed `0.1.1116`, produced by `/marshall-steward upgrade`. No source or behavioral code changes.

### Changes

Schema migration in `plan.phase-6-finalize.steps`:

- The per-step `qgate`, `self_review`, `simplify`, and `security_audit` knobs collapse into a single unified `lane` key.
- Newly-materialized default finalize steps seeded with their default lanes (`adr-propose` → `off`, `finalize-step-security-audit` → `full`, `finalize-step-simplify` / `pre-submission-self-review` → `auto`, `automatic-review` / `sonar-roundtrip` → `ask`, remainder → `minimal`).
- Step order normalized to declared frontmatter `order` via `steps-sort`.

`build.map` drift check reported `in_sync: true` — no re-seed performed.

### Verification

- `manage-config sync-defaults` → `materialized_count: 15`
- `generate_executor preflight` → `marshal_status: fresh`; installed / executor / marshal all at `0.1.1116`

### Notes

- Labelled `skip-bot-review`. Per the bot skip-label matrix, this fully suppresses only CodeRabbit; Sourcery requires per-repo `.sourcery.yaml` opt-in and Gemini cannot honor the label.
