### PR TITLE
fix(config): close Plan-02/01 landing gaps from post-merge review

### DIFF
--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/topology/TopologyResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/topology/TopologyResolver.java
@@ -131,14 +131,12 @@ public final class TopologyResolver {
             resolved.put(alias, decompose(alias, value.trim()));
         }
         for (String alias : additionalAliases) {
-            if (resolved.containsKey(alias)) {
-                continue;
+            if (!resolved.containsKey(alias)) {
+                String value = resolveValue(alias, fileAliases);
+                if (value != null) {
+                    resolved.put(alias, decompose(alias, value.trim()));
+                }
             }
-            String value = resolveValue(alias, fileAliases);
-            if (value == null) {
-                continue;
-            }
-            resolved.put(alias, decompose(alias, value.trim()));
         }
         return new ResolvedTopology(resolved);
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/topology/TopologyResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/topology/TopologyResolver.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -37,16 +38,32 @@ import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Resolves topology aliases to decomposed upstreams for enabled endpoints (pipeline
- * step 6).
+ * Resolves topology aliases to decomposed upstreams for enabled endpoints and for the
+ * supplied additional aliases (pipeline step 6).
  * <p>
  * Each alias (pattern {@code [A-Z][A-Z0-9_]*}) is resolved with the precedence
  * {@code TOPOLOGY_<ALIAS>} environment variable over the {@code topology.properties}
  * file value, validated as a well-formed absolute URL, and decomposed once into a
- * {@link ResolvedUpstream} (ADR-0004). Only aliases referenced by <em>enabled</em>
- * endpoints are resolved; an alias referenced by an enabled endpoint that resolves
- * to neither an environment nor a file value is a boot failure, while a disabled
- * endpoint's alias need not resolve.
+ * {@link ResolvedUpstream} (ADR-0004).
+ * <p>
+ * Two alias sources are resolved, and they fail <em>asymmetrically</em>:
+ * <ul>
+ * <li>An <em>enabled</em> endpoint's {@code base_url} alias must resolve or the boot
+ * fails: an unresolved one throws {@link TopologyResolutionException}.</li>
+ * <li>An {@code additionalAliases} entry (the {@code tls.passthrough_sni} targets)
+ * resolves regardless of endpoint enablement, because passthrough is a TLS-level
+ * concern — but an unresolved one is <em>skipped silently</em> (omitted from the
+ * result), never thrown. This asymmetry is deliberate: this resolver runs
+ * <em>before</em>
+ * {@link de.cuioss.sheriff.api.config.validation.ConfigValidator} in the boot
+ * pipeline, so throwing here would abort the boot at step 6 and make the validator's
+ * unresolved-passthrough-alias rule unreachable. Skipping leaves that validator rule
+ * the sole reporter of the failure and keeps violation collection to a single pass.
+ * A <em>malformed</em> (as opposed to unresolved) URL still throws from either
+ * source.</li>
+ * <li>A <em>disabled</em> endpoint's {@code base_url} alias remains exempt from
+ * resolution entirely and need not resolve.</li>
+ * </ul>
  * <p>
  * Framework-agnostic (ADR-0005): the environment lookup is constructor-injected.
  *
@@ -81,15 +98,23 @@ public final class TopologyResolver {
 
     /**
      * Resolves and decomposes the topology aliases referenced by the enabled
-     * endpoints.
+     * endpoints together with the supplied additional aliases.
      *
-     * @param topologyFile     the {@code topology.properties} file (may be absent)
-     * @param enabledEndpoints the endpoints already filtered to those enabled
+     * @param topologyFile      the {@code topology.properties} file (may be absent)
+     * @param enabledEndpoints  the endpoints already filtered to those enabled
+     * @param additionalAliases aliases to resolve independently of endpoint
+     *                          enablement (the {@code tls.passthrough_sni} targets);
+     *                          an entry that resolves to no value is skipped rather
+     *                          than thrown, leaving
+     *                          {@link de.cuioss.sheriff.api.config.validation.ConfigValidator}
+     *                          to report it
      * @return the immutable resolved topology
-     * @throws TopologyResolutionException when a referenced alias is unresolved or
-     *                                     resolves to a malformed URL
+     * @throws TopologyResolutionException when an alias referenced by an enabled
+     *                                     endpoint is unresolved, or when any
+     *                                     resolved alias carries a malformed URL
      */
-    public ResolvedTopology resolve(Path topologyFile, List<EndpointConfig> enabledEndpoints) {
+    public ResolvedTopology resolve(Path topologyFile, List<EndpointConfig> enabledEndpoints,
+            Collection<String> additionalAliases) {
         Map<String, String> fileAliases = readProperties(topologyFile);
         Map<String, ResolvedUpstream> resolved = new LinkedHashMap<>();
         for (EndpointConfig endpoint : enabledEndpoints) {
@@ -102,6 +127,16 @@ public final class TopologyResolver {
                 throw new TopologyResolutionException(
                         "Unresolved topology alias '%s' referenced by enabled endpoint '%s'"
                                 .formatted(alias, endpoint.id()));
+            }
+            resolved.put(alias, decompose(alias, value.trim()));
+        }
+        for (String alias : additionalAliases) {
+            if (resolved.containsKey(alias)) {
+                continue;
+            }
+            String value = resolveValue(alias, fileAliases);
+            if (value == null) {
+                continue;
             }
             resolved.put(alias, decompose(alias, value.trim()));
         }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -261,7 +261,7 @@ public final class ConfigValidator {
             for (RouteConfig route : endpoint.routes()) {
                 routeHost(route).ifPresent(host -> {
                     for (String sniHost : passthrough.keySet()) {
-                        if (sniHost.toLowerCase(Locale.ROOT).equalsIgnoreCase(host)) {
+                        if (sniHost.equalsIgnoreCase(host)) {
                             errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
                                     "route '%s' matches host '%s', which is relayed at L4 by passthrough_sni and is never routed"
                                             .formatted(route.id(), sniHost)));
@@ -284,7 +284,7 @@ public final class ConfigValidator {
                 continue;
             }
             String basePath = upstream.get().basePath();
-            if (!basePath.isEmpty()) {
+            if (!basePath.isEmpty() && !"/".equals(basePath)) {
                 errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
                         "passthrough_sni alias '%s' must resolve to an origin without a base path, but resolved to '%s'"
                                 .formatted(alias, basePath)));

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -61,6 +61,7 @@ public final class ConfigValidator {
 
     private static final int SUPPORTED_VERSION = 1;
     private static final String GATEWAY_FILE = "gateway.yaml";
+    private static final String PASSTHROUGH_SNI_POINTER = "/tls/passthrough_sni";
     private static final String TRUST_ALL_IPV4 = "0.0.0.0/0";
     private static final String TRUST_ALL_IPV6 = "::/0";
     private static final String WILDCARD_ORIGIN = "*";
@@ -262,7 +263,7 @@ public final class ConfigValidator {
                 routeHost(route).ifPresent(host -> {
                     for (String sniHost : passthrough.keySet()) {
                         if (sniHost.equalsIgnoreCase(host)) {
-                            errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                            errors.add(new ConfigError(GATEWAY_FILE, PASSTHROUGH_SNI_POINTER,
                                     "route '%s' matches host '%s', which is relayed at L4 by passthrough_sni and is never routed"
                                             .formatted(route.id(), sniHost)));
                         }
@@ -278,14 +279,14 @@ public final class ConfigValidator {
             String alias = entry.getValue();
             Optional<ResolvedUpstream> upstream = topology.lookup(alias);
             if (upstream.isEmpty()) {
-                errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                errors.add(new ConfigError(GATEWAY_FILE, PASSTHROUGH_SNI_POINTER,
                         "unresolved topology alias '%s' referenced by passthrough_sni host '%s'"
                                 .formatted(alias, entry.getKey())));
                 continue;
             }
             String basePath = upstream.get().basePath();
             if (!basePath.isEmpty() && !"/".equals(basePath)) {
-                errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                errors.add(new ConfigError(GATEWAY_FILE, PASSTHROUGH_SNI_POINTER,
                         "passthrough_sni alias '%s' must resolve to an origin without a base path, but resolved to '%s'"
                                 .formatted(alias, basePath)));
             }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -19,7 +19,10 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import de.cuioss.sheriff.api.config.load.ConfigError;
@@ -29,7 +32,9 @@ import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.OidcConfig;
 import de.cuioss.sheriff.api.config.model.ResolvedTopology;
+import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteConfig;
+import de.cuioss.sheriff.api.config.model.TlsConfig;
 import de.cuioss.sheriff.api.config.validation.rule.ValidationRule;
 
 /**
@@ -71,7 +76,9 @@ public final class ConfigValidator {
             (gateway, endpoints, topology, errors) -> validateWholeSecondTimeouts(endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateForwardedTrust(gateway, errors),
             (gateway, endpoints, topology, errors) -> validateCors(gateway, errors),
-            (gateway, endpoints, topology, errors) -> validateSessionMode(gateway, errors));
+            (gateway, endpoints, topology, errors) -> validateSessionMode(gateway, errors),
+            (gateway, endpoints, topology, errors) -> validatePassthroughHostCollision(gateway, endpoints, errors),
+            (gateway, endpoints, topology, errors) -> validatePassthroughAliasResolvable(gateway, topology, errors));
 
     private final List<ValidationRule> rules;
 
@@ -242,6 +249,55 @@ public final class ConfigValidator {
                                 "server session mode requires a store"));
                     }
                 }));
+    }
+
+    private static void validatePassthroughHostCollision(GatewayConfig gateway, List<EndpointConfig> endpoints,
+            List<ConfigError> errors) {
+        Map<String, String> passthrough = passthroughSni(gateway);
+        if (passthrough.isEmpty()) {
+            return;
+        }
+        for (EndpointConfig endpoint : endpoints) {
+            for (RouteConfig route : endpoint.routes()) {
+                routeHost(route).ifPresent(host -> {
+                    for (String sniHost : passthrough.keySet()) {
+                        if (sniHost.toLowerCase(Locale.ROOT).equalsIgnoreCase(host)) {
+                            errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                                    "route '%s' matches host '%s', which is relayed at L4 by passthrough_sni and is never routed"
+                                            .formatted(route.id(), sniHost)));
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private static void validatePassthroughAliasResolvable(GatewayConfig gateway, ResolvedTopology topology,
+            List<ConfigError> errors) {
+        for (Map.Entry<String, String> entry : passthroughSni(gateway).entrySet()) {
+            String alias = entry.getValue();
+            Optional<ResolvedUpstream> upstream = topology.lookup(alias);
+            if (upstream.isEmpty()) {
+                errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                        "unresolved topology alias '%s' referenced by passthrough_sni host '%s'"
+                                .formatted(alias, entry.getKey())));
+                continue;
+            }
+            String basePath = upstream.get().basePath();
+            if (!basePath.isEmpty()) {
+                errors.add(new ConfigError(GATEWAY_FILE, "/tls/passthrough_sni",
+                        "passthrough_sni alias '%s' must resolve to an origin without a base path, but resolved to '%s'"
+                                .formatted(alias, basePath)));
+            }
+        }
+    }
+
+    private static Map<String, String> passthroughSni(GatewayConfig gateway) {
+        return gateway.tls().map(TlsConfig::passthroughSni).orElseGet(Map::of);
+    }
+
+    private static Optional<String> routeHost(RouteConfig route) {
+        return route.match().host().map(host -> host.toLowerCase(Locale.ROOT)).filter(host -> !host.isEmpty());
     }
 
     private static String effectiveRequire(EndpointConfig endpoint, RouteConfig route) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigProducer.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.api.quarkus;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import de.cuioss.sheriff.api.config.ConfigLogMessages;
 import de.cuioss.sheriff.api.config.RouteTableBuilder;
@@ -29,6 +30,7 @@ import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.Metadata;
 import de.cuioss.sheriff.api.config.model.ResolvedTopology;
 import de.cuioss.sheriff.api.config.model.RouteTable;
+import de.cuioss.sheriff.api.config.model.TlsConfig;
 import de.cuioss.sheriff.api.config.topology.TopologyResolver;
 import de.cuioss.sheriff.api.config.validation.ConfigValidator;
 import de.cuioss.tools.logging.CuiLogger;
@@ -122,7 +124,8 @@ public class ConfigProducer {
         try {
             ConfigLoader.LoadedConfig loaded = new ConfigLoader(directory, new EnvSecretResolver()).load();
             List<EndpointConfig> enabled = loaded.endpoints().stream().filter(EndpointConfig::enabled).toList();
-            ResolvedTopology topology = new TopologyResolver().resolve(directory.resolve(TOPOLOGY_FILE), enabled);
+            ResolvedTopology topology = new TopologyResolver().resolve(directory.resolve(TOPOLOGY_FILE), enabled,
+                    loaded.gateway().tls().map(TlsConfig::passthroughSni).map(Map::values).orElse(List.of()));
             List<ConfigError> violations = new ConfigValidator().validate(loaded.gateway(), enabled, topology);
             if (!violations.isEmpty()) {
                 abort(violations);

--- a/api-sheriff/src/main/resources/schema/gateway.schema.json
+++ b/api-sheriff/src/main/resources/schema/gateway.schema.json
@@ -112,6 +112,7 @@
     "forwarded": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["trusted_proxies"],
       "properties": {
         "trusted_proxies": { "type": "array", "items": { "type": "string" } },
         "trust_scheme_host": { "type": "boolean" },

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.api.config;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,7 +32,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.generator.junit.parameterized.GeneratorType;
+import de.cuioss.test.generator.junit.parameterized.GeneratorsSource;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
@@ -51,7 +56,13 @@ import de.cuioss.sheriff.api.config.model.UpstreamDefaultsConfig;
  * ordering, same-prefix disjointness enforcement, and the materialization of
  * effective auth, effective {@code allowed_methods}, and the three-level
  * retry / not-modified override chain.
+ * <p>
+ * The example-based cases above pin each invariant with one concrete path; the
+ * {@link PropertyBasedInvariants} nested class complements — never replaces — them by
+ * re-asserting the same invariants over generated prefix / host / method
+ * permutations, so a rule that happens to hold only for the chosen literal is caught.
  */
+@EnableGeneratorController
 class RouteTableBuilderTest {
 
     private final RouteTableBuilder builder = new RouteTableBuilder();
@@ -80,6 +91,16 @@ class RouteTableBuilderTest {
 
     private static RouteConfig routeWithPrefix(String id, String pathPrefix, HttpMethod... methods) {
         return RouteConfig.builder().id(id).match(match(pathPrefix, methods)).build();
+    }
+
+    private static RouteConfig routeWithPrefixAndHost(String id, String pathPrefix, String host,
+            HttpMethod... methods) {
+        MatchConfig match = MatchConfig.builder()
+                .pathPrefix(pathPrefix)
+                .methods(List.of(methods))
+                .host(Optional.of(host))
+                .build();
+        return RouteConfig.builder().id(id).match(match).build();
     }
 
     private static RouteConfig routeWithHeader(String id, String pathPrefix, HeaderMatcher header) {
@@ -390,6 +411,136 @@ class RouteTableBuilderTest {
             ResolvedRoute resolved = find(table, "r");
             assertFalse(resolved.retryEnabled(), "absent retry toggle should inherit the endpoint value");
             assertTrue(resolved.notModifiedEnabled(), "absent not-modified toggle should inherit the endpoint value");
+        }
+    }
+
+    @Nested
+    @DisplayName("Invariants over generated prefix / host / method permutations")
+    class PropertyBasedInvariants {
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should order any generated prefix family longest-first, regardless of declaration order")
+        void shouldOrderByLongestPrefixFirstForAnyGeneratedSegment(String segment) {
+            String shortPrefix = "/" + segment;
+            String midPrefix = shortPrefix + "/mid";
+            String longPrefix = midPrefix + "/leaf";
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(routeWithPrefix("short", shortPrefix, HttpMethod.GET),
+                            routeWithPrefix("long", longPrefix, HttpMethod.GET),
+                            routeWithPrefix("mid", midPrefix, HttpMethod.GET)))
+                    .build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            assertEquals(List.of("long", "mid", "short"),
+                    table.routes().stream().map(ResolvedRoute::id).toList(),
+                    () -> "routes must be ordered by descending prefix length for segment: " + segment);
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should match any generated prefix only on a segment boundary")
+        void shouldMatchOnSegmentBoundaryOnlyForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(routeWithPrefix("target", prefix, HttpMethod.GET))).build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            assertAll("segment-boundary matching for prefix " + prefix,
+                    () -> assertEquals("target", table.lookup(prefix).orElseThrow().id(),
+                            "an exact prefix match must resolve the route"),
+                    () -> assertEquals("target", table.lookup(prefix + "/child").orElseThrow().id(),
+                            "a child path must match on the segment boundary"),
+                    () -> assertTrue(table.lookup(prefix + "-suffix").isEmpty(),
+                            "a mere leading-substring match must not resolve the route"));
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should accept any generated same-prefix pair made disjoint by method")
+        void shouldAcceptSamePrefixRoutesDisjointByMethodForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(routeWithPrefix("reader", prefix, HttpMethod.GET),
+                            routeWithPrefix("writer", prefix, HttpMethod.POST)))
+                    .build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            assertEquals(2, table.routes().size(),
+                    () -> "method-disjoint same-prefix routes must both survive for prefix: " + prefix);
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should reject any generated same-prefix pair overlapping on method")
+        void shouldRejectSamePrefixRoutesOverlappingOnMethodForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(routeWithPrefix("first", prefix, HttpMethod.GET),
+                            routeWithPrefix("second", prefix, HttpMethod.GET)))
+                    .build();
+            GatewayConfig config = gateway().build();
+            ResolvedTopology topology = topologyWith("ORDERS");
+
+            assertThrows(RouteTableBuilder.RouteTableException.class,
+                    () -> builder.build(config, List.of(endpoint), topology),
+                    () -> "method-overlapping same-prefix routes must be rejected for prefix: " + prefix);
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should accept any generated same-prefix pair made disjoint by host")
+        void shouldAcceptSamePrefixRoutesDisjointByHostForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(
+                            routeWithPrefixAndHost("alpha", prefix, segment + "-alpha.example.com", HttpMethod.GET),
+                            routeWithPrefixAndHost("beta", prefix, segment + "-beta.example.com", HttpMethod.GET)))
+                    .build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            assertEquals(2, table.routes().size(),
+                    () -> "host-disjoint same-prefix routes must both survive for prefix: " + prefix);
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should reject any generated same-prefix pair sharing one host and method")
+        void shouldRejectSamePrefixRoutesSharingHostForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            String host = segment + ".example.com";
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(routeWithPrefixAndHost("first", prefix, host, HttpMethod.GET),
+                            routeWithPrefixAndHost("second", prefix, host, HttpMethod.GET)))
+                    .build();
+            GatewayConfig config = gateway().build();
+            ResolvedTopology topology = topologyWith("ORDERS");
+
+            assertThrows(RouteTableBuilder.RouteTableException.class,
+                    () -> builder.build(config, List.of(endpoint), topology),
+                    () -> "same-prefix routes sharing host and method must be rejected for prefix: " + prefix);
+        }
+
+        @ParameterizedTest
+        @GeneratorsSource(generator = GeneratorType.LETTER_STRINGS, minSize = 3, maxSize = 8, count = 5)
+        @DisplayName("Should accept any generated same-prefix pair made disjoint by header presence")
+        void shouldAcceptSamePrefixRoutesDisjointByHeaderForAnyGeneratedSegment(String segment) {
+            String prefix = "/" + segment;
+            String headerName = "X-" + segment;
+            RouteConfig present = routeWithHeader("present", prefix,
+                    HeaderMatcher.builder().name(headerName).present(Optional.of(true)).build());
+            RouteConfig absent = routeWithHeader("absent", prefix,
+                    HeaderMatcher.builder().name(headerName).present(Optional.of(false)).build());
+            EndpointConfig endpoint = endpoint("orders", "ORDERS").routes(List.of(present, absent)).build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            assertEquals(2, table.routes().size(),
+                    () -> "presence-disjoint same-prefix routes must both survive for prefix: " + prefix);
         }
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
@@ -178,4 +178,35 @@ class ConfigLoaderTest {
         assertEquals(1, loaded.gateway().version());
         assertTrue(loaded.endpoints().isEmpty());
     }
+
+    @Test
+    void rejectsForwardedBlockOmittingTrustedProxies() throws Exception {
+        writeConfig("gateway.yaml", """
+                version: 1
+                forwarded:
+                  trust_scheme_host: true
+                """);
+
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+
+        assertTrue(exception.errors().stream()
+                        .anyMatch(error -> "gateway.yaml".equals(error.file())
+                                && error.pointer().contains("forwarded")),
+                () -> "expected a schema violation for a forwarded block omitting trusted_proxies, got: "
+                        + exception.errors());
+    }
+
+    @Test
+    void acceptsForwardedBlockDeclaringEmptyTrustedProxies() throws Exception {
+        writeConfig("gateway.yaml", """
+                version: 1
+                forwarded:
+                  trusted_proxies: []
+                """);
+
+        ConfigLoader.LoadedConfig loaded = loader(Map.of()).load();
+
+        assertTrue(loaded.gateway().forwarded().orElseThrow().trustedProxies().isEmpty(),
+                "an explicitly empty trusted_proxies list means no proxy is trusted and stays valid");
+    }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/topology/TopologyResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/topology/TopologyResolverTest.java
@@ -183,9 +183,10 @@ class TopologyResolverTest {
         Path file = topologyFile("SECURE=https://secure.internal\n");
         TopologyResolver resolver = resolverWith(Map.of());
         List<EndpointConfig> endpoints = List.of(endpointFor("MISSING"));
+        List<String> additionalAliases = List.of("SECURE");
 
         assertThrows(TopologyResolutionException.class,
-                () -> resolver.resolve(file, endpoints, List.of("SECURE")),
+                () -> resolver.resolve(file, endpoints, additionalAliases),
                 "an unresolvable enabled-endpoint base_url alias must still fail the boot");
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/topology/TopologyResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/topology/TopologyResolverTest.java
@@ -15,6 +15,8 @@
  */
 package de.cuioss.sheriff.api.config.topology;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,8 +44,9 @@ import de.cuioss.sheriff.api.config.topology.TopologyResolver.TopologyResolution
 
 /**
  * Tests for {@link TopologyResolver}: file / environment resolution precedence, URL
- * decomposition with scheme-default ports, and the boot failures for malformed or
- * missing aliases referenced by enabled endpoints.
+ * decomposition with scheme-default ports, the boot failures for malformed or
+ * missing aliases referenced by enabled endpoints, and the throw/skip asymmetry
+ * between enabled-endpoint {@code base_url} aliases and additional aliases.
  */
 class TopologyResolverTest {
 
@@ -73,7 +76,8 @@ class TopologyResolverTest {
     void resolvesFromFileAndDecomposesComponents() throws Exception {
         Path file = topologyFile("ORDERS=https://orders.internal:8443/api\n");
 
-        ResolvedTopology topology = resolverWith(Map.of()).resolve(file, List.of(endpointFor("ORDERS")));
+        ResolvedTopology topology = resolverWith(Map.of())
+                .resolve(file, List.of(endpointFor("ORDERS")), List.of());
 
         ResolvedUpstream upstream = topology.lookup("ORDERS").orElseThrow();
         assertEquals("https", upstream.scheme());
@@ -87,7 +91,7 @@ class TopologyResolverTest {
         Path file = topologyFile("USERS=https://users.internal\nORDERS=http://orders.internal\n");
 
         ResolvedTopology topology = resolverWith(Map.of())
-                .resolve(file, List.of(endpointFor("USERS"), endpointFor("ORDERS")));
+                .resolve(file, List.of(endpointFor("USERS"), endpointFor("ORDERS")), List.of());
 
         assertEquals(443, topology.lookup("USERS").orElseThrow().port());
         assertEquals(80, topology.lookup("ORDERS").orElseThrow().port());
@@ -99,7 +103,7 @@ class TopologyResolverTest {
         Path file = topologyFile("ORDERS=https://file.host:1000/file\n");
 
         ResolvedTopology topology = resolverWith(Map.of("TOPOLOGY_ORDERS", "https://env.host:2000/env"))
-                .resolve(file, List.of(endpointFor("ORDERS")));
+                .resolve(file, List.of(endpointFor("ORDERS")), List.of());
 
         ResolvedUpstream upstream = topology.lookup("ORDERS").orElseThrow();
         assertEquals("env.host", upstream.host());
@@ -110,7 +114,8 @@ class TopologyResolverTest {
     void trimsSurroundingWhitespaceBeforeParsing() throws Exception {
         Path file = topologyFile("ORDERS=  https://orders.internal:8443/api  \n");
 
-        ResolvedTopology topology = resolverWith(Map.of()).resolve(file, List.of(endpointFor("ORDERS")));
+        ResolvedTopology topology = resolverWith(Map.of())
+                .resolve(file, List.of(endpointFor("ORDERS")), List.of());
 
         ResolvedUpstream upstream = topology.lookup("ORDERS").orElseThrow();
         assertEquals("orders.internal", upstream.host());
@@ -126,7 +131,7 @@ class TopologyResolverTest {
         List<EndpointConfig> endpoints = List.of(endpointFor(endpointAlias));
 
         assertThrows(TopologyResolutionException.class,
-                () -> resolver.resolve(file, endpoints));
+                () -> resolver.resolve(file, endpoints, List.of()));
     }
 
     static Stream<Arguments> invalidTopologies() {
@@ -141,8 +146,46 @@ class TopologyResolverTest {
     void resolvesNothingWhenNoEnabledEndpointsAndToleratesAbsentFile() {
         Path absent = directory.resolve("does-not-exist.properties");
 
-        ResolvedTopology topology = resolverWith(Map.of()).resolve(absent, List.of());
+        ResolvedTopology topology = resolverWith(Map.of()).resolve(absent, List.of(), List.of());
 
         assertTrue(topology.aliases().isEmpty());
+    }
+
+    @Test
+    void resolvesAdditionalAliasNotReferencedByAnyEnabledEndpoint() throws Exception {
+        Path file = topologyFile("ORDERS=https://orders.internal\nSECURE=https://secure.internal:8443\n");
+
+        ResolvedTopology topology = resolverWith(Map.of())
+                .resolve(file, List.of(endpointFor("ORDERS")), List.of("SECURE"));
+
+        ResolvedUpstream upstream = topology.lookup("SECURE").orElseThrow();
+        assertEquals("secure.internal", upstream.host());
+        assertEquals(8443, upstream.port());
+    }
+
+    @Test
+    void skipsUnresolvableAdditionalAliasWithoutThrowing() throws Exception {
+        Path file = topologyFile("ORDERS=https://orders.internal\n");
+        TopologyResolver resolver = resolverWith(Map.of());
+        List<EndpointConfig> endpoints = List.of(endpointFor("ORDERS"));
+
+        ResolvedTopology topology = assertDoesNotThrow(
+                () -> resolver.resolve(file, endpoints, List.of("MISSING")),
+                "an unresolvable additional alias must be skipped, not thrown");
+
+        assertAll("the unresolvable additional alias is omitted, leaving ConfigValidator to report it",
+                () -> assertTrue(topology.lookup("MISSING").isEmpty(), "MISSING must be absent from the topology"),
+                () -> assertTrue(topology.lookup("ORDERS").isPresent(), "ORDERS must still resolve"));
+    }
+
+    @Test
+    void stillThrowsForUnresolvableEnabledEndpointAliasAlongsideSkippedAdditionalAlias() throws Exception {
+        Path file = topologyFile("SECURE=https://secure.internal\n");
+        TopologyResolver resolver = resolverWith(Map.of());
+        List<EndpointConfig> endpoints = List.of(endpointFor("MISSING"));
+
+        assertThrows(TopologyResolutionException.class,
+                () -> resolver.resolve(file, endpoints, List.of("SECURE")),
+                "an unresolvable enabled-endpoint base_url alias must still fail the boot");
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
@@ -43,6 +43,7 @@ import de.cuioss.sheriff.api.config.model.ResolvedTopology;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteConfig;
 import de.cuioss.sheriff.api.config.model.SecurityHeadersConfig;
+import de.cuioss.sheriff.api.config.model.TlsConfig;
 import de.cuioss.sheriff.api.config.model.TokenValidationConfig;
 import de.cuioss.sheriff.api.config.model.UpstreamConfig;
 
@@ -78,6 +79,21 @@ class ConfigValidatorTest {
         return RouteConfig.builder().id(id).match(match("/" + id, methods)).build();
     }
 
+    private static RouteConfig routeWithHost(String id, String host, HttpMethod... methods) {
+        MatchConfig match = MatchConfig.builder()
+                .pathPrefix("/" + id)
+                .methods(List.of(methods))
+                .host(Optional.of(host))
+                .build();
+        return RouteConfig.builder().id(id).match(match).build();
+    }
+
+    private static GatewayConfig gatewayWithPassthrough(Map<String, String> passthroughSni) {
+        return validGateway()
+                .tls(Optional.of(TlsConfig.builder().passthroughSni(passthroughSni).build()))
+                .build();
+    }
+
     private static EndpointConfig endpoint(String id, String alias, List<HttpMethod> allowedMethods,
             RouteConfig... routes) {
         return EndpointConfig.builder()
@@ -108,6 +124,31 @@ class ConfigValidatorTest {
             EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("orders-list", HttpMethod.GET));
 
             List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should report no violations for a route host that no passthrough_sni host claims")
+        void shouldAcceptRouteHostWithoutPassthroughCollision() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "SECURE"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(),
+                    routeWithHost("orders-list", "api.example.com", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint),
+                    topologyWith("ORDERS", "SECURE"));
+
+            assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should report no violations for a passthrough_sni alias resolving without a base path")
+        void shouldAcceptResolvablePassthroughAlias() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "SECURE"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("orders-list", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint),
+                    topologyWith("ORDERS", "SECURE"));
 
             assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
         }
@@ -363,6 +404,46 @@ class ConfigValidatorTest {
             List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
 
             assertTrue(errors.isEmpty(), () -> "expected no violations for a valid bearer config, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should reject a route whose match.host collides case-insensitively with a passthrough_sni host")
+        void shouldRejectRouteHostCollidingWithPassthroughSni() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "SECURE"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(),
+                    routeWithHost("orders-list", "SECURE.EXAMPLE.COM", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint),
+                    topologyWith("ORDERS", "SECURE"));
+
+            assertHasError(errors, "/tls/passthrough_sni",
+                    "route 'orders-list' matches host 'secure.example.com'");
+        }
+
+        @Test
+        @DisplayName("Should reject a passthrough_sni alias that does not resolve")
+        void shouldRejectUnresolvedPassthroughAlias() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "MISSING"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("orders-list", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            assertHasError(errors, "/tls/passthrough_sni",
+                    "unresolved topology alias 'MISSING' referenced by passthrough_sni host 'secure.example.com'");
+        }
+
+        @Test
+        @DisplayName("Should reject a passthrough_sni alias resolving to an upstream carrying a base path")
+        void shouldRejectPassthroughAliasWithBasePath() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "SECURE"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("orders-list", HttpMethod.GET));
+            ResolvedTopology topology = new ResolvedTopology(Map.of(
+                    "ORDERS", new ResolvedUpstream("https", "orders.internal", 443, ""),
+                    "SECURE", new ResolvedUpstream("https", "secure.internal", 443, "/api")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topology);
+
+            assertHasError(errors, "/tls/passthrough_sni", "must resolve to an origin without a base path");
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
@@ -152,6 +152,21 @@ class ConfigValidatorTest {
 
             assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
         }
+
+        @Test
+        @DisplayName("Should report no violations for a passthrough_sni alias resolving to a bare '/' base path")
+        void shouldAcceptPassthroughAliasWithTrailingSlashBasePath() {
+            GatewayConfig gateway = gatewayWithPassthrough(Map.of("secure.example.com", "SECURE"));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("orders-list", HttpMethod.GET));
+            ResolvedTopology topology = new ResolvedTopology(Map.of(
+                    "ORDERS", new ResolvedUpstream("https", "orders.internal", 443, ""),
+                    "SECURE", new ResolvedUpstream("https", "secure.internal", 443, "/")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topology);
+
+            assertTrue(errors.isEmpty(),
+                    () -> "expected no violations for a topology URL ending in a bare '/', got: " + errors);
+        }
     }
 
     @Nested

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
@@ -98,4 +98,28 @@ class ConfigProducerTest {
                 "a valid configuration should assemble without failing startup");
         assertNotNull(producer.gatewayConfig(), "beans should be available after startup assembly");
     }
+
+    @Test
+    void shouldNotFailBootWhenDisabledEndpointAliasIsUnresolvable() throws Exception {
+        ConfigProducer producer = producerForValidConfig();
+        Files.createDirectories(configDir.resolve("endpoints"));
+        Files.writeString(configDir.resolve("endpoints/disabled.yaml"), """
+                endpoint:
+                  id: disabled
+                  enabled: false
+                  base_url: MISSING_ALIAS
+                  auth:
+                    require: none
+                  routes:
+                    - id: disabled-route
+                      match:
+                        path_prefix: /disabled
+                        methods: ["GET"]
+                """);
+
+        assertDoesNotThrow(() -> producer.onStartup(null),
+                "a disabled endpoint whose base_url alias resolves to nothing must not fail boot");
+        assertTrue(producer.routeTable().routes().isEmpty(),
+                "a disabled endpoint contributes no route to the assembled table");
+    }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -49,14 +50,31 @@ class ConfigProducerTest {
               config_version: "2026-07-13"
             """;
 
+    private static final String PASSTHROUGH_HOST = "payments.example.com";
+    private static final String PASSTHROUGH_ALIAS = "PAYMENTS_BACKEND";
+    private static final String PASSTHROUGH_ORIGIN = "https://payments.internal:8443";
+
+    private static final String GATEWAY_WITH_PASSTHROUGH_SNI = """
+            version: 1
+            metadata:
+              config_version: "2026-07-13"
+            tls:
+              passthrough_sni:
+                "%s": "%s"
+            """.formatted(PASSTHROUGH_HOST, PASSTHROUGH_ALIAS);
+
     @TempDir
     Path configDir;
 
-    private ConfigProducer producerForValidConfig() throws IOException {
-        Files.writeString(configDir.resolve("gateway.yaml"), VALID_GATEWAY);
+    private ConfigProducer producerForGateway(String gatewayYaml) throws IOException {
+        Files.writeString(configDir.resolve("gateway.yaml"), gatewayYaml);
         ConfigProducer producer = new ConfigProducer();
         producer.configDir = configDir.toString();
         return producer;
+    }
+
+    private ConfigProducer producerForValidConfig() throws IOException {
+        return producerForGateway(VALID_GATEWAY);
     }
 
     @Test
@@ -121,5 +139,43 @@ class ConfigProducerTest {
                 "a disabled endpoint whose base_url alias resolves to nothing must not fail boot");
         assertTrue(producer.routeTable().routes().isEmpty(),
                 "a disabled endpoint contributes no route to the assembled table");
+    }
+
+    /**
+     * Pins the {@code tls.passthrough_sni} wiring at {@code ConfigProducer}: the map is
+     * host -> alias, so the producer must hand the map's <em>values</em> (the aliases) to
+     * {@link de.cuioss.sheriff.api.config.topology.TopologyResolver}'s
+     * {@code additionalAliases}, never its {@code keySet()} (the SNI hosts).
+     * <p>
+     * The alias is resolvable via {@code topology.properties} while the host key is not a
+     * topology alias at all, which is what makes this test discriminating: with the
+     * correct {@code values()} wiring the alias resolves and the boot is clean, whereas a
+     * {@code keySet()} swap would hand the resolver the host, leave the alias unresolved,
+     * and trip {@code ConfigValidator}'s unresolved-passthrough-alias rule — failing this
+     * test. Asserting on an <em>unresolvable</em> alias instead would be vacuous: the
+     * resolver skips unresolved additional aliases silently, so the validator reports the
+     * same violation under either wiring.
+     */
+    @Test
+    void shouldResolvePassthroughSniAliasValueRatherThanHostKey() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_PASSTHROUGH_SNI);
+        Files.writeString(configDir.resolve("topology.properties"),
+                "%s=%s%n".formatted(PASSTHROUGH_ALIAS, PASSTHROUGH_ORIGIN));
+
+        assertDoesNotThrow(() -> producer.onStartup(null),
+                "the passthrough_sni alias value must reach the topology resolver and resolve");
+        assertNotNull(producer.gatewayConfig(), "beans should be available after startup assembly");
+    }
+
+    @Test
+    void shouldFailBootWhenPassthroughSniAliasIsUnresolvable() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_PASSTHROUGH_SNI);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> producer.onStartup(null),
+                "an unresolvable passthrough_sni alias should abort startup");
+
+        assertTrue(exception.getMessage().contains("Refusing to start"),
+                "the abort should carry the refusing-to-start summary");
     }
 }

--- a/api-sheriff/src/test/resources/config/testboot/endpoints/proxy.yaml
+++ b/api-sheriff/src/test/resources/config/testboot/endpoints/proxy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../../main/resources/schema/endpoint.schema.json
 # Proxy endpoint for the @QuarkusTest boot configuration.
 #
 # Declares the single /proxy route ProxyRouteTest exercises. Its upstream is the

--- a/api-sheriff/src/test/resources/config/testboot/gateway.yaml
+++ b/api-sheriff/src/test/resources/config/testboot/gateway.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../main/resources/schema/gateway.schema.json
 # Minimal valid boot configuration for the @QuarkusTest container.
 # The sibling endpoints/proxy.yaml + topology.properties add the single /proxy
 # route that ProxyRouteTest exercises, so ConfigProducer assembles a RouteTable

--- a/api-sheriff/src/test/resources/config/valid/gateway.yaml
+++ b/api-sheriff/src/test/resources/config/valid/gateway.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../main/resources/schema/gateway.schema.json
 version: 1
 metadata:
   config_version: "2024-05-01"

--- a/doc/adr/0009-asymmetric-alias-resolution-failure.adoc
+++ b/doc/adr/0009-asymmetric-alias-resolution-failure.adoc
@@ -1,0 +1,92 @@
+= ADR-0009: Asymmetric alias-resolution failure: enabled-endpoint aliases abort boot, additional aliases defer to the validator
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: TopologyResolver aborts boot on an unresolvable enabled-endpoint base_url alias but silently skips an unresolvable additional (passthrough-SNI) alias, leaving ConfigValidator the single authoritative reporter of alias-resolvability violations.
+// tags: topology, configuration-validation, boot-sequence, error-ownership
+// affects: api-sheriff
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+The topology resolver runs early in the boot pipeline and turns configured aliases
+into a resolved topology before the configuration validator runs. Two structurally
+distinct classes of alias reach it: the `base_url` aliases of enabled endpoints,
+which are required for routing, and additional aliases contributed by other features
+(the `tls.passthrough_sni` keys). Any alias may be unresolvable against the topology.
+
+The architecture must decide *where* an unresolvable-alias violation is detected and
+reported. Because resolution runs before the configuration validator, a resolver that
+aborts on every unresolvable alias makes any validator rule covering the same alias
+class unreachable: the boot aborts at the resolver with a generic, un-aggregated
+message, and the validator's precise rule can never fire. The question this record
+settles is which stage owns the resolvability judgement for each alias class.
+
+== Decision
+
+Resolution applies an asymmetric failure policy keyed to the alias class:
+
+* An unresolvable *enabled-endpoint `base_url`* alias *throws*, aborting boot.
+  Routing cannot proceed without it and no validator rule owns this class, so
+  failing fast at the resolver is correct.
+* An unresolvable *additional* alias (`passthrough_sni`) is *skipped silently*.
+  Resolution records only what resolves and defers the resolvability judgement to
+  the configuration validator, which owns the passthrough-alias-resolvable rule and
+  reports it alongside every other configuration violation in one aggregated pass.
+
+The governing principle: a validation concern owned by the configuration validator
+must not be pre-empted by an earlier pipeline stage throwing on the same condition.
+The validator is the single authoritative reporter of configuration-validation
+violations; the resolver supplies structured facts and does not adjudicate
+validator-owned rules.
+
+== Consequences
+
+=== Positive
+
+* Every configuration-validation violation for additional aliases surfaces through
+  one reporter, collected in a single pass with precise messages; the validator rule
+  stays live rather than becoming dead code.
+* Routing-critical failures still fail fast at resolution time, preserving the
+  fail-fast-at-startup property (see xref:0004-topology-indirection.adoc[ADR-0004])
+  for the enabled-endpoint class.
+
+=== Negative
+
+* Resolution's failure behaviour is deliberately non-uniform across alias classes; a
+  reader must know the class distinction to predict whether an unresolvable alias
+  throws or is skipped. The asymmetry is intentional.
+
+=== Risks
+
+* A future alias class added to the resolver inherits neither policy automatically.
+  Its author must decide which stage owns its resolvability and wire the throw-or-skip
+  accordingly.
+
+== Alternatives Considered
+
+* *Symmetric throw* -- the resolver aborts on any unresolvable alias. Uniform and
+  simple, but it renders the validator's passthrough-alias-resolvable rule unreachable
+  dead code and aborts boot with a less precise, non-aggregated message. Rejected
+  because it destroys single-reporter ownership and degrades diagnostics.
+* *Symmetric skip* -- the resolver never throws and the validator owns all
+  alias-resolvability. This would defer even routing-critical enabled-endpoint failures
+  to a later stage, letting boot proceed further into an unroutable state before
+  failing. Rejected because enabled-endpoint aliases are structurally required and have
+  no validator rule; fail-fast is correct for them.
+
+Both alternatives fall in one class: they force a single uniform policy across two
+alias classes whose ownership genuinely differs. The asymmetry is the point.
+
+== References
+
+* xref:0004-topology-indirection.adoc[ADR-0004 -- Topology Indirection] -- establishes
+  fail-fast-at-startup for aliases; this record refines it for the additional-alias class.
+* xref:../configuration.adoc[Configuration Model] -- Configuration Validation Rules and `tls.passthrough_sni`.

--- a/integration-tests/scripts/verify-environment.sh
+++ b/integration-tests/scripts/verify-environment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Setup environment for JWT Integration Tests
+# Setup environment for API Gateway Integration Tests
 
 set -e
 
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ROOT_DIR="$(dirname "$(dirname "$PROJECT_DIR")")"
 
-echo "🔧 Setting up JWT Integration Tests environment"
+echo "🔧 Setting up API Gateway Integration Tests environment"
 
 cd "${PROJECT_DIR}"
 

--- a/integration-tests/src/main/docker/health-check.sh
+++ b/integration-tests/src/main/docker/health-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Internal health check script for JWT Integration Tests
+# Internal health check script for API Gateway Integration Tests
 # Uses /dev/tcp for connection testing (Docker best practice)
 
 # Check if the application port is listening using /dev/tcp

--- a/integration-tests/src/main/docker/sheriff-config/endpoints/httpbin.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/endpoints/httpbin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../../../api-sheriff/src/main/resources/schema/endpoint.schema.json
 # The single proxied endpoint the integration suite exercises. Its /proxy route
 # is the only route in the assembled RouteTable, so a request that echoes proves
 # the gateway sourced its upstream from this mounted configuration (not from a

--- a/integration-tests/src/main/docker/sheriff-config/gateway.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/gateway.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../../api-sheriff/src/main/resources/schema/gateway.schema.json
 # Global gateway document mounted into the api-sheriff container at
 # /app/sheriff-config (SHERIFF_CONFIG_DIR). Kept intentionally minimal: the proxy
 # integration suite only needs the single httpbin endpoint's /proxy route, and

--- a/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/ConfigLoadedIntegrationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/ConfigLoadedIntegrationIT.java
@@ -63,12 +63,12 @@ class ConfigLoadedIntegrationIT extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("container boots healthy from the mounted configuration")
+    @DisplayName("container reports ready — its dependencies are available, not merely the process alive")
     void managementHealthReportsUp() {
         given()
                 .baseUri(managementBaseUri())
                 .when()
-                .get("/q/health/live")
+                .get("/q/health/ready")
                 .then()
                 .statusCode(200)
                 .body("status", is("UP"));


### PR DESCRIPTION
## Summary

Closes six of the seven landing gaps found during post-merge verification of Plan-02
(Configuration Management) and Plan-01, all shipped in this single PR against `main`:

1. Two documented-but-unimplemented `ConfigValidator` cross-cutting rules for
   `tls.passthrough_sni` (host-collision detection, alias-resolvability + no-base-path),
   plus a widened `TopologyResolver.resolve(...)` signature so passthrough aliases are
   resolved into `ResolvedTopology` regardless of endpoint enablement.
2. `forwarded.trusted_proxies` presence enforced at the JSON Schema level (a
   `ConfigValidator` rule cannot distinguish "omitted" from "explicitly empty" once
   `ForwardedConfig`'s canonical constructor normalizes `null` to `List.of()`).
3. `# yaml-language-server: $schema=...` header comments on the sample/test YAML
   configs (excluding the two deliberately schema-violating negative fixtures).
4. Property-based `RouteTableBuilder` tests (`@GeneratorsSource`) covering
   prefix/host/method permutations, alongside the existing example-based tests.
5. A boot test pinning the disabled-endpoint alias-resolution exemption (a disabled
   endpoint's unresolvable `base_url` alias must not fail boot).
6. `ConfigLoadedIntegrationIT.managementHealthReportsUp` now asserts
   `/q/health/ready` instead of `/q/health/live`.
7. Stale "JWT Integration Tests" wording removed from `health-check.sh` and
   `verify-environment.sh` (comment/echo text only).

### Out of scope: request item 1 (endpoint-enablement env override)

Request item 1 — wiring `EndpointEnablementResolver` into `ConfigProducer.buildOnce()`
so the `ENDPOINT_<ID>_ENABLED` environment override stops being dead code — is
**deliberately dropped from this plan's scope**, by operator decision, and is
**not** included in this PR. The defect is real and was verified against source, but
a parallel workstream is moving environment handling that concerns config-file
content out of the Java layer and into Docker-side structures. Since
`ENDPOINT_<ID>_ENABLED` overrides the endpoint `enabled` field — which *is*
config-file content — it is subsumed by that migration: the override will be
materialized into the YAML before the JVM starts, so wiring the resolver into
`buildOnce()` now would create code the migration would immediately delete.
Concretely, `ConfigProducer.buildOnce()` line 124's `.filter(EndpointConfig::enabled)`
is left untouched, and `EndpointEnablementResolver` is neither wired nor deleted
here — ownership passes to the parallel workstream. Full rationale is recorded in
this plan's `solution_outline.md` § "Out of scope: the endpoint-enablement env
override (request item 1)".

## Changes

- `api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java` —
  two new passthrough-SNI validation rules.
- `api-sheriff/src/main/java/de/cuioss/sheriff/api/config/topology/TopologyResolver.java` —
  widened `resolve(...)` signature to accept `additionalAliases`; skip-not-throw on an
  unresolvable passthrough alias.
- `api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigProducer.java` —
  passes `tls.passthrough_sni` values into the widened `resolve(...)` call.
- `api-sheriff/src/main/resources/schema/gateway.schema.json` — `trusted_proxies`
  added to the `forwarded` object's `required` array.
- `api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java` —
  valid/violating tests for both new rules.
- `api-sheriff/src/test/java/de/cuioss/sheriff/api/config/topology/TopologyResolverTest.java` —
  coverage for the widened `resolve(...)` signature (passthrough-only alias resolves,
  unresolvable passthrough alias is skipped, enabled-endpoint alias still throws).
- `api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java` —
  structural schema-validation test for `forwarded.trusted_proxies` presence.
- `api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java` —
  property-based tests over prefix/host/method permutations.
- `api-sheriff/src/test/resources/config/valid/gateway.yaml`,
  `api-sheriff/src/test/resources/config/testboot/gateway.yaml`,
  `api-sheriff/src/test/resources/config/testboot/endpoints/proxy.yaml`,
  `integration-tests/src/main/docker/sheriff-config/gateway.yaml`,
  `integration-tests/src/main/docker/sheriff-config/endpoints/httpbin.yaml` —
  `yaml-language-server` schema headers added.
- `integration-tests/src/test/java/de/cuioss/sheriff/api/integration/ConfigLoadedIntegrationIT.java` —
  readiness assertion instead of liveness.
- `integration-tests/scripts/verify-environment.sh`,
  `integration-tests/src/main/docker/health-check.sh` — stale "JWT Integration Tests"
  wording removed.

## Test Plan

- [ ] `verify -Ppre-commit` (quality gate) passed
- [ ] `verify` (full build with module tests) passed
- [ ] `verify -Pintegration-tests -pl integration-tests -am` passed (readiness IT)

## Related Issues

N/A — sourced from post-merge review of Plan-02/Plan-01, no linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TLS passthrough SNI alias support, including resolving aliases not tied to enabled endpoints.
  - Added stricter validation for `passthrough_sni`, including route-host collisions and upstream base-path compatibility checks.
- **Bug Fixes**
  - Unresolvable passthrough SNI aliases are now handled asymmetrically: enabled-endpoint aliases still fail boot, while additional/unreferenced aliases are skipped and reported via validation.
  - Improved boot behavior for disabled endpoints referencing unresolvable aliases.
- **Documentation / Tests**
  - `forwarded.trusted_proxies` is now required by schema, with updated test coverage and YAML schema directives in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->