### PR TITLE
docs: anchors + data-plane transport decisions, full plan roadmap, consistency pass

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -28,8 +28,10 @@ together*.
   *Where it and the archived manifest differ, `doc/client` governs.*
 
 | link:technical_aspects.adoc[Technical Aspects]
-| The CUI libraries API Sheriff builds on -- `cui-http` (downstream calls + inbound
-  security filtering), `token-sheriff-validation` (offline JWT validation),
+| The CUI libraries API Sheriff builds on -- `cui-http` (inbound security filtering,
+  forwarded-header resolution, control-plane calls -- see
+  link:adr/0008-data-plane-transport.adoc[ADR-0008]), `token-sheriff-validation` (offline JWT
+  validation),
   `token-sheriff-client` (the OIDC confidential-client engine used by the BFF variants),
   logging and testing.
 
@@ -87,8 +89,10 @@ configuration. Each has its own design section:
 == Implementation Plans
 
 Sequenced plans for building what these documents describe live under
-link:plan/README.adoc[`plan/`]: base implementation, configuration management, and the
-request pipeline. Each plan names the design documents that must be read before
+link:plan/README.adoc[`plan/`]: base implementation and configuration management (delivered),
+then endpoint anchors, the request pipeline, protocol processors, the TLS edge, the two BFF
+variants (server-session first), and release readiness -- the full sequence to the 1.0 cut.
+Rate limiting is out of scope. Each plan names the design documents that must be read before
 implementing it.
 
 == Architecture Decisions
@@ -111,7 +115,8 @@ implementing it.
 
 | link:adr/0004-topology-indirection.adoc[ADR-0004]
 | Configuration layout: portable endpoint files reference `base_url` aliases resolved by
-  `topology.properties`; a single URL per alias, overridable by `TOPOLOGY_<ALIAS>` env vars.
+  `topology.properties`; a single URL per alias. Amendment A1: env override expressed as a
+  visible in-file `${TOPOLOGY_<ALIAS>:-default}` placeholder, not a convention-named lookup.
 
 | link:adr/0005-module-structure.adoc[ADR-0005]
 | One Quarkus module for now (no separate core module yet); keep the framework-agnostic seam
@@ -120,6 +125,18 @@ implementing it.
 | link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006]
 | Stream data-plane bodies with backpressure; use the `HttpResult<T>` materialize-the-body
   pattern on the control plane only. `max_body_bytes` is a streaming counter, not a buffer.
+
+| link:adr/0007-anchor-scoped-policy.adoc[ADR-0007]
+| Anchors: namespace-scoped policy in `gateway.yaml` -- disjoint path namespaces carrying an
+  inherited, non-weakenable policy floor (auth/filter/headers/methods), single declared
+  membership per route, wholesale replacement, erased into the route table at boot.
+  *(Status: proposed.)*
+
+| link:adr/0008-data-plane-transport.adoc[ADR-0008]
+| Data plane: Vert.x `HttpClient` (streams, trailers, upgrades) shared per upstream tuple;
+  resilience via per-route programmatic SmallRye Fault Tolerance guards with a stream-aware
+  retry gate; gateway-side response caching rejected; `not_modified.enabled` = end-to-end
+  conditional pass-through; `cui-http`'s client stack is control-plane only.
 |===
 
 == Reading Order

--- a/doc/adr/0004-topology-indirection.adoc
+++ b/doc/adr/0004-topology-indirection.adoc
@@ -4,7 +4,9 @@
 
 == Status
 
-Accepted.
+Accepted; the *override channel* is superseded by link:#_amendment_a1[Amendment A1] below
+(in-file `${VAR:-default}` placeholder instead of the convention-named env var). The
+single-URL-per-alias model is unchanged.
 
 == Context
 
@@ -45,6 +47,8 @@ researched what the majority of widely-used systems do for human-authored, env-o
   `APP1=https://app1.internal:8443/app1`.
 * *Environment variable `TOPOLOGY_<ALIAS>` overrides the file and takes precedence.*
   Precedence, highest first: `TOPOLOGY_<ALIAS>` env var -> `topology.properties`.
+  *(Superseded by link:#_amendment_a1[Amendment A1]: the same precedence, expressed as a
+  visible in-file placeholder instead of a convention-named lookup.)*
 * *Decompose-on-read (Kong model).* On load, each resolved URL is validated and decomposed once into
   `{scheme, host, port, base-path}`; the rest of the gateway works with the structured components. A
   route's upstream is `resolved(base_url) + route.upstream.path + <request-path remainder after
@@ -65,6 +69,29 @@ researched what the majority of widely-used systems do for human-authored, env-o
   boot).
 * Partial override (port only) requires restating the whole URL until/unless the component escape
   hatch is added -- an accepted, low-cost trade.
+
+[[_amendment_a1]]
+== Amendment A1 (2026-07-15) -- Override channel becomes an in-file placeholder
+
+The *single-URL-per-alias* decision above is unchanged. What A1 supersedes is the *override
+channel*: the convention-named environment variable (`TOPOLOGY_<ALIAS>` wins over the file),
+which was implemented as an invisible Java-class-level lookup a reader cannot discover from
+the artifact. It is replaced by the unified in-file substitution mechanism decided with the
+anchors work (link:../plan/03-endpoint-anchors.adoc[Plan 03], D4): every override point is a
+visible shell-style placeholder in the artifact it affects --
+
+[source,properties]
+----
+APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
+----
+
+`${VAR}` is a required substitution (unset fails the boot); `${VAR:-default}` expresses "file
+value as default, environment wins" -- the role the convention override played. The familiar
+`TOPOLOGY_<ALIAS>` variable *names* survive as a sample-config convention; the *mechanism* is
+the placeholder, resolved once before schema validation. Everything else in this ADR
+(one URL per alias, decompose-on-read, no component split, no concrete host in endpoint
+files) stands. Implementation lands with Plan 03; `configuration.adoc`'s topology section is
+rewritten in the same PR.
 
 == References
 

--- a/doc/adr/0005-module-structure.adoc
+++ b/doc/adr/0005-module-structure.adoc
@@ -10,7 +10,7 @@ Accepted.
 
 API Sheriff's production code currently lives in a single deployable Quarkus module
 (`api-sheriff`), alongside the `integration-tests` and `benchmarks` coordinator modules. As the
-request pipeline (link:../plan/03-request-pipeline.adoc[Plan 03]) lands, that module gains a
+request pipeline (link:../plan/04-request-pipeline.adoc[Plan 04]) lands, that module gains a
 substantial body of logic that is *not* inherently Quarkus-specific: the immutable
 configuration model and validators (Plan 02, delivered),
 the event/counter system, the route table and matchers, the forward policy, and the boot-time
@@ -49,7 +49,7 @@ Concretely:
   MicroProfile Config, Vert.x, or Micrometer -- e.g. `de.cuioss.sheriff.api.config.model`,
   `...config.validation`, `...events`, `...routing`, `...forward`, `...pipeline`. These types
   take their collaborators through *constructor parameters*, never field/CDI injection, and are
-  assembled once at boot (see link:../plan/03-request-pipeline.adoc[Plan 03]'s `RouteRuntime`).
+  assembled once at boot (see link:../plan/04-request-pipeline.adoc[Plan 04]'s `RouteRuntime`).
 * *Confine framework wiring to an edge layer.* CDI producers/observers, the Vert.x route
   handler, config-source plumbing, health/metrics binding, and the RFC 9457 exception edge live
   in dedicated packages (e.g. `...quarkus`, `...edge`) that *may* depend on the framework and
@@ -79,7 +79,7 @@ Negative / to watch:
 
 * The boundary is enforced by an arch-gate rule rather than by module compilation, so it is
   only as strong as that rule -- the rule must be present and part of the quality gate from the
-  first pipeline PR (Plan 03), or the seam silently erodes.
+  first pipeline PR (Plan 04), or the seam silently erodes.
 * If the framework-agnostic surface grows large and stable, the argument for a real module
   strengthens; this ADR is explicitly a *"not yet"*, not a *"never"*.
 

--- a/doc/adr/0006-body-streaming-vs-httpresult.adoc
+++ b/doc/adr/0006-body-streaming-vs-httpresult.adoc
@@ -4,18 +4,19 @@
 
 == Status
 
-Accepted.
+Accepted. Completed by link:0008-data-plane-transport.adoc[ADR-0008], which names the client
+and the resilience mechanism on each plane.
 
 == Context
 
-`cui-http` offers two shapes for a downstream call:
-
-* the *async/streaming* client surface (`HttpHandler`, `ResilientHttpAdapter`,
-  `ETagAwareHttpAdapter`, JDK `HttpClient`), and
-* the `HttpResult<T>` *result object* -- a sealed `Success`/`Failure` that carries the
-  *fully-materialized, deserialized* response body as an in-memory `T`, plus status, ETag, an
-  `HttpErrorCategory`, and optional fallback content
-  (link:../technical_aspects.adoc#_httpresult_pattern[Technical Aspects -- HttpResult]).
+`cui-http`'s client stack is *typed and materializing by construction*: `HttpHandler` wraps
+the JDK `HttpClient`, and the adapters (`ResilientHttpAdapter`, `ETagAwareHttpAdapter`)
+return `HttpResult<T>` -- a sealed `Success`/`Failure` that carries the *fully-materialized,
+deserialized* response body as an in-memory `T`, plus status, ETag, an `HttpErrorCategory`,
+and optional fallback content
+(link:../technical_aspects.adoc#_httpresult_pattern[Technical Aspects -- HttpResult]).
+Materialization is not incidental -- the adapters' retry and ETag caching work *because* the
+body is a replayable / cacheable `T`.
 
 `HttpResult<T>` is excellent where the response is *small, bounded, and wanted as an object*.
 It is the wrong shape for the *proxy data plane*, where the gateway forwards arbitrary client
@@ -89,11 +90,11 @@ backpressure, and forces time-to-first-byte up to time-to-last-byte.
   bodies as *streams with backpressure*, in *both directions*: in Quarkus/Vert.x, pipe the
   client `ReadStream` to the upstream `WriteStream` (the *request* body) and the upstream
   `ReadStream` to the client `WriteStream` (the *response* body) via `pipeTo`/`Pipe`, pausing
-  the source when the sink's write queue is full and resuming on drain. The gateway does *not*
-  wrap the proxied body in `HttpResult<byte[]>` / `HttpResult<String>`. `HttpResult` may still be
-  used on the data plane for its *control metadata* (status, error category for the
-  `502`/`503`/`504` mapping) as long as the *body* is a stream, not a materialized `T` -- i.e.
-  never `HttpResult<byte[]>` for the proxied payload.
+  the source when the sink's write queue is full and resuming on drain. `HttpResult` does not
+  appear on the data plane at all: the transport and per-route resilience are named in
+  link:0008-data-plane-transport.adoc[ADR-0008] (shared Vert.x client + programmatic
+  fault-tolerance guards), and the `502`/`503`/`504` failure mapping is driven by the
+  gateway's own event types, not by `HttpErrorCategory`.
 * *`max_body_bytes` is a streaming counter, not a buffer.* The per-route body cap
   (link:../configuration.adoc#_security_filtering[`security_filter.max_body_bytes`]) is enforced
   by counting bytes as they flow through the pipe and aborting once the cap is exceeded; the
@@ -117,9 +118,9 @@ backpressure, and forces time-to-first-byte up to time-to-last-byte.
   hold-until-complete), matching every surveyed proxy's default.
 * The `HttpResult<T>` ergonomics are retained exactly where they help -- the small control-plane
   JSON calls -- without leaking their materialize-the-body cost onto the data plane.
-* Plan 03 replaces the interim `ofByteArray()` buffering proxy with the streaming pipe; the body
+* Plan 04 replaces the interim `ofByteArray()` buffering proxy with the streaming pipe; the body
   cap is re-expressed as a streaming counter (see
-  link:../plan/03-request-pipeline.adoc[Plan 03], dispatch/response stages).
+  link:../plan/04-request-pipeline.adoc[Plan 04], dispatch/response stages).
 
 == References
 

--- a/doc/adr/0007-anchor-scoped-policy.adoc
+++ b/doc/adr/0007-anchor-scoped-policy.adoc
@@ -1,0 +1,125 @@
+= ADR-0007 -- Anchors: Namespace-Scoped Policy Inheritance
+:toc:
+:toclevels: 2
+
+== Status
+
+Proposed.
+
+== Context
+
+The configuration model (link:../configuration.adoc[Configuration Model]) groups routes into
+endpoint files sharing one `base_url` alias and an endpoint-level `auth` default. That is the
+only grouping mechanism: there is no policy level *above* the endpoint, and no formal owner of
+a URL namespace. Two problems follow as the route population grows:
+
+* *Duplication.* A deployment-wide invariant like "every call under `/api` must present a valid
+  bearer token from the configured IdP" must be restated in every endpoint file whose routes
+  live under `/api` -- and equally for the security-filter profile and response-header posture
+  of a surface like `/bff`.
+* *No namespace guarantee.* Nothing prevents a new endpoint file from placing a route under
+  `/api` with a weaker posture. The invariant lives in the operator's head, not in the model --
+  a fail-open risk for a security gateway.
+
+The obvious alternative -- keep duplicating everything per endpoint (the KrakenD position) --
+is maximally explicit but scales poorly for hand-authored files and leaves the fail-open risk
+unaddressed: with duplication the policy floor exists in N places, and one omission is an open
+endpoint.
+
+=== Research findings
+
+How comparable products bundle endpoints and inherit configuration:
+
+* *Kong* -- plugins attach at global / service / route / consumer scope; the most specific
+  scope wins and *replaces the whole plugin config* -- no merging. Tags are metadata only and
+  never carry policy.
+* *APISIX* -- named *Plugin Config* objects bundle plugin settings and are referenced by ID
+  from routes; route-level config overrides the referenced bundle per plugin, wholesale.
+  Grouping by *named reference*, not by URL.
+* *Traefik* -- no inheritance; named middlewares composed as an explicit ordered list per
+  router, entrypoints may prepend a default chain.
+* *Kubernetes Gateway API (GEP-713 policy attachment)* -- hierarchical policies with separate
+  *defaults* and *overrides* semantics; widely criticised for a discoverability problem
+  ("why does my route behave this way?") that required extra status machinery to mitigate.
+* *Azure API Management* -- global -> product -> API -> operation policy scopes; the child
+  policy places an explicit `<base/>` element marking where the parent chain executes -- the
+  child *sees and controls* its inheritance.
+* *NGINX* -- server/location directive inheritance; array directives (`add_header`,
+  `proxy_set_header`) silently *replace* rather than merge at lower levels -- the canonical
+  cautionary tale for implicit merge expectations.
+* *KrakenD* -- deliberately no inheritance; everything flat per endpoint, viable because
+  configs are typically machine-generated.
+* *OpenAPI* -- global `security` requirement overridden per operation *by replacement*.
+
+Three lessons condense out:
+
+. *Nobody deep-merges.* Every surviving design overrides at whole-block granularity. The model
+  already commits to this for endpoint -> route `auth` ("whole block replaces, no merge").
+. *Grouping is usually by named reference, not URL prefix* -- but reference-based grouping
+  cannot express "nothing may appear under `/api` without this posture". For a security
+  gateway, binding policy to a *namespace the anchor owns* buys boot-time namespace
+  enforcement, which the reference model cannot.
+. *Keep the hierarchy shallow and the effective result visible.* Gateway API shows where deep
+  attachment models end up; the existing boot-time materialization (`RouteTable` carries the
+  *effective* auth and methods) is the right antidote and must absorb any new layer.
+
+== Decision
+
+* *Introduce anchors*: named policy scopes declared in `gateway.yaml`, each *owning* a URL
+  path namespace (`path_prefix`) and optionally carrying policy blocks (`auth`,
+  `security_filter`, `security_headers`, `allowed_methods`).
+* *Anchor prefixes are pairwise disjoint* (no anchor prefix is a prefix of another); overlap
+  fails the boot.
+* *Exactly one anchor per route.* Membership is *declared* at the endpoint level (`anchor:`)
+  and may be overridden per route -- never derived silently. A route exposed on two surfaces
+  (e.g. the same upstream under `/api` with bearer and under `/bff` with session) is two
+  routes, one per anchor. Multi-anchor membership is rejected by construction -- it would
+  reintroduce the merge-order ambiguity every surveyed product avoids.
+* *Namespace enforcement at boot.* When an `anchors` block is configured: every enabled
+  route's `match.path_prefix` must fall inside its *declared* anchor's `path_prefix`, and
+  every route whose path falls inside *any* anchor's namespace must declare that anchor.
+  A mismatch (declared anchor vs. actual path) or an undeclared squatter fails the boot.
+  When no `anchors` block is configured, nothing changes.
+* *Inheritance chain and semantics*: `gateway` defaults -> `anchor` -> `endpoint` -> `route`,
+  with *wholesale block replacement at every step, never a merge* -- the one rule the model
+  already has, extended by one rung.
+* *The auth floor cannot be weakened.* If an anchor declares `auth.require` of `bearer` or
+  `session`, a member endpoint/route whose *effective* auth resolves to `require: none` fails
+  the boot. Overriding between non-`none` postures (e.g. anchor `bearer`, route `session`) is
+  a replacement, not a weakening, and is allowed. Non-auth overrides that relax anchor limits
+  follow the existing convention: replacement plus a boot-log WARN.
+* *Endpoint `auth` becomes optional for anchored endpoints* whose anchor declares `auth`; the
+  existing "every endpoint file declares an `auth` block" rule applies unchanged to endpoints
+  without an anchor-provided posture. Every route still has a non-ambiguous effective auth --
+  resolvable from route, endpoint, or anchor -- or the boot fails.
+* *Anchors vanish at runtime.* They are resolved during `RouteTable` assembly into the same
+  materialized per-route effective values that already exist (effective auth, effective
+  `allowed_methods`, now effective filter/headers). The request pipeline never sees an anchor;
+  there is no runtime lookup, and the boot log can print the effective posture per route --
+  the discoverability answer to the Gateway API lesson.
+
+== Consequences
+
+* Namespace invariants become *structural*: "everything under `/api` presents a bearer token"
+  is declared once and enforced at boot; a forgotten declaration is a refused boot, not an
+  open endpoint. This inverts the fail-open risk of the duplication alternative.
+* Endpoint files shed repeated posture blocks and keep locality: overrides are declared in the
+  endpoint file, and the materialized result is visible in the boot log.
+* One more rung in a still-shallow chain (four levels, one override rule). The complexity
+  ceiling observed in Gateway API is avoided by forbidding merge, forbidding multi-membership,
+  and erasing anchors before runtime.
+* The same-upstream-two-surfaces case costs one extra route entry per surface -- accepted; the
+  two surfaces need different auth anyway.
+* Must land *before* the request pipeline (Plan 04) freezes route selection; retrofitting
+  namespace enforcement into an existing pipeline is substantially harder. See
+  link:../plan/03-endpoint-anchors.adoc[Plan 03].
+
+== References
+
+* https://developer.konghq.com/gateway/entities/plugin/[Kong -- plugin scopes and precedence]
+* https://apisix.apache.org/docs/apisix/terminology/plugin-config/[APISIX -- Plugin Config objects]
+* https://doc.traefik.io/traefik/middlewares/overview/[Traefik -- middleware composition]
+* https://gateway-api.sigs.k8s.io/geps/gep-713/[Kubernetes Gateway API -- GEP-713 policy attachment]
+* https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-policies[Azure APIM -- policy scopes and `<base/>`]
+* link:../configuration.adoc[Configuration Model] -- the wholesale-replacement convention this
+  decision extends

--- a/doc/adr/0008-data-plane-transport.adoc
+++ b/doc/adr/0008-data-plane-transport.adoc
@@ -1,0 +1,114 @@
+= ADR-0008 -- Data-Plane Transport, Resilience, and Conditional-Request Posture
+:toc:
+:toclevels: 2
+
+== Status
+
+Accepted.
+
+== Context
+
+link:0006-body-streaming-vs-httpresult.adoc[ADR-0006] split the gateway's HTTP surface into
+two planes -- control plane materializes (`HttpResult<T>`), data plane streams -- but never
+named the *client* on each side. Two governing texts consequently contradicted each other:
+the Architecture "Downstream Client" section said upstream calls use `cui-http`'s
+`HttpHandler` ("one pooled JDK `HttpClient` per upstream tuple"), while ADR-0006's decision
+is written in Vert.x vocabulary ("pipe the client `ReadStream` to the *upstream
+`WriteStream`*"), presupposing a Vert.x upstream leg. Plan 04 inherited both.
+
+Source verification (local `cui-http` checkout) sharpened this into a type-level fact rather
+than a preference: the `cui-http` client adapters are materializing *by construction*.
+`ResilientHttpAdapter<T>` and `ETagAwareHttpAdapter<T>` implement `HttpAdapter<T>` returning
+`CompletableFuture<HttpResult<T>>` -- a typed, fully-deserialized body. Retry works *because*
+the request body is a re-serializable `T` held in memory; the ETag adapter is a whole-response
+in-memory cache that issues its own conditional requests and serves cached bodies on `304`,
+with a `cacheKeyHeaderFilter` designed to *exclude* headers such as `Authorization` from the
+cache key. Neither can carry a streamed body; neither was designed for a multi-user proxy
+path.
+
+Meanwhile the delivered configuration model already promises per-route `304` behaviour:
+`upstream_defaults.not_modified.enabled`, default *enabled*, materialized into
+`ResolvedRoute` -- with semantics specified in a single vague sentence. The obvious (wrong)
+implementation would have been the ETag adapter on the data plane.
+
+Forward-looking transport requirements from the later protocol plans: gRPC requires HTTP
+*trailers* (`grpc-status` lives there) -- the JDK `HttpClient` exposes none; WebSocket
+proxying requires the raw upgrade stream; upstream HTTP/2 multiplexing is expected. All three
+are native to the Vert.x client that already runs the gateway's edge.
+
+== Decision
+
+* *Data-plane transport is the Vert.x `HttpClient`.* Proxied request and response bodies are
+  piped as streams with backpressure in both directions (ADR-0006), directly between the edge
+  and upstream Vert.x streams. One shared client (and connection pool) per *distinct upstream
+  target tuple* (resolved host + timeouts + TLS context), options assembled once at boot from
+  `upstream` config -- the same dedup lever previously assigned to `HttpHandler`.
+* *Control plane stays on `cui-http`.* `HttpHandler`, `ResilientHttpAdapter`,
+  `ETagAwareHttpAdapter`, and `HttpResult<T>` serve the gateway's own small, bounded JSON
+  calls (OIDC discovery, JWKS, token exchange, revocation) -- consumed chiefly *inside*
+  `token-sheriff-validation`/`token-sheriff-client`. ADR-0006's plane split, with the client
+  now named per plane. `cui-http`'s data-plane role remains the parts it is genuinely built
+  for: the inbound security pipelines and the forwarded-header resolver.
+* *Gateway-side response caching on the data plane is REJECTED* -- including ETag
+  revalidation-from-cache (serving a cached body on upstream `304`). A shared response cache
+  keyed by anything less than the full authorization context is a cross-user data leak; keyed
+  by the full context it is memory-unbounded per user; either way it materializes proxied
+  bodies (the ADR-0006 anti-pattern) and adds a cache-poisoning surface. `ETagAwareHttpAdapter`
+  is control-plane only, permanently.
+* *`not_modified.enabled` means end-to-end conditional pass-through*, nothing more:
+** *enabled* (default) -- the conditional-request headers (`If-None-Match`,
+   `If-Modified-Since`) are implicitly part of the route's effective `forward.headers_allow`,
+   and upstream `304` responses plus validator response headers (`ETag`, `Last-Modified`)
+   relay untouched. `304` carries no body -- fully streaming-compatible, zero gateway state.
+** *disabled* -- validators are stripped in *both* directions (request conditionals and
+   response `ETag`/`Last-Modified`), deliberately forcing full `200` exchanges -- the
+   hardening knob for upstreams whose ETags are inconsistent across nodes or leak
+   inode/version information.
+* *Resilience uses SmallRye Fault Tolerance's programmatic API*
+  (`quarkus-smallrye-fault-tolerance`) -- the Quarkus-native mechanism, applied without
+  annotations or CDI interception on the hot path: one guard per route, assembled at boot
+  from `upstream.retry` / `upstream.circuit_breaker` (attempt count, breaker `failures` /
+  `reset_ms`), invoked around the dispatch call in the framework-bound *edge* layer -- the
+  ADR-0005 boundary stays intact, the framework-agnostic core carries only the resolved
+  policy values. Breaker state transitions surface as WARN LogRecords and metrics.
+* *Retry is stream-aware gateway policy, enforced before the guard*: an attempt is retried
+  only when the method is idempotent *and zero request-body bytes have been sent upstream*.
+  No replay buffering in the initial release. Timeouts are transport options on the shared
+  Vert.x client (connect/read per upstream tuple), not fault-tolerance timeouts.
+* *The whole-second timeout rule is dropped.* `connect_timeout_ms`/`read_timeout_ms` were
+  restricted to multiples of 1000 ms only because `cui-http`'s `HttpHandler` builder takes
+  whole seconds; the Vert.x client takes milliseconds natively. The delivered
+  `ConfigValidator` rule and its documentation entries are removed (pre-1.0: break freely).
+
+== Consequences
+
+* The later gRPC and WebSocket plans get trailers, upgrade streams, and h2 natively -- no
+  transport swap mid-series.
+* `cui-http`'s retry/backoff (`RetryConfig`) goes unused on the data plane -- it was unusable
+  there anyway (retry presupposes a replayable materialized body). The breaker was already
+  specified as gateway-side; it now has a concrete, Quarkus-supported home instead of a
+  hand-rolled state machine.
+* `HttpHandler` becomes nearly invisible in API Sheriff's own code (it lives behind the
+  token-sheriff libraries). "Standardize on cui-http" remains true for what cui-http is best
+  at -- inbound security filtering, forwarded-header resolution, control-plane calls -- and
+  stops being over-generalized to opaque byte relay.
+* One new Quarkus extension dependency (`quarkus-smallrye-fault-tolerance`, version from the
+  Quarkus BOM), subject to the usual explicit dependency approval in Plan 04.
+* Millisecond-precision timeouts become legal configuration; existing configs remain valid
+  (whole seconds are a subset).
+* The exact SmallRye FT programmatic surface (`Guard`/`TypedGuard`, `CircuitBreakerMaintenance`
+  state callbacks) is verified against the shipped extension version during Plan 04
+  implementation; if a needed hook is missing, the fallback is the same policy expressed as a
+  small gateway-side component -- the *decision* (per-route guards in the edge layer,
+  stream-aware retry gate) is unchanged either way.
+
+== References
+
+* link:0005-module-structure.adoc[ADR-0005] -- the edge/core boundary the guards respect
+* link:0006-body-streaming-vs-httpresult.adoc[ADR-0006] -- the plane split this ADR completes
+* https://quarkus.io/guides/smallrye-fault-tolerance[Quarkus -- SmallRye Fault Tolerance]
+  (programmatic API)
+* https://vertx.io/docs/vertx-core/java/#_making_requests[Vert.x HttpClient] -- streams,
+  trailers, upgrade support
+* `cui-http` sources: `ResilientHttpAdapter`, `ETagAwareHttpAdapter` (materializing adapter
+  contracts; cache-key header filtering)

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -18,9 +18,13 @@ the active mode is a function of configuration.
 == Component Model
 
 An inbound request flows left to right through a fixed pipeline. The TLS edge terminates
-(or passes through) the connection; the security filter, route matcher, authentication layer,
-and zero-trust forward policy each act in turn; a request that fails any stage is rejected
-before it reaches the upstream. The event system and metrics observe every stage.
+(or passes through) the connection; a *security-headers/CORS stage* prepares the response
+headers applied to *every* response -- including rejections -- and answers CORS preflight
+`OPTIONS` requests before authentication (preflights carry no credentials by spec; see
+link:configuration.adoc#_security_headers[Configuration -- `security_headers`]); then the
+security filter, route matcher, authentication layer, and zero-trust forward policy each act
+in turn; a request that fails any stage is rejected before it reaches the upstream. The event
+system and metrics observe every stage.
 
 image::resources/diagrams/request-pipeline.svg[Inbound request pipeline: TLS edge, security filter, route match, authenticate, forward policy, then upstream, align=center]
 
@@ -37,11 +41,13 @@ start* on invalid configuration -- it never serves traffic against a partially v
 table. Only *Static mode* is supported initially (link:adr/0002-initial-scope.adoc[ADR-0002]);
 the manifest's dynamic `/api/gateway-config.json` discovery pattern is deferred.
 
-Configuration is layered: a global `gateway.yaml`, one *portable* `endpoints/*.yaml` file per
-service that references an abstract `base_url` alias, and a `topology.properties` that binds each
-alias to a concrete location (overridable by `TOPOLOGY_<ALIAS>` env vars). Endpoint files carry no
-real host, so a deployment is relocated by changing only the topology
-(link:adr/0004-topology-indirection.adoc[ADR-0004]).
+Configuration is layered: a global `gateway.yaml` (including the namespace-scoped `anchors`
+policy, link:adr/0007-anchor-scoped-policy.adoc[ADR-0007]), one *portable* `endpoints/*.yaml`
+file per service that references an abstract `base_url` alias, and a `topology.properties`
+that binds each alias to a concrete location (environment overrides are visible in-file
+`${VAR:-default}` placeholders, link:adr/0004-topology-indirection.adoc[ADR-0004] +
+Amendment A1). Endpoint files carry no real host, so a deployment is relocated by changing
+only the topology.
 
 Immutability is a security property: a running node's behaviour is fully determined by an
 auditable, reproducible artifact. Changes are rolled out by restarting nodes (rolling
@@ -77,12 +83,14 @@ with `404` (deny-by-default). Routes from all endpoint files form one table orde
 most-specific-first; see link:configuration.adoc#_route_ordering[Configuration -- Route ordering]. Routing
 carries no dynamic rule language.
 
-Only routes of *enabled* endpoints enter the table: an endpoint switched off by `enabled: false`
-or `ENDPOINT_<ID>_ENABLED=false` contributes nothing (its paths fall through to `404`), which
+Only routes of *enabled* endpoints enter the table: an endpoint switched off by its resolved
+`enabled` value (file literal or `${ENDPOINT_<ID>_ENABLED:-...}` placeholder, ADR-0004 A1)
+contributes nothing (its paths fall through to `404`), which
 lets one config set be shipped across environments and toggled per environment (see
 link:configuration.adoc#_endpoint_identity[Configuration -- `endpoint`]). Orthogonally, a coarse
-*positive verb allowlist* -- `allowed_methods`, global with wholesale per-endpoint override and
-no inheritance -- gates which HTTP methods an endpoint serves at all: a routed request whose
+*positive verb allowlist* -- `allowed_methods`, global with wholesale per-anchor and
+per-endpoint replacement and no inheritance -- gates which HTTP methods an endpoint serves at
+all: a routed request whose
 method is outside the matched route's effective set is rejected `405` with an `Allow` header,
 above and beyond the per-route `match.methods` matcher (see
 link:configuration.adoc#_allowed_methods[Configuration -- `allowed_methods`]).
@@ -153,28 +161,43 @@ TCP-peer gate, scheme/host/port/prefix only when `trust_scheme_host` opts in -- 
 gateway emits *freshly regenerated* canonical output from it: `X-Forwarded-*` by default,
 RFC 7239 opt-in and additive
 (link:adr/0003-forwarded-headers.adoc[ADR-0003]); inbound chains are never propagated.
-Everything else is stripped. This deny-by-default posture is the KrakenD-inspired security
-default.
+Everything else is stripped. This deny-by-default posture is the security default throughout.
 
 === Downstream Client
 
-Upstream calls use `cui-http`:
+The upstream client is split by plane
+(link:adr/0008-data-plane-transport.adoc[ADR-0008]):
 
-* `HttpHandler` -- immutable, thread-safe client wrapper; HTTPS-by-default with a TLS 1.2+
-  floor; per-route connect/read timeouts.
-* `ETagAwareHttpAdapter` -- optional ETag/304 caching.
-* `ResilientHttpAdapter` -- non-blocking retry with exponential backoff (parks no thread);
-  idempotency-aware.
-* `HttpResult<T>` -- sealed `Success`/`Failure`; failures carry an `HttpErrorCategory`
-  (`NETWORK_ERROR`, `SERVER_ERROR`, `CLIENT_ERROR`, `INVALID_CONTENT`, `CONFIGURATION_ERROR`)
-  and may carry fallback content for graceful degradation.
-* Per-route *circuit breaker* -- a small gateway-side component wrapped around the adapter
-  chain (stateless, per node): opens after the configured consecutive failures, half-opens
-  after `reset_ms`. `cui-http` supplies retry and timeouts but no breaker, so this is gateway
-  code by design.
-
-The adapters are `CompletableFuture`-based; under the virtual-thread model the gateway may
-also call the blocking JDK `send()` from a virtual-thread-per-request worker.
+* *Data plane -- Vert.x `HttpClient`.* Proxied traffic is dispatched on the Vert.x client
+  that already runs the edge: request and response bodies are piped as streams in both
+  directions, and the transport natively provides what the later protocol plans need --
+  HTTP trailers (gRPC), raw upgrade streams (WebSocket), upstream h2. One shared client and
+  connection pool per *distinct upstream target tuple* (resolved host + connect/read timeouts
+  + TLS context), options assembled once at boot; timeouts are millisecond-precision client
+  options.
+* *Resilience -- SmallRye Fault Tolerance, programmatic.* One guard per route, built at boot
+  from `upstream.retry` / `upstream.circuit_breaker` and invoked around the dispatch call in
+  the framework-bound edge layer (no annotations, no CDI interception on the hot path; the
+  framework-agnostic core carries only the resolved policy values, per
+  link:adr/0005-module-structure.adoc[ADR-0005]). Retry is *stream-aware*: an attempt is
+  retried only for an idempotent method *and only when zero request-body bytes have been sent
+  upstream* -- there is no replay buffer. The breaker is stateless per node: opens after the
+  configured consecutive failures, half-opens after `reset_ms`; state transitions surface as
+  WARN LogRecords and metrics.
+* *Control plane -- `cui-http`.* The gateway's own small, bounded JSON calls (OIDC discovery,
+  JWKS, token exchange, revocation -- made chiefly inside the token-sheriff libraries) use
+  `HttpHandler` (immutable, thread-safe, HTTPS-by-default), `ResilientHttpAdapter`
+  (idempotency-aware retry), `ETagAwareHttpAdapter` (ETag/304 caching of the gateway's *own*
+  control resources), and `HttpResult<T>` (sealed `Success`/`Failure` with `HttpErrorCategory`
+  and fallback content).
+* *No gateway response cache.* Response caching of proxied traffic -- including serving a
+  cached body on an upstream `304` -- is rejected by design: a shared cache keyed by less
+  than the full authorization context is a cross-user data leak, and any variant materializes
+  proxied bodies (the ADR-0006 anti-pattern). Conditional requests instead pass through
+  end-to-end, governed per route by `upstream_defaults.not_modified.enabled`: enabled relays
+  `If-None-Match`/`If-Modified-Since` and the upstream's `304`/`ETag`/`Last-Modified`
+  untouched (a `304` has no body -- streaming-compatible, zero gateway state); disabled
+  strips the validators in both directions.
 
 *Two planes, two body shapes* (link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006]). The
 `HttpResult<T>` *materialize-the-body* pattern is used on the *control plane* only -- the small,
@@ -187,8 +210,10 @@ the sink's write queue is full) and *never* materializes the proxied body into
 `HttpResult<byte[]>`/`HttpResult<String>`. Buffering a proxied body is the documented OOM /
 broken-SSE / lost-backpressure anti-pattern every mainstream proxy avoids by default; the
 `security_filter.max_body_bytes` cap is enforced as a *streaming byte counter*, not by holding
-the body. `HttpResult`'s control metadata (status, `HttpErrorCategory`) may still drive the
-`502`/`503`/`504` mapping as long as the body itself stays a stream.
+the body. The `502`/`503`/`504` failure mapping is driven by the gateway's own event types
+from the Vert.x client / fault-tolerance guard outcomes
+(link:adr/0008-data-plane-transport.adoc[ADR-0008]) -- `HttpResult` does not appear on the
+data plane.
 
 [[_event_system]]
 == Event System
@@ -237,8 +262,8 @@ names the category but leaks no internal detail. The consolidated status mapping
 | `401` | Missing/invalid bearer token; invalid or expired session on a non-navigation request. Unauthenticated *navigation* requests (those accepting `text/html`) on `session` routes are redirected into the login flow instead -- content negotiation, not configuration (see link:configuration.adoc#_auth[Configuration -- `auth`]). Gateway `401`s carry `WWW-Authenticate` (`Bearer` per RFC 6750 on bearer routes). | `AUTHENTICATION`
 | `403` | Valid credentials lacking a required scope; failed CSRF origin check | `AUTHORIZATION`
 | `404` | No route matched (deny-by-default routing); reserved-for-passthrough `Host` on a terminated connection; disabled endpoint (e.g. back-channel logout in cookie mode) | `INPUT_VALIDATION`
-| `405` | Request method not in the matched route's *effective* `allowed_methods` verb allowlist (global default or endpoint override); the response carries an `Allow` header listing the permitted set | `INPUT_VALIDATION`
-| `429` | Rate limit exceeded -- *reserved*; the feature is deferred | --
+| `405` | Request method not in the matched route's *effective* `allowed_methods` verb allowlist (global default, or anchor/endpoint replacement); the response carries an `Allow` header listing the permitted set | `INPUT_VALIDATION`
+| `429` | Rate limit exceeded -- *reserved*; the feature is out of scope | --
 | `502` | Upstream connection failure / invalid upstream response | `UPSTREAM`
 | `503` | Circuit breaker open -- the upstream was not called (`Retry-After` hints at `reset_ms`) | `UPSTREAM`
 | `504` | Upstream timeout (`connect_timeout_ms` / `read_timeout_ms`) | `UPSTREAM`
@@ -306,7 +331,8 @@ HTTP/3 / QUIC is deferred.
 
 | WebSocket
 | Proxied bidirectionally (Quarkus/Vert.x). Authentication is enforced on the handshake; the
-  established stream is relayed. A differentiator -- WebSocket is enterprise-only in KrakenD.
+  established stream is relayed. A differentiator against the evaluated competitors (see
+  link:features-analysis.adoc[Feature Analysis]).
 
 | gRPC (incl. gRPCS)
 | gRPC rides on HTTP/2, so it is largely covered by the standard HTTP/2 path: the gateway
@@ -333,8 +359,11 @@ behaviour applies to them.
 The gateway targets a virtual-thread-per-request model:
 
 * Inbound security validation is synchronous CPU work and runs inline on the request thread.
-* Downstream I/O uses either the `cui-http` async `CompletableFuture` adapters or blocking
-  JDK `HttpClient.send()` from a virtual-thread worker -- both are virtual-thread-friendly.
+* Data-plane downstream I/O is the shared Vert.x client's event-loop streaming
+  (link:adr/0008-data-plane-transport.adoc[ADR-0008]) -- the virtual thread coordinates the
+  request but never blocks on proxied body bytes. Control-plane calls (inside the
+  token-sheriff libraries) use the `cui-http` async `CompletableFuture` adapters or blocking
+  JDK `HttpClient.send()` from a virtual-thread worker -- both virtual-thread-friendly.
 * Offline token validation (`TokenValidator`) is thread-safe and cache-backed; a single
   instance is created at startup and shared.
 
@@ -366,12 +395,13 @@ shared objects are immutable.
   a profile share one pipeline instance rather than each compiling its own. Built at boot,
   referenced by every matching route's `RouteRuntime`.
 
-| `HttpHandler` (downstream client) + its connection pool
-| Immutable and thread-safe after construction. One `HttpHandler` per *distinct upstream target
+| Data-plane Vert.x `HttpClient` + its connection pool
+| Immutable options, thread-safe client. One Vert.x client per *distinct upstream target
   tuple* (resolved host + connect/read timeouts + TLS context) -- *deduplicated across routes*,
-  so N routes to the same backend with the same timeouts share one handler and one pooled JDK
-  `HttpClient`/connection pool, rather than opening N pools. This is the single biggest "reuse a
-  large object" lever.
+  so N routes to the same backend with the same options share one client and one connection
+  pool, rather than opening N pools (link:adr/0008-data-plane-transport.adoc[ADR-0008]). This
+  is the single biggest "reuse a large object" lever. Per-route resilience guards (SmallRye FT)
+  are built once at boot and wrap the shared client per route.
 
 | `TokenValidator`
 | A single shared, cache-backed, thread-safe instance created at startup (already the rule --
@@ -383,8 +413,10 @@ shared objects are immutable.
 
 | `RouteTable` / per-route `RouteRuntime`
 | Assembled once at boot (matchers, effective auth, effective `allowed_methods`, filter
-  pipelines, forward sets, upstream client chain, circuit breaker, protocol processor). The
-  request path *looks up* an immutable `RouteRuntime`; it compiles nothing.
+  pipelines, forward sets, shared upstream client reference, resilience guard, protocol
+  processor) -- with any anchor policy already resolved into these effective values
+  (link:adr/0007-anchor-scoped-policy.adoc[ADR-0007]); the runtime never consults an anchor.
+  The request path *looks up* an immutable `RouteRuntime`; it compiles nothing.
 
 | Event counters (`GatewayEventCounter`, cui-http `SecurityEventCounter`)
 | Shared, lock-free (`ConcurrentHashMap` + `AtomicLong`); safe to increment concurrently.

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -20,15 +20,17 @@ Two structural principles shape the layout:
 * *Zero-trust and deny-by-default* throughout: nothing is forwarded, routed, or trusted unless
   it is explicitly configured.
 
-The model draws the best of the evaluated competitors (see link:features-analysis.adoc[Feature Analysis]):
+The model rests on a small set of adopted patterns:
 
-* *Endpoint-centric routes* with per-route timeout and circuit breaker -- from KrakenD.
-* *Composable, bounded matchers* (path, method, host, header) -- from Traefik.
-* *Validated-then-immutable, atomic config* -- from APISIX standalone mode + KrakenD GitOps.
-* *Zero-trust forwarding* (deny-by-default allowlists) -- from KrakenD.
-* *Alias -> URL indirection with env override* -- 12-factor "config in the environment"; the
-  single-URL alias and decompose-on-read model follow Kong / Spring / Traefik (see
-  link:adr/0004-topology-indirection.adoc[ADR-0004]).
+* *Endpoint-centric routes* with per-route timeout and circuit breaker.
+* *Composable, bounded matchers* (path, method, host, header).
+* *Validated-then-immutable, atomic config.*
+* *Zero-trust forwarding* (deny-by-default allowlists).
+* *Alias -> URL indirection with env override* -- config in the environment; a single-URL alias,
+  decomposed on read (see link:adr/0004-topology-indirection.adoc[ADR-0004]).
+
+The provenance of these patterns -- what was adopted from which evaluated product and why -- is
+recorded in the link:features-analysis.adoc[Feature Analysis] and the ADRs, not here.
 
 The schema is intentionally declarative; there is no rule language and no runtime mutation API.
 
@@ -42,7 +44,8 @@ Configuration is three kinds of artifact:
 
 | `gateway.yaml`
 | *Global* settings: schema version, TLS, security-response headers, filter defaults, the
-  `forwarded`-header policy, and the `oidc` block (BFF variants). No routes.
+  link:#_anchors[`anchors`] (namespace-scoped policy), the `forwarded`-header policy, and the
+  `oidc` block (BFF variants). No routes.
 
 | `endpoints/*.yaml`
 | *One file per endpoint* -- a service / host / app, or a logical group. Each file binds to one
@@ -70,12 +73,20 @@ conf/
   startup.
 * Each endpoint's `base_url` alias is *resolved* against the topology (env var wins over the file,
   see link:#_topology[Topology]); the resolved URL is *decomposed once* into
-  `{scheme, host, port, base-path}` (the Kong "accept URL, store components" model).
+  `{scheme, host, port, base-path}` (see link:adr/0004-topology-indirection.adoc[ADR-0004]).
 * The document set is validated as a whole; unknown keys, unknown `version`, an unresolved alias,
   a malformed topology URL, or a route referencing a missing endpoint all *fail the boot*.
 * Secrets are never inlined: they are `${ENV_VAR}` references, so the config artifacts are safe to
   commit. Topology values may be literal (they are locations, not secrets) but are still
   overridable by env.
+* *Environment override mechanism* (link:adr/0004-topology-indirection.adoc#_amendment_a1[ADR-0004
+  Amendment A1], implementation lands with link:plan/03-endpoint-anchors.adoc[Plan 03]): every
+  override point is a *visible in-file placeholder* -- `${VAR}` (required; unset fails the
+  boot, the secrets semantics) or `${VAR:-default}` (file default, environment wins) --
+  resolved once, before schema validation, across all three artifacts. The
+  `TOPOLOGY_<ALIAS>` / `ENDPOINT_<ID>_ENABLED` names used throughout this document are the
+  *conventional variable names* written inside those placeholders, not invisible
+  code-level lookups.
 * On any validation error the process exits non-zero and logs the offending file/alias -- it does
   not start a degraded gateway.
 
@@ -99,13 +110,14 @@ file-and-JSON-pointer error before any immutable value object is built:
 
 | `schema/gateway.schema.json`
 | The global `gateway.yaml` document -- `version` (the only required key), `metadata`, `tls`,
-  `security_headers`, `security_defaults`, `allowed_methods`, `upstream_defaults`, `forwarded`,
-  `token_validation` and `oidc`.
+  `security_headers`, `security_defaults`, `allowed_methods`, `anchors`, `upstream_defaults`,
+  `forwarded`, `token_validation` and `oidc`.
 
 | `schema/endpoint.schema.json`
-| A single `endpoints/*.yaml` file -- the `endpoint` block (`id`, `enabled`, `base_url`, `auth`,
-  `allowed_methods`, `upstream_defaults`) and its `routes[]`, each route's `match`, `auth`,
-  `security_filter`, `forward`, `upstream` and reserved `rate_limit`.
+| A single `endpoints/*.yaml` file -- the `endpoint` block (`id`, `enabled`, `base_url`,
+  `anchor`, `auth`, `allowed_methods`, `upstream_defaults`) and its `routes[]`, each route's
+  `anchor`, `match`, `auth`, `security_filter`, `forward`, `upstream` and reserved
+  `rate_limit`.
 |===
 
 Both schemas set `additionalProperties: false` at *every* object level, so an *unknown key* -- a
@@ -151,11 +163,21 @@ security_defaults:                 # default inbound filter profile; overridable
   profile: strict                  # default | strict | lenient  (maps to cui-http presets)
 
 allowed_methods: [GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS]   # positive HTTP-verb allowlist
-                                   #   (global default). An endpoint may REPLACE this wholesale
-                                   #   (no inheritance -- see endpoint.allowed_methods). A routed
-                                   #   request whose method is not in the EFFECTIVE list is
-                                   #   rejected 405. TRACE and CONNECT are never permitted and
+                                   #   (global default). An anchor or endpoint may REPLACE this
+                                   #   wholesale (no inheritance -- see endpoint.allowed_methods).
+                                   #   A routed request whose method is not in the EFFECTIVE list
+                                   #   is rejected 405. TRACE and CONNECT are never permitted and
                                    #   cannot be listed. Omit => the standard set shown here.
+
+anchors:                           # OPTIONAL namespace-scoped policy (see "Anchors"); each
+  api:                             #   anchor OWNS a disjoint path namespace and carries the
+    path_prefix: /api              #   policy floor for every route inside it
+    auth: { require: bearer }      # every /api route presents a bearer token; a member route
+                                   #   may replace this block but never weaken it to `none`
+    security_filter: { profile: strict }
+  bff:
+    path_prefix: /bff
+    auth: { require: session }     # the BFF surface: mediated OIDC session per the oidc block
 
 forwarded:                         # resolved by cui-http (de.cuioss.http.forwarded)
   trusted_proxies: [10.0.0.5/32, 10.0.0.6/32]   # MANDATORY; the exact proxy addresses --
@@ -207,6 +229,55 @@ oidc:                              # only used by the BFF variants (2 and 3)
     honor_upstream_challenge: true
 ----
 
+[[_anchors]]
+== Anchors -- Namespace-Scoped Policy
+
+Anchors (decision: link:adr/0007-anchor-scoped-policy.adoc[ADR-0007]) are *named policy scopes
+that own a URL path namespace*. They are declared in `gateway.yaml` and answer one question the
+per-endpoint model cannot: "how is an invariant like _every call under `/api` presents a valid
+bearer token_ declared once and *enforced*, instead of restated in every endpoint file?"
+
+Semantics -- deliberately few rules:
+
+* *Ownership.* Each anchor declares a `path_prefix`; anchor prefixes are pairwise disjoint
+  (no anchor prefix is a prefix of another). The anchor owns everything under its prefix.
+* *Membership: exactly one anchor per route, declared, never derived.* An endpoint file
+  declares `anchor: <name>` as the default for its routes; a route may override it. When any
+  `anchors` block is configured, membership and namespace must agree *both ways*: a route whose
+  declared anchor does not contain its `match.path_prefix` fails the boot, and a route whose
+  path falls inside an anchor namespace without declaring that anchor fails the boot. No
+  `anchors` block => this section does not apply.
+* *Policy blocks.* An anchor may carry `auth`, `security_filter`, `security_headers` and
+  `allowed_methods`. Resolution follows one chain -- *gateway defaults -> anchor -> endpoint ->
+  route* -- and every step *replaces the whole block, never merges* (the same rule as
+  endpoint -> route `auth` today). The chain applies per block *at the scopes where the block
+  exists*: `auth` -> anchor, endpoint, route; `allowed_methods` -> anchor, endpoint (there is
+  no route-level `allowed_methods` -- routes constrain via `match.methods` *within* the
+  effective list); `security_filter` -> anchor, route; `security_headers` -> anchor *only*
+  (below).
+* *`security_headers` resolves at gateway -> anchor level only* -- endpoints and routes cannot
+  override it. Rationale: response headers (and the CORS preflight answer) are emitted
+  *before* route selection, but an anchor is identifiable from the raw path prefix alone -- so
+  stage-0 header preparation and preflight handling use the anchor's block when the request
+  path lies inside an anchor namespace, and the gateway block otherwise (including every
+  pre-routing rejection).
+* *The auth floor cannot be weakened.* Where the anchor declares `require: bearer` or
+  `require: session`, a member whose *effective* auth resolves to `require: none` fails the
+  boot. Replacing one non-`none` posture with another (anchor `bearer`, route `session`) is
+  allowed. Non-auth overrides that relax anchor limits are replacements logged as boot WARNs.
+* *Anchored endpoints may omit `auth`.* The endpoint-level `auth` block becomes optional when
+  the endpoint's anchor declares one; every route must still resolve to an unambiguous
+  effective auth (route, else endpoint, else anchor) or the boot fails.
+* *Anchors vanish at runtime.* They are resolved during route-table assembly into the
+  materialized per-route *effective* values (auth, `allowed_methods`, filter, headers); the
+  request pipeline never consults an anchor. The boot log reports the effective posture per
+  route.
+
+The one modelling consequence: a service exposed on two surfaces -- the same upstream reachable
+under `/api` with bearer *and* under `/bff` with a session -- is *two routes* (in the same
+endpoint file, sharing the `base_url` alias), one per anchor. Multi-anchor membership does not
+exist; it would reintroduce merge-order ambiguity.
+
 == Endpoint Configuration Files (`endpoints/*.yaml`)
 
 One file per endpoint (service / host / app) or logical group. The file binds to a single
@@ -219,17 +290,23 @@ from the topology at startup.
 endpoint:
   id: app1                         # unique endpoint name (mandatory); a duplicate id across
                                    #   endpoint files fails the boot
-  enabled: true                    # default true. false => this endpoint is inert: its routes
-                                   #   are not added to the table and its base_url alias need
-                                   #   not resolve. Overridable per environment by the env var
-                                   #   ENDPOINT_APP1_ENABLED (wins over the file), the same
-                                   #   indirection topology uses
+  enabled: ${ENDPOINT_APP1_ENABLED:-true}   # default true. false => this endpoint is inert:
+                                   #   its routes are not added to the table and its base_url
+                                   #   alias need not resolve. The ${VAR:-default} placeholder
+                                   #   makes the env override visible in-file (ADR-0004 A1);
+                                   #   a plain literal (enabled: true) is equally valid
   base_url: APP1                   # alias; resolved from topology.properties / env
-  auth:                            # MANDATORY: default auth posture for every route in
-    require: bearer                #   this file; a route may override it (below)
-  allowed_methods: [GET, POST]     # optional per-endpoint verb allowlist; REPLACES the global
-                                   #   gateway.allowed_methods wholesale for this endpoint (no
-                                   #   inheritance, no merge). Omit => the global list applies
+  anchor: api                      # anchor membership (see "Anchors"): default for every route
+                                   #   in this file, overridable per route; the route paths must
+                                   #   lie inside the anchor's path_prefix. Mandatory for routes
+                                   #   inside a configured anchor namespace
+  auth:                            # default auth posture for every route in this file; a route
+    require: bearer                #   may override it (below). MANDATORY unless the endpoint's
+                                   #   anchor declares an auth block (see "Anchors")
+  allowed_methods: [GET, POST]     # optional per-endpoint verb allowlist; REPLACES the
+                                   #   anchor/global allowed_methods wholesale for this
+                                   #   endpoint (no inheritance, no merge). Omit => the
+                                   #   anchor's list applies, else the global list
   routes:                          # merged into one table across all endpoint files
                                    #   (see "Route ordering"); no match => 404
     - id: orders-api
@@ -338,11 +415,13 @@ Deny-by-default extends to omitted configuration:
 | Omitted block | Effect
 
 | `auth` (route level)
-| The route inherits the *endpoint's* `auth` block. The authentication posture is defined per
-  endpoint file -- `endpoint.auth` is *mandatory*, and anonymous access is
-  `auth: { require: none }`, written out; there is no implicit default. A route-level `auth`
-  block *replaces* the endpoint default wholesale (no field merging). An endpoint file without
-  an `auth` block fails the boot.
+| The route inherits the *endpoint's* `auth` block (or, when the endpoint omits one, its
+  *anchor's* -- see link:#_anchors[Anchors]). The authentication posture is defined per
+  endpoint file -- `endpoint.auth` is *mandatory unless the endpoint's anchor declares an
+  `auth` block*, and anonymous access is `auth: { require: none }`, written out; there is no
+  implicit default. A route-level `auth` block *replaces* the endpoint/anchor default
+  wholesale (no field merging). An endpoint file with neither its own nor an anchor-provided
+  `auth` block fails the boot.
 
 | `enabled` (endpoint level)
 | The endpoint is *active* (`enabled: true`). Set `false` -- or the env override
@@ -350,29 +429,32 @@ Deny-by-default extends to omitted configuration:
   link:#_endpoint_identity[`endpoint`]).
 
 | `allowed_methods` (endpoint level)
-| The *global* `gateway.allowed_methods` applies (which itself defaults to the standard verb
-  set when omitted). No inheritance/merge -- see link:#_allowed_methods[`allowed_methods`].
+| The *anchor's* `allowed_methods` applies if the route's anchor declares one, else the
+  *global* `gateway.allowed_methods` (which itself defaults to the standard verb set when
+  omitted). No inheritance/merge -- see link:#_allowed_methods[`allowed_methods`].
 
 | `security_filter`
 | The global `security_defaults.profile` applies with the preset's limits.
 
 | `forward`
 | Nothing is forwarded: no request headers and no query parameters cross to the upstream
-  beyond the *automatic* injections (the mediated `Authorization: Bearer` on session routes
-  and the regenerated forwarding-header set -- see `forward` below). A route that needs
-  client input must list it.
+  beyond the *automatic* injections (the mediated `Authorization: Bearer` on session routes,
+  the regenerated forwarding-header set -- see `forward` below -- and, when the route's
+  `not_modified` toggle is enabled, the conditional-request validators, see
+  link:#_upstream_defaults[`upstream_defaults`]). A route that needs client input must list
+  it.
 
 | `rate_limit`
-| No rate limiting (the feature is deferred regardless; the field is reserved).
+| No rate limiting (the feature is out of scope regardless; the field is reserved).
 |===
 
 [[_topology]]
 == Topology (`topology.properties`)
 
-Each `base_url` alias maps to *one URL* -- the concrete location of the current installation. A URL
-is the majority idiom for a human-authored, env-overridden target (12-factor resource handle;
-Traefik `url`, Spring `uri`, Nginx `proxy_pass`); the gateway decomposes it once on load into its
-components. See link:adr/0004-topology-indirection.adoc[ADR-0004].
+Each `base_url` alias maps to *one URL* -- the concrete location of the current installation.
+One atomic URL is the unit of authoring and of override; the gateway decomposes it once on load
+into its components. Rationale and the researched alternatives:
+link:adr/0004-topology-indirection.adoc[ADR-0004].
 
 [source,properties]
 ----
@@ -383,16 +465,19 @@ KEYCLOAK=https://kc.internal:8443
 
 === Environment-variable override (takes precedence)
 
-Any alias may be overridden by an environment variable `TOPOLOGY_<ALIAS>`, which *wins over* the
-file. This lets an operator relocate a backend without touching any file:
+Any alias may be overridden per environment: the entry declares its override point as an
+in-file placeholder (link:adr/0004-topology-indirection.adoc#_amendment_a1[ADR-0004
+Amendment A1]), with the file value as the default and the environment winning when set:
 
-[source,bash]
+[source,properties]
 ----
-TOPOLOGY_APP1=https://app1.mycompany.com
+APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
 ----
 
-Precedence, highest first: `TOPOLOGY_<ALIAS>` env var -> `topology.properties` entry. An alias
-referenced by an endpoint file that resolves to neither is a *boot failure*.
+An operator relocates a backend by setting `TOPOLOGY_APP1=https://app1.mycompany.com` --
+no file edit. Precedence, highest first: the `TOPOLOGY_<ALIAS>` environment variable -> the
+placeholder's default. A `${VAR}` placeholder without a default whose variable is unset, or
+an alias referenced by an endpoint file that resolves to nothing, is a *boot failure*.
 
 === Resolution semantics
 
@@ -404,7 +489,7 @@ referenced by an endpoint file that resolves to neither is a *boot failure*.
   `upstream.path: /orders` therefore reaches `<resolved APP1>/orders/42`.
 * Component overrides (e.g. changing only the port) are intentionally *not* supported initially; the
   whole URL is the unit of override. A `TOPOLOGY_<ALIAS>_PORT`-style escape hatch may be added later
-  if a real partial-override need appears (Kong's component model) -- see
+  if a real partial-override need appears -- see
   link:adr/0004-topology-indirection.adoc[ADR-0004].
 
 == Field Reference
@@ -432,15 +517,18 @@ enablement fields:
   `base_url` alias *need not resolve* -- so an endpoint whose backend is absent in a given
   environment can be shipped in the config set and simply switched off there. A disabled
   endpoint is still *schema-validated* (typos are caught), it is just not activated. Overridable
-  per environment by the environment variable *`ENDPOINT_<ID>_ENABLED`* (`true`/`false`), which
-  *wins over the file value* -- the same file-plus-env-override indirection
-  link:#_topology[topology] uses. `<ID>` is the upper-cased `id` with hyphens mapped to
-  underscores (endpoint `order-api` -> `ENDPOINT_ORDER_API_ENABLED`).
+  per environment via the in-file placeholder form -- `enabled: ${ENDPOINT_ORDER_API_ENABLED:-true}`
+  -- where the environment variable *wins over the placeholder default* (ADR-0004 Amendment A1,
+  the same mechanism link:#_topology[topology] uses). By convention `<ID>` in the variable name
+  is the upper-cased `id` with hyphens mapped to underscores (endpoint `order-api` ->
+  `ENDPOINT_ORDER_API_ENABLED`).
 |===
 
 The endpoint's other fields are documented under their own headings: `base_url`
-(link:#_topology[Topology] / link:adr/0004-topology-indirection.adoc[ADR-0004]), `auth`
-(link:#_auth[`auth`]), `allowed_methods` (link:#_allowed_methods[`allowed_methods`]), and
+(link:#_topology[Topology] / link:adr/0004-topology-indirection.adoc[ADR-0004]), `anchor`
+(link:#_anchors[Anchors] -- the normative reference for both the gateway `anchors` block and
+the endpoint/route `anchor` membership field), `auth` (link:#_auth[`auth`]),
+`allowed_methods` (link:#_allowed_methods[`allowed_methods`]), and
 `routes` (link:#_route_ordering[Route ordering] + the per-route field headings).
 
 === `tls`
@@ -583,7 +671,8 @@ UTF-8, doubled slashes) cannot bypass the allowlist. `/api/orders/{id}` matches
 === `auth`
 
 Whether authentication is required is defined *per endpoint file*: `endpoint.auth` is
-mandatory and is the default posture for every route in the file. A route-level `auth` block
+mandatory (unless the endpoint's anchor declares an `auth` block -- see
+link:#_anchors[Anchors]) and is the default posture for every route in the file. A route-level `auth` block
 replaces the endpoint default wholesale for that route (no field merging). "Effective auth"
 below means the route's own block if present, else the endpoint's. `required_scopes` is valid
 at either level; because override is wholesale, a route-level block that omits it *drops*
@@ -595,7 +684,7 @@ is called out in the boot log, so weakening is always an explicit, audited choic
 |===
 | Value | Behaviour
 
-| `require: none`  | No authentication (e.g. `/health`). Must be written explicitly at the endpoint (or route) level -- an endpoint file without an `auth` block fails the boot (see "Defaults for omitted blocks").
+| `require: none`  | No authentication (e.g. `/health`). Must be written explicitly at the endpoint (or route) level -- an endpoint file without an `auth` block, and without an anchor-provided one, fails the boot (see "Defaults for omitted blocks").
 | `require: bearer`| Offline-validate the incoming `Authorization: Bearer` via `token-sheriff-validation` against the issuers in link:#_token_validation[`token_validation`]; enforce `required_scopes`. link:variants/01-base-gateway.adoc[Variant 1].
 | `require: session`| Require a valid mediated OIDC session per the link:#_oidc[`oidc`] block; inject the token upstream. The BFF variants. An unauthenticated *navigation* request (one that accepts `text/html`, i.e. a browser page load) is redirected into the auth-code flow; any other unauthenticated request (XHR/`fetch`, API clients) receives `401` `application/problem+json` -- redirecting a JSON call is useless to its caller. The distinction is content negotiation, not per-route configuration. `required_scopes` on a session route are enforced against the *mediated* access token's granted scopes -- so they must be requested in `oidc.scopes` at login, or every request on the route fails with `403`.
 |===
@@ -755,11 +844,14 @@ Matchers compose with AND semantics; a route matches only if every declared matc
 === `forward`
 
 Deny-by-default. `headers_allow` / `query_allow` are allowlists; anything not listed is not
-forwarded. `set_headers` adds *static*, gateway-controlled headers. Two injections happen
-*automatically* and are never written in `set_headers`: the mediated `Authorization: Bearer`
-on `require: session` routes (Variants 2/3 -- the gateway sets it from the session's access
-token, and an inbound `Authorization` header from the client is always stripped on those
-routes), and the regenerated forwarding-header set per the `forwarded` policy.
+forwarded. `set_headers` adds *static*, gateway-controlled headers. Three injections happen
+*automatically* and are never written in `set_headers` / `headers_allow`: the mediated
+`Authorization: Bearer` on `require: session` routes (Variants 2/3 -- the gateway sets it
+from the session's access token, and an inbound `Authorization` header from the client is
+always stripped on those routes), the regenerated forwarding-header set per the `forwarded`
+policy, and -- when the route's `not_modified` toggle is enabled -- the conditional-request
+validators `If-None-Match` / `If-Modified-Since`
+(link:#_upstream_defaults[`upstream_defaults`], ADR-0008).
 
 === `upstream`
 
@@ -767,13 +859,14 @@ The target is `resolved(endpoint.base_url) + upstream.path + remainder`, where *
 the request path after stripping the matched `match.path_prefix` -- so path parameters survive
 the mapping (`/api/orders/42` -> `.../orders/42`), and `upstream.path` *replaces* the matched
 prefix rather than prepending to the full request path. Allowed query parameters
-(`forward.query_allow`) are appended unchanged. `connect_timeout_ms` / `read_timeout_ms`
-map to `cui-http` `HttpHandler` (whose builder takes *whole seconds*; a value that is not a
-multiple of 1000 ms -- i.e. does not represent a whole number of seconds -- is rejected at
-boot, fail-fast rather than silently rounded); `retry` maps to `ResilientHttpAdapter` + `RetryConfig`
-(`idempotent_only` retries idempotent methods only -- GET, HEAD, OPTIONS, PUT, DELETE; never
-POST or PATCH). `circuit_breaker` is a small *gateway-side* component wrapped around the
-downstream call -- stateless, per node; `cui-http` supplies retry and timeouts but no breaker
+(`forward.query_allow`) are appended unchanged. `connect_timeout_ms` / `read_timeout_ms` are
+millisecond-precision options on the shared per-upstream-tuple data-plane client
+(link:adr/0008-data-plane-transport.adoc[ADR-0008]). `retry` and `circuit_breaker` map to the
+per-route resilience guard assembled at boot (SmallRye Fault Tolerance, programmatic --
+ADR-0008): retry applies to idempotent methods only (`idempotent_only` -- GET, HEAD, OPTIONS,
+PUT, DELETE; never POST or PATCH) *and* only while no request-body byte has been sent
+upstream; the breaker is stateless per node, opens after `failures` consecutive failures and
+half-opens after `reset_ms`
 (see link:architecture.adoc#_downstream_client[Architecture -- Downstream Client]). The upstream host is never
 written literally here -- only the alias-relative `path`.
 
@@ -795,7 +888,15 @@ pipeline reads a single resolved `true`/`false` and never re-derives the inherit
   see link:#_upstream[`upstream`].
 
 | `not_modified.enabled`
-| Whether the route participates in conditional-request / HTTP `304 Not Modified` handling.
+| End-to-end conditional-request *pass-through* for the route
+  (link:adr/0008-data-plane-transport.adoc[ADR-0008]). *Enabled* (default): the
+  conditional-request headers (`If-None-Match`, `If-Modified-Since`) are implicitly part of
+  the route's effective `forward.headers_allow`, and upstream `304` responses plus the
+  validator response headers (`ETag`, `Last-Modified`) relay untouched. *Disabled*: the
+  validators are stripped in *both* directions, deliberately forcing full `200` exchanges --
+  for upstreams whose ETags are inconsistent across nodes or leak inode/version detail. In
+  *neither* state does the gateway cache response bodies or answer `304` from a cache --
+  gateway-side response caching is rejected by design (ADR-0008).
 |===
 
 *Resolution (wholesale, no merge).* Each route's effective `retry` / `not_modified` toggle is,
@@ -821,10 +922,10 @@ upstream_defaults:
 === `rate_limit`
 
 Reserved schema for per-node, in-memory token-bucket rate limiting
-(`requests_per_second`, `burst`). The feature is *deferred* and not part of the initial
-release (link:features-analysis.adoc[Feature Analysis, Tier 3]); the field is documented so
-the schema need not change when it ships. Until then it is accepted and ignored, and no
-`429` is ever produced.
+(`requests_per_second`, `burst`). The feature is *out of scope* (see
+link:plan/README.adoc[the plan roadmap]); the field is documented only so the schema need not
+change should that decision ever be revisited. It is accepted and ignored, and no `429` is
+ever produced.
 
 === `metadata`
 
@@ -834,8 +935,11 @@ discovery is added later (link:adr/0002-initial-scope.adoc[ADR-0002]).
 
 === `security_headers`
 
-Response-header middleware applied to every response the gateway returns (global; a route
-cannot disable it).
+Response-header middleware applied to every response the gateway returns. Resolved at
+*gateway -> anchor* scope only (an anchor may replace the block wholesale for its namespace --
+see link:#_anchors[Anchors]); endpoints and routes can neither override nor disable it.
+Responses emitted before route selection (CORS preflight, pre-routing rejections) use the
+anchor block when the request path lies inside an anchor namespace, else the gateway block.
 
 [cols="1,3"]
 |===
@@ -870,18 +974,19 @@ The global inbound-filter baseline: `profile` selects the `cui-http` preset
 [[_allowed_methods]]
 === `allowed_methods`
 
-A *positive allowlist of HTTP verbs*, declarable at two scopes -- `gateway.yaml` (global) and
-per `endpoint` -- with *explicit no-inheritance semantics*. It is a coarse, defence-in-depth
-verb gate that sits *above* the per-route `match.methods` matcher: `match.methods` selects which
-route serves a verb; `allowed_methods` decides whether the gateway will serve the verb *at all*
-for that endpoint.
+A *positive allowlist of HTTP verbs*, declarable at three scopes -- `gateway.yaml` (global),
+per link:#_anchors[anchor], and per `endpoint` -- with *explicit no-inheritance semantics*.
+It is a coarse, defence-in-depth verb gate that sits *above* the per-route `match.methods`
+matcher: `match.methods` selects which route serves a verb; `allowed_methods` decides whether
+the gateway will serve the verb *at all* for that endpoint.
 
 *Resolution (no inheritance).* Each route's *effective* `allowed_methods` is materialized once
 at boot:
 
-* the *endpoint's* `allowed_methods` if the endpoint declares one -- it *replaces* the global
-  list wholesale for that endpoint (no merge, no union, no intersection -- exactly the
-  wholesale-replace rule the `auth` block uses); else
+* the *endpoint's* `allowed_methods` if the endpoint declares one -- it *replaces* the
+  anchor/global list wholesale for that endpoint (no merge, no union, no intersection --
+  exactly the wholesale-replace rule the `auth` block uses); else
+* the *anchor's* `allowed_methods` if the route's anchor declares one; else
 * the *global* `gateway.allowed_methods` if declared; else
 * the standard set `{GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS}`.
 
@@ -1008,26 +1113,39 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 * Every `endpoint.id` is unique across all endpoint files (in one file or across files); a
   duplicate endpoint `id` fails the boot.
 * Every route has a unique `id` (across all endpoint files) and a resolvable `endpoint.base_url`.
-* An endpoint is *enabled* unless `enabled: false` (file) or `ENDPOINT_<ID>_ENABLED=false` (env,
-  which wins). A *disabled* endpoint is schema-validated but otherwise inert: its routes are not
-  merged into the table, its `base_url` alias is *exempt* from the resolution requirement below,
-  and it takes no part in the disjointness / passthrough-collision checks.
-* Every `base_url` alias *of an enabled endpoint* resolves via `TOPOLOGY_<ALIAS>` or
-  `topology.properties` to a well-formed URL; otherwise boot fails.
-* Every endpoint file declares an `auth` block (the default posture for its routes); omitting
-  it fails the boot. Routes may override it per route (see "Defaults for omitted blocks").
+* An endpoint is *enabled* unless its resolved `enabled` value is `false` (file literal, or a
+  `${ENDPOINT_<ID>_ENABLED:-...}` placeholder resolved against the environment -- ADR-0004
+  Amendment A1). A *disabled* endpoint is schema-validated but otherwise inert: its routes are
+  not merged into the table, its `base_url` alias is *exempt* from the resolution requirement
+  below, and it takes no part in the disjointness / passthrough-collision checks.
+* Every `base_url` alias *of an enabled endpoint* resolves (after placeholder substitution)
+  to a well-formed URL; otherwise boot fails.
+* Every endpoint file declares an `auth` block (the default posture for its routes) *unless*
+  its anchor declares one (see link:#_anchors[Anchors]); an endpoint with neither fails the
+  boot. Routes may override it per route (see "Defaults for omitted blocks").
+* Anchor `path_prefix` values are pairwise disjoint -- no anchor prefix is a prefix of another;
+  overlap fails the boot.
+* When an `anchors` block is configured: every enabled route's `match.path_prefix` lies inside
+  its *declared* anchor's `path_prefix`, and every enabled route whose path lies inside any
+  anchor's namespace declares exactly that anchor. A membership/namespace mismatch, a missing
+  declaration inside an anchor namespace, or a reference to an undefined anchor fails the boot.
+* Where a route's anchor declares `auth.require` of `bearer` or `session`, the route's
+  *effective* auth must not resolve to `require: none` -- the anchor floor cannot be weakened;
+  violation fails the boot. Non-auth overrides that relax anchor limits are logged as boot
+  WARNs (weakening-override convention).
 * A route whose *effective* auth is `require: bearer` requires a `token_validation` block with
   at least one issuer.
 * A route whose *effective* auth is `require: session` requires an `oidc` block.
 * Any two routes with an identical `match.path_prefix` -- same file or not -- must be statically
   disjoint (both declare different `host` values, or non-overlapping `methods`, or same-name
   header matchers with different exact values); otherwise the boot fails (see "Route ordering").
-* `allowed_methods` (global or endpoint) may list only `GET`, `HEAD`, `POST`, `PUT`, `PATCH`,
-  `DELETE`, `OPTIONS`; listing `TRACE` or `CONNECT` fails the boot. An endpoint `allowed_methods`
-  *replaces* the global list wholesale (no inheritance).
+* `allowed_methods` (global, anchor, or endpoint) may list only `GET`, `HEAD`, `POST`, `PUT`,
+  `PATCH`, `DELETE`, `OPTIONS`; listing `TRACE` or `CONNECT` fails the boot. An endpoint
+  `allowed_methods` *replaces* the anchor/global list wholesale, an anchor's replaces the
+  global (no inheritance).
 * Every method in a route's `match.methods` must be a member of that route's *effective*
-  `allowed_methods` (the endpoint's list if declared, else the global list, else the standard
-  set); a route matching a verb its endpoint forbids fails the boot (see
+  `allowed_methods` (the endpoint's list if declared, else the anchor's, else the global list,
+  else the standard set); a route matching a verb its endpoint forbids fails the boot (see
   link:#_allowed_methods[`allowed_methods`]).
 * A route whose `match.host` equals (case-insensitively) a key in `tls.passthrough_sni`
   fails the boot -- the route and the passthrough declaration contradict each other
@@ -1036,9 +1154,10 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
   base-path; otherwise the boot fails.
 * `forwarded.trusted_proxies` must be present (may be empty = forwarding headers are never
   trusted); the trust-all CIDRs `0.0.0.0/0` *and* `::/0` are rejected as unsafe.
-* `upstream.connect_timeout_ms` / `read_timeout_ms` values wired through the `cui-http`
-  `HttpHandler` must represent a whole number of seconds (multiples of 1000 ms); anything
-  else fails the boot (no silent rounding).
+* `upstream.connect_timeout_ms` / `read_timeout_ms` must be positive integers; they are
+  millisecond-precision options on the data-plane client
+  (link:adr/0008-data-plane-transport.adoc[ADR-0008] dropped the former whole-second
+  restriction, which existed only for the `cui-http` `HttpHandler` builder).
 * Secrets in `oidc` (`client_secret`, the session keys) must be `${ENV_VAR}` references, not
   literals.
 * `session.mode: cookie` requires `session.encryption_key`; `previous_key` is optional and

--- a/doc/features-analysis.adoc
+++ b/doc/features-analysis.adoc
@@ -104,8 +104,10 @@ set of things well, with zero mandatory external dependencies.
   CORS. Cheap, high value, on-brand.
 
 | *Per-route timeouts, retry, circuit breaker*
-| Traefik/KrakenD built-ins. Retry and timeouts are delivered by `cui-http`; the breaker is
-  gateway code -- component ownership is stated in
+| Traefik/KrakenD built-ins. All three are gateway-side per
+  link:adr/0008-data-plane-transport.adoc[ADR-0008]: retry and the breaker are per-route
+  programmatic SmallRye Fault-Tolerance guards (retry stream-aware), timeouts are options on
+  the shared Vert.x data-plane client -- component ownership is stated in
   link:architecture.adoc#_downstream_client[Architecture -- Downstream Client].
 
 | *WebSocket + HTTP/2 + gRPC + GraphQL in OSS, from the start*
@@ -118,17 +120,18 @@ set of things well, with zero mandatory external dependencies.
 | KrakenD (TLS 1.3 default) + Traefik (mTLS, custom certs). Expected of a security gateway.
 |===
 
-=== Tier 3 -- Later
+=== Tier 3 -- Out of Scope (evaluated, not adopted)
 
 [cols="1,3"]
 |===
 | Feature | Rationale
 
 | *Per-node in-memory rate limiting*
-| KrakenD CE / Traefik token-bucket -- explicitly per-node and stateless. Avoid the
-  Redis-backed distributed variant (that is what makes Tyk stateful). The `rate_limit` field
-  is reserved in the link:configuration.adoc[configuration schema] but the feature is
-  *deferred* -- it is not part of the initial release.
+| KrakenD CE / Traefik token-bucket -- explicitly per-node and stateless; the Redis-backed
+  distributed variant is what makes Tyk stateful. Evaluated, and *out of scope* (see the
+  link:plan/README.adoc[plan roadmap]): the `rate_limit` field stays reserved in the
+  link:configuration.adoc[configuration schema] -- accepted and ignored, no `429` is ever
+  produced.
 |===
 
 == Features to Avoid

--- a/doc/plan/01-base-implementation.adoc
+++ b/doc/plan/01-base-implementation.adoc
@@ -92,10 +92,10 @@ status verified as of 2026) condense to:
   static/minimal backends); saturates far above the gateway so the backend never pollutes
   the measurement. JSON-serializing echo servers are wrong for benchmarks.
 
-| *Fault injection (Plan 03)*
+| *Fault injection (Plan 04)*
 | `ghcr.io/shopify/toxiproxy` (pin `2.12.0`) between gateway and upstream
 | L4 toxics (timeout, latency, reset, disable) -- the only option that also faults
-  gRPC/WS/TLS streams; needed for circuit-breaker half-open tests. *Wired in Plan 03*, when
+  gRPC/WS/TLS streams; needed for circuit-breaker half-open tests. *Wired in Plan 04*, when
   the breaker exists; documented here so the compose topology anticipates it.
 
 | *gRPC / GraphQL upstreams (later protocol plans)*
@@ -106,7 +106,7 @@ status verified as of 2026) condense to:
 |===
 
 Keycloak (already present, realm files committed) stays: it becomes the token issuer in
-Plan 03. Testcontainers-based alternatives (dasniko `testcontainers-keycloak`, WireMock
+Plan 04. Testcontainers-based alternatives (dasniko `testcontainers-keycloak`, WireMock
 module, Quarkus `@QuarkusIntegrationTest` resource managers) were evaluated: the existing
 docker-compose approach is kept -- it matches TokenSheriff, gives stable hostnames/certs
 (needed later for SNI passthrough tests), and already has CI wiring. WireMock (JVM-mode unit
@@ -117,7 +117,7 @@ All compose images stay digest/tag-pinned (existing convention).
 === D3 -- Minimal proxy: a Vert.x catch-all route, property-configured
 
 One real end-to-end path, deliberately interim but on the final architecture line
-(link:03-request-pipeline.adoc[Plan 03] keeps the edge, replaces the internals):
+(link:04-request-pipeline.adoc[Plan 04] keeps the edge, replaces the internals):
 
 * A Vert.x route handler (`quarkus-vertx-http`, already present transitively) registered as
   catch-all on the data plane, executing per-request on a *virtual thread*.
@@ -126,11 +126,11 @@ One real end-to-end path, deliberately interim but on the final architecture lin
   `sheriff.proxy.path-prefix` and `sheriff.proxy.upstream-url`.
 * Forwarding: method + path remainder + query + body pass through; hop-by-hop headers
   stripped; JDK `HttpClient` blocking `send()` on the virtual thread (the `cui-http`
-  handler stack arrives with Plan 03's dependency approval). No security stages yet.
+  handler stack arrives with Plan 04's dependency approval). No security stages yet.
 * Unmatched path -> `404` (deny-by-default from day one).
 * The placeholder `/api/health` + `/api/info` endpoints and their tests remain for now
   (health is used by scripts/benchmarks); `ApiSheriff`/`GatewayResource` are deleted in
-  Plan 03.
+  Plan 04.
 * Rename the virtual-thread prefix from `jwt-validation` to `api-sheriff`.
 
 No new Maven dependencies are needed for this plan (Vert.x HTTP and JDK HttpClient are
@@ -143,9 +143,9 @@ already available).
   (Docker required), `./mvnw clean verify -pl benchmarks -Pbenchmark`. Fix anything red
   *before* changing behaviour, so regressions are attributable.
 . *Housekeeping* -- delete `TestDataGenerator` + the `generators` test-jar wiring (or keep
-  the wiring only if Plan 03 will publish real generators -- decide then; delete now),
+  the wiring only if Plan 04 will publish real generators -- decide then; delete now),
   `test-jwks.json`, unused PEM files, the empty stub `application.properties`; fix or delete
-  `benchmark-with-monitoring.sh` (it greps `jwt`/JMH -- delete, it returns with Plan 03's
+  `benchmark-with-monitoring.sh` (it greps `jwt`/JMH -- delete, it returns with Plan 04's
   benchmarks if needed); prune unused test dependencies flagged by the build. Pre-1.0 rule:
   remove, never deprecate.
 . *Parent + native alignment (D1)* -- `cui-java-parent` 1.4.5 -> 1.5.0; Mandrel builder
@@ -209,9 +209,9 @@ must be green after every one.
 
 * Real configuration files/schemas (Plan 02, delivered).
 * Security filtering, token validation, forward policy, events/metrics/error contract
-  (link:03-request-pipeline.adoc[Plan 03]).
+  (link:04-request-pipeline.adoc[Plan 04]).
 * gRPC/WebSocket/GraphQL processors, TLS passthrough, mTLS, BFF variants (later plans).
-* Toxiproxy wiring (arrives with the circuit breaker in Plan 03).
+* Toxiproxy wiring (arrives with the circuit breaker in Plan 04).
 
 [[_post_merge_amendments]]
 == Post-Merge Amendments

--- a/doc/plan/03-endpoint-anchors.adoc
+++ b/doc/plan/03-endpoint-anchors.adoc
@@ -1,0 +1,230 @@
+= Plan 03 -- Endpoint Anchors (Namespace-Scoped Policy)
+:toc:
+:toclevels: 3
+:sectnums:
+
+[IMPORTANT]
+====
+*Ordering: this plan must land before link:04-request-pipeline.adoc[Plan 04 -- Request
+Pipeline].* Anchors are a boot-time concept that changes what the route table materializes;
+retrofitting namespace enforcement after the request pipeline freezes route selection is
+substantially harder.
+====
+
+== Goal
+
+Implement *anchors* as decided in link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007] and
+specified in link:../configuration.adoc#_anchors[Configuration Model -- Anchors]: named policy
+scopes in `gateway.yaml` that own disjoint URL path namespaces (`/api`, `/bff`, ...), carry
+policy blocks (`auth`, `security_filter`, `security_headers`, `allowed_methods`) inherited by
+member endpoints/routes with wholesale-replacement semantics, and are enforced and fully
+materialized at boot. Additionally (D4), replace the convention-named, Java-class-level env
+overrides with one transparent in-file `${ENV_VAR}` / `${ENV_VAR:-default}` substitution
+mechanism across all three config artifacts. At the end of this plan the configuration
+subsystem is *feature-complete for anchors and substitution*: parsed, validated, resolved into
+the `RouteTable`'s effective per-route values, and invisible at runtime.
+
+== Required Reading (before implementation)
+
+Read these documents *in full* before touching code; the semantics are specified there, not
+here:
+
+. link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007] -- the decision, the research behind it,
+  and the non-negotiables (single membership, no merge, non-weakenable auth floor, boot-time
+  erasure).
+. link:../configuration.adoc[Configuration Model] -- the
+  link:../configuration.adoc#_anchors[Anchors] section, the updated `gateway.yaml` and
+  endpoint exhibits, and the updated
+  link:../configuration.adoc#_configuration_validation_rules_summary[validation-rules summary].
+. Plan 02 (delivered; document archived under
+  `.plan/local/archived-plans/2026-07-13-implement-configuration-management/`) -- the config
+  subsystem this plan extends: loading pipeline, `ConfigValidator` conventions
+  (collect *all* violations), `RouteTableBuilder` materialization, fail-fast CDI wiring.
+. link:../architecture.adoc[Architecture], section "Configuration Subsystem" -- immutability
+  as a security property, refuse-to-start semantics.
+
+== Prerequisites
+
+* Plan 02 delivered (it is): schemas, loader, `ConfigValidator`, `RouteTable`, fail-fast boot.
+* The Plan-02 landing-gap fixes (separate plan, in flight). *Coordination note:* that plan
+  wires `EndpointEnablementResolver` into the producer; D4 below *replaces* the
+  convention-named env-override mechanism entirely (the resolver classes' env lookups are
+  removed). If this plan starts before the gap-fix plan merges, drop the enablement-wiring
+  item there instead of wiring code D4 deletes.
+
+== Design Decisions
+
+Decided in ADR-0007 / the configuration doc; restated here only as implementation directives.
+
+=== D1 -- Schema changes
+
+* `gateway.schema.json`: new optional `anchors` object -- map of anchor name
+  (`[a-z][a-z0-9_-]*`) to `{path_prefix (required), auth, security_filter, security_headers,
+  allowed_methods}`, `additionalProperties: false` at every level; the policy sub-blocks reuse
+  the exact structures already defined for their endpoint/route counterparts (extract shared
+  `$defs` rather than duplicating).
+* `endpoint.schema.json`: new optional `anchor` string on the `endpoint` block and on each
+  route; `auth` on the `endpoint` block changes from required to optional (its
+  conditional mandatoriness moves to the cross-cutting validator, which can see the anchor).
+
+=== D2 -- Model and resolution
+
+* New record `AnchorConfig` (name, pathPrefix, optional policy blocks) under
+  `config.model`; `GatewayConfig` gains `Map<String, AnchorConfig> anchors` (empty map when
+  absent). `EndpointConfig` and `RouteConfig` gain `Optional<String> anchor`.
+* Resolution lives where effective values already live: `RouteTableBuilder` resolves the
+  chain gateway -> anchor -> endpoint -> route per block (wholesale replacement) and
+  materializes the results into `ResolvedRoute`. This extends the existing effective-auth and
+  effective-`allowed_methods` materialization with effective `security_filter` and
+  `security_headers`; the pipeline (Plan 04) reads only the materialized `ResolvedRoute`
+  values (compiled into its own `RouteRuntime`), never an anchor.
+* Boot log: on success, report per route the effective posture (anchor name, effective
+  `auth.require`, filter profile) at INFO -- one line per route, the discoverability
+  requirement from ADR-0007.
+
+=== D3 -- Validation rules (ConfigValidator, all-violations convention)
+
+One rule per bullet, mirroring the updated validation-rules summary:
+
+. anchor-prefix disjointness (no anchor prefix is a prefix of another);
+. declared anchor exists;
+. route path inside its declared anchor's prefix;
+. no undeclared squatter: an enabled route whose path lies inside any anchor namespace must
+  declare that anchor;
+. auth-floor: effective `require: none` under an anchor requiring `bearer`/`session` fails;
+. endpoint-auth conditional mandatoriness: endpoint without `auth` and without an
+  anchor-provided `auth` fails;
+. effective-auth completeness re-checked against the extended chain (the existing
+  effective-auth -> `token_validation`/`oidc` rules now consider anchor-provided auth).
+
+Weakening non-auth overrides (route filter limits above anchor limits, etc.) follow the
+existing boot-WARN convention in `RouteTableBuilder`.
+
+=== D4 -- Unified `${ENV_VAR}` substitution replaces convention-named env overrides
+
+Today the environment can override configuration through two *invisible* channels implemented
+at the Java-class level: `TOPOLOGY_<ALIAS>` (ADR-0004) and `ENDPOINT_<ID>_ENABLED` -- naming
+conventions a reader cannot discover from the files they affect. The gateway always runs in a
+container, so env override is the normal case, not the exception -- it must be *transparent in
+the artifact*, not folklore in resolver code.
+
+Decision:
+
+* *One substitution mechanism* for all three artifacts (`gateway.yaml`, `endpoints/*.yaml`,
+  `topology.properties`), shell-style, resolved *once* on the parsed scalar values *before*
+  schema validation:
+** `${VAR}` -- required; an unset variable fails the boot (the existing secrets semantics,
+   unchanged);
+** `${VAR:-default}` -- optional override; the literal default applies when the variable is
+   unset. This is the form that expresses "file value as default, environment wins" -- the
+   role the convention-named overrides played, now visible in place:
++
+[source,yaml]
+----
+enabled: ${ENDPOINT_APP1_ENABLED:-true}
+----
++
+[source,properties]
+----
+APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
+----
+* *The convention-named Java-level lookups are removed* (`TOPOLOGY_<ALIAS>` inside
+  `TopologyResolver`, the `ENDPOINT_<ID>_ENABLED` machinery). The familiar variable *names*
+  survive as a documented convention in the sample configs; the *mechanism* is the visible
+  placeholder.
+* *Validation operates on the resolved document.* Substitution happens before schema
+  validation and before every cross-cutting rule, so an env-supplied value cannot bypass the
+  anchor auth floor, the secrets rule, or any other check -- and a substitution producing a
+  type-invalid value fails the schema gate with the usual file/pointer error.
+* *Secrets rule unchanged*: fields classified as secrets must still be `${VAR}` references
+  (no default, no literal).
+* *Doc-first cascade (same PR)*: amend link:../adr/0004-topology-indirection.adoc[ADR-0004]
+  (the single-URL-per-alias decision *stands*; the override channel changes from convention
+  env var to in-file placeholder) and rewrite the affected `configuration.adoc` passages
+  (topology env-override section, endpoint `enabled` comment, validation-rules bullets that
+  name `TOPOLOGY_<ALIAS>` / `ENDPOINT_<ID>_ENABLED`).
+
+== Work Breakdown
+
+. *Schemas* (D1) -- extend both schema files; refactor shared block definitions into `$defs`.
+  Review field-by-field against link:../configuration.adoc[the doc]; the doc governs.
+. *Model records* (D2) -- `AnchorConfig`, extended `GatewayConfig`/`EndpointConfig`/
+  `RouteConfig`/`ResolvedRoute`; contract tests via the established `cui-test-value-objects` /
+  `cui-test-generator` patterns; `package-info.java` untouched packages excepted.
+. *Loader* -- bind the new blocks; no new pipeline stages (anchors ride the existing
+  gateway.yaml parse).
+. *`${ENV_VAR}` substitution* (D4) -- generalize the existing secret resolver into the single
+  pre-schema substitution pass (`${VAR}` required / `${VAR:-default}` optional) over all three
+  artifacts; remove the convention-named env lookups (`TOPOLOGY_<ALIAS>` in `TopologyResolver`,
+  the `ENDPOINT_<ID>_ENABLED` machinery). Tests: default applies when unset, env wins when
+  set, unset-without-default fails boot, substitution result is schema-type-checked, secret
+  fields still reject literals and defaults.
+. *Validator rules* (D3) -- each rule with valid + violating fixtures; all violations
+  collected in one pass with file/pointer context, per the Plan 02 convention.
+. *RouteTable materialization* (D2) -- chain resolution, effective-value materialization,
+  weakening WARNs, per-route effective-posture INFO log (new LogRecord, documented in
+  `doc/LogMessages.adoc`).
+. *Sample configs* -- extend `api-sheriff/src/test/resources/config/` sets and the runnable
+  `integration-tests/src/main/docker/sheriff-config/` example with an `anchors` block
+  (`api` + `bff`) and anchored endpoint files; keep the anchor-less variants as fixtures for
+  the "no anchors configured => unchanged" path.
+. *Tests* -- beyond per-rule fixtures: a Quarkus fail-fast test for an anchor violation
+  (squatter route) asserting refused boot; property-based `@GeneratorsSource` tests for
+  namespace containment/disjointness permutations; an assertion that `ResolvedRoute` carries
+  anchor-derived effective values with route-level overrides winning.
+. *Integration test* -- the mounted example config uses anchors; the existing routed-request
+  IT keeps passing (proving materialization is behaviour-neutral for a conforming config);
+  extend the negative script check (`verify-invalid-config-fails.sh`) with an anchor-violation
+  config variant.
+. *Docs & cleanup* -- the D4 doc-first cascade (ADR-0004 amendment, `configuration.adoc`
+  override passages); `doc/LogMessages.adoc` for the new records; verify the
+  link:../configuration.adoc#_anchors[Anchors] section, exhibits, field reference, and
+  validation summary match the implementation field-for-field (the doc changes landed with
+  ADR-0007; fix the *doc* in the same PR if implementation review finds a gap). Flip ADR-0007
+  to `Accepted` in the same PR that merges the implementation.
+. *(Optional, if time permits)* -- start an operator-facing configuration guide (there is
+  none today; `doc/configuration.adoc` is design-level). A thin "configuring API Sheriff"
+  walkthrough seeded from the sample config set; may be split out.
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-03-endpoint-anchors`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+== Acceptance Criteria
+
+* Both schemas validate the new blocks; an unknown key inside `anchors` fails the boot.
+* All seven D3 rules enforced with at least one negative test each; violations reported
+  together with file/pointer context in one pass.
+* `ResolvedRoute` carries anchor-derived effective auth, methods, filter, and headers;
+  route/endpoint overrides replace wholesale; the auth floor is non-weakenable (negative test).
+* A config *without* an `anchors` block behaves exactly as before (regression suite green,
+  anchor-less fixtures untouched).
+* Per-route effective-posture INFO log emitted and documented in `doc/LogMessages.adoc`.
+* `${VAR}` / `${VAR:-default}` substitution works across all three artifacts with the D4 test
+  matrix green; no convention-named env lookup remains in Java code (grep for
+  `TOPOLOGY_`/`ENDPOINT_` env access is clean); ADR-0004 amended and `configuration.adoc`
+  consistent with the placeholder mechanism.
+* `./mvnw -Ppre-commit clean verify -DskipTests` and `./mvnw clean install` pass; coverage of
+  the changed `config` packages >= 80%; integration tests (including the anchor-violation
+  negative script) pass locally and on CI.
+* ADR-0007 status flipped to Accepted.
+
+== Out of Scope
+
+* *Consuming* the materialized `security_filter` / `security_headers` values at runtime --
+  that is Plan 04's pipeline; this plan only guarantees they are resolved and carried.
+* Anchor-level `forward` policy, rate limits, or any block not listed in D1 (add later only
+  with a doc-first change).
+* Multi-anchor membership, anchor nesting/composition, derived (undeclared) membership --
+  rejected by ADR-0007, not deferred.
+* Dynamic configuration (ADR-0002).

--- a/doc/plan/04-request-pipeline.adoc
+++ b/doc/plan/04-request-pipeline.adoc
@@ -1,4 +1,4 @@
-= Plan 03 -- Request Pipeline
+= Plan 04 -- Request Pipeline
 :toc:
 :toclevels: 3
 :sectnums:
@@ -20,8 +20,8 @@ the event system, metrics, structured logging, and the RFC 9457 error contract.
   security filter wiring, routing, authentication layer, forward policy, downstream client,
   event system, error contract, metrics, threading model.
 . link:../variants/01-base-gateway.adoc[Variant 1 -- Base Security Gateway] -- request flow,
-  responsibilities, offline validation wiring (incl. the 4-arg `AccessTokenRequest.of(...)`
-  DPoP requirement).
+  responsibilities, offline validation wiring (incl. the 4-component `AccessTokenRequest`
+  constructor -- URI + method are mandatory for DPoP; the `of(...)` factories omit them).
 . link:../configuration.adoc[Configuration Model] -- sections `security_filter`, `auth`,
   `token_validation`, `match`, `forward`, `upstream`, `forwarded`, `security_headers`.
 . link:../adr/0003-forwarded-headers.adoc[ADR-0003] -- forwarding-header posture; note the
@@ -29,22 +29,32 @@ the event system, metrics, structured logging, and the RFC 9457 error contract.
 . link:../adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006] -- stream data-plane bodies
   (never materialize the proxied body into `HttpResult<byte[]>`); `max_body_bytes` as a
   streaming counter. Governs the dispatch/response stages.
+. link:../adr/0008-data-plane-transport.adoc[ADR-0008] -- the data-plane transport is the
+  Vert.x `HttpClient` (shared per upstream tuple); resilience is per-route SmallRye Fault
+  Tolerance guards with the stream-aware retry gate; gateway-side response caching is
+  rejected; `not_modified.enabled` = conditional pass-through. Governs stages 5-7.
 . link:../architecture.adoc#_performance_object_reuse[Architecture -- Object Reuse] +
   link:../adr/0005-module-structure.adoc[ADR-0005] -- assemble heavy objects once at boot and
-  share the immutable instances (dedup `SecurityConfiguration`/`HttpHandler`); keep the
+  share the immutable instances (dedup `SecurityConfiguration` / the per-upstream-tuple
+  Vert.x client); keep the
   framework-agnostic pipeline packages free of CDI/Vert.x imports (arch-gate).
 . link:../technical_aspects.adoc[Technical Aspects] -- the concrete `cui-http` and
   `token-sheriff-validation` APIs (pipelines, `SecurityConfiguration`,
-  `ForwardedHeaderResolver`/`ResolvedForwarding`, `HttpHandler`/`HttpResult`,
-  `TokenValidator`).
+  `ForwardedHeaderResolver`/`ResolvedForwarding`, `TokenValidator`;
+  `HttpHandler`/`HttpResult` are control-plane/JWKS only -- the data-plane transport is the
+  Vert.x client, ADR-0008).
 . `cui-http/doc/forwarded-header-resolution.adoc` (in the cui-http repository) -- the
   authoritative resolver behaviour contract.
 . Plan 02 (delivered) -- the `GatewayConfig`/`RouteTable` model this plan consumes.
+. link:03-endpoint-anchors.adoc[Plan 03] + link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007]
+  -- anchors are erased into the materialized per-route effective values at boot; the pipeline
+  reads only those effective values (materialized into `ResolvedRoute`, compiled into this
+  plan's `RouteRuntime`) and must never consult an anchor.
 
 == Prerequisites
 
-* Plans 01 and 02 delivered: green builds, config subsystem produces `GatewayConfig` +
-  `RouteTable`.
+* Plans 01, 02 and 03 delivered: green builds, config subsystem produces `GatewayConfig` +
+  `RouteTable` with anchor-derived effective values materialized per route.
 
 == Design Decisions
 
@@ -58,11 +68,13 @@ released 2.0.0 jar*. This plan therefore pins `cui-http:2.1`.
 ====
 Dependency changes -- *require explicit user approval before adding*:
 
-* `de.cuioss:cui-http:2.1` (security pipelines, forwarded resolver, HttpHandler
-  stack).
-* `de.cuioss.sheriff.token:token-sheriff-validation-quarkus:1.0.0-SNAPSHOT` (direct; core
-  `token-sheriff-validation` arrives transitively). Same snapshot caveat -- TokenSheriff is
-  unreleased.
+* `de.cuioss:cui-http:2.1` (inbound security pipelines, forwarded resolver; its client stack
+  serves the control plane only -- ADR-0008).
+* `de.cuioss.sheriff.token:token-sheriff-validation-quarkus:0.9.1` (direct; core
+  `token-sheriff-validation` arrives transitively). 0.9.1 is the released TokenSheriff line --
+  no snapshot repository needed.
+* `io.quarkus:quarkus-smallrye-fault-tolerance` (version from the Quarkus BOM) -- the
+  programmatic per-route resilience guards of ADR-0008.
 
 The BFF engine modules (`token-sheriff-client*`) are *not* added here -- they belong to the
 later variant plans.
@@ -112,9 +124,9 @@ inbound request (virtual thread)
      violation -> 400 problem+json, INPUT_VALIDATION event                   [stage 1]
   2. ROUTE SELECTION: RouteTable candidate match (path prefix AND methods AND
      host AND headers), longest prefix wins; no candidate -> 404             [stage 2]
-  2b. VERB GATE: matched route's effective allowed_methods (endpoint list, else
-      global, else standard set -- materialized at boot); method outside it ->
-      405 + Allow header, INPUT_VALIDATION event                             [stage 2b]
+  2b. VERB GATE: matched route's effective allowed_methods (the anchor-aware
+      effective set materialized at boot into ResolvedRoute); method outside
+      it -> 405 + Allow header, INPUT_VALIDATION event                       [stage 2b]
   3. THOROUGH CHECKS (route's optional `security_filter`, cui-http):
      - per-route SecurityConfiguration (profile + explicit overrides) pipelines,
        re-run only when they differ from the stage-1 defaults
@@ -128,22 +140,28 @@ inbound request (virtual thread)
   4. AUTHENTICATION (effective auth):
      - require: none    -> pass
      - require: bearer  -> TokenValidator.createAccessToken(
-                             AccessTokenRequest.of(token, headers, uri, method))
+                             new AccessTokenRequest(token, headers, uri, method))
                            401 on missing/invalid (+ WWW-Authenticate: Bearer);
                            providesScopes(required) -> 403 SCOPE_MISSING
      - require: session -> boot-time rejection in this plan (variant plans)  [stage 4]
   5. FORWARD POLICY (zero-trust):
      - headers_allow / query_allow filtering; set_headers appended
+     - not_modified pass-through (ADR-0008): when the route's effective toggle is
+       enabled, If-None-Match / If-Modified-Since join the effective allowlist;
+       when disabled, request conditionals are dropped here and ETag/Last-Modified
+       are stripped from the response at stage 7
      - forwarded handling: gateway-side TCP-peer gate against
        forwarded.trusted_proxies FIRST, then ForwardedHeaderResolver.resolve(...),
        emit regenerated toXForwardedHeaders() (+ toForwardedHeader() when
        emit: both); inbound forwarding headers never propagated
      - inbound Authorization stripped unless explicitly allow-listed         [stage 5]
-  6. DISPATCH: upstream URL = resolved(base_url) + upstream.path + remainder
-     + allowed query; shared per-upstream-tuple HttpHandler (timeouts) wrapped
-     in ResilientHttpAdapter (retry, idempotent-only) wrapped in the gateway
-     circuit breaker; request body STREAMED to the upstream (never buffered),
-     the max_body_bytes streaming counter enforcing here -- a breach mid-stream
+  6. DISPATCH (ADR-0008): upstream URL = resolved(base_url) + upstream.path +
+     remainder + allowed query; the shared per-upstream-tuple Vert.x HttpClient
+     (millisecond connect/read timeouts as client options), invoked through the
+     route's SmallRye FT guard (retry attempts + circuit breaker); the retry gate
+     is stream-aware -- idempotent method AND zero body bytes sent, else no
+     retry; request body STREAMED to the upstream (never buffered), the
+     max_body_bytes streaming counter enforcing here -- a breach mid-stream
      ABORTS the in-flight upstream call (400, INPUT_VALIDATION);
      failure mapping per the error contract
      (502 / 503 breaker-open + Retry-After / 504 timeout)                    [stage 6]
@@ -184,17 +202,28 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 == Work Breakdown
 
 . *Dependencies* (after approval): cui-http 2.1,
-  token-sheriff-validation-quarkus 1.0.0-SNAPSHOT; verify CI snapshot resolution first.
+  token-sheriff-validation-quarkus 0.9.1 (released), quarkus-smallrye-fault-tolerance
+  (Quarkus BOM).
+. *Arch-gate* (ADR-0005 -- mandatory from this first pipeline PR): the ArchUnit rule
+  asserting the framework-agnostic packages (`config.model`, `config.validation`, `events`,
+  `routing`, `forward`, `pipeline`) carry no `io.quarkus..`, `io.vertx..`,
+  `jakarta.enterprise..`, `jakarta.inject..`, `org.eclipse.microprofile..`, or
+  `io.micrometer..` import, wired into the quality gate.
 . *Event system + error edge* (D4) -- pure unit-tested base package first; problem+json
   rendering tests for every row of the error-contract table.
 . *RouteRuntime assembly* -- boot-time compilation of `RouteTable` into runtime objects:
   matchers, the effective `allowed_methods` verb set, per-route `SecurityConfiguration`/pipelines,
-  forward sets, `HttpHandler` + `ResilientHttpAdapter` chain, circuit breaker, protocol processor
-  lookup, weakening-override boot WARNs. *Deduplicate shared heavy objects* per
+  forward sets, the shared data-plane Vert.x `HttpClient` reference plus the per-route
+  SmallRye FT guard (ADR-0008; verify the exact programmatic surface --
+  `Guard`/`TypedGuard`, `CircuitBreakerMaintenance` state hooks -- against the shipped
+  extension), the shared `ForwardedHeaderResolver`, protocol processor lookup,
+  weakening-override boot WARNs. *Deduplicate shared heavy objects* per
   link:../architecture.adoc#_performance_object_reuse[Architecture -- Object Reuse]: one
-  `SecurityConfiguration`/pipeline set per distinct profile shape, one `HttpHandler` (+ pooled
-  client) per distinct upstream-target tuple -- routes sharing a shape/target share the instance,
-  not a copy. Boot-time rejection of `grpc`/`websocket`/`session` (this plan's scope guard).
+  `SecurityConfiguration`/pipeline set per distinct profile shape, one Vert.x client
+  (+ connection pool) per distinct upstream-target tuple -- routes sharing a shape/target
+  share the instance, not a copy. Boot-time rejection of `grpc`/`websocket`/`session` (this
+  plan's scope guard). Remove the whole-second-timeout `ConfigValidator` rule and its tests
+  (obsolete per ADR-0008 -- millisecond timeouts are native now).
 . *Stages 0-3* -- security headers + CORS preflight, basic pipelines, route selection, the
   `allowed_methods` verb gate (stage 2b -> 405 + `Allow`), thorough checks, allowed_paths
   matcher, body cap. Unit tests use the cui-http *attack databases* (`OWASPTop10AttackDatabase`,
@@ -208,12 +237,16 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 . *Stage 5* -- forward-policy filtering; TCP-peer gate + resolver wiring + regeneration
   (assert: spoofed inbound `X-Forwarded-For` from a non-trusted peer is ignored; chains are
   regenerated, never appended).
-. *Stage 6 + 7* -- dispatch, hop-by-hop header stripping, *body streaming with backpressure*
-  (Vert.x `ReadStream.pipeTo`/`Pipe` in both directions -- no `HttpResult<byte[]>`
-  materialization of the proxied body, per ADR-0006), circuit breaker (unit-test state machine:
-  closed -> open after N failures -> half-open after reset_ms), timeout/retry mapping to
-  504/502/503. Tests: assert a large response streams (first byte before last, bounded memory)
-  and that `max_body_bytes` aborts mid-stream without buffering the whole body.
+. *Stage 6 + 7* -- dispatch via the shared Vert.x client through the route's FT guard,
+  hop-by-hop header stripping, *body streaming with backpressure* (Vert.x
+  `ReadStream.pipeTo`/`Pipe` in both directions -- no `HttpResult<byte[]>` materialization of
+  the proxied body, per ADR-0006/0008), breaker behaviour (closed -> open after N failures ->
+  half-open after reset_ms, transitions logged + metered), timeout/retry mapping to
+  504/502/503, `not_modified` pass-through/strip per ADR-0008. Tests: a large response
+  streams (first byte before last, bounded memory); `max_body_bytes` aborts mid-stream
+  without buffering the whole body; the retry gate never re-sends after the first body byte
+  (assert via upstream request counting); `304` relays untouched on an enabled route;
+  `ETag`/`If-None-Match` are stripped both ways on a disabled route.
 . *Vert.x edge* -- catch-all route, virtual-thread dispatch, wire stages; delete the Plan 01
   placeholder resource/tests.
 . *Metrics + readiness* (D4/D5) -- meter binding, health checks; assert metric presence in
@@ -237,7 +270,7 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-03-request-pipeline`.
+. Create a feature branch from up-to-date `main`: `feature/plan-04-request-pipeline`.
 . Implement the work breakdown above.
 . Verify everything locally -- both must pass with zero errors/warnings:
   `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
@@ -263,6 +296,8 @@ must be green after every one.
 * Bearer validation works offline against Keycloak-issued tokens in ITs; upstream is never
   called on any rejection (assert via echo-side request counting).
 * Metrics/eventing surface matches the names in `architecture.adoc`.
+* The ADR-0005 arch-gate rule exists, runs in the quality gate, and fails on a deliberate
+  violation (verified once, then reverted).
 * `./mvnw -Ppre-commit clean verify -DskipTests`, `./mvnw clean install`, integration-tests
   profile, and the benchmark profile all pass locally and on CI; coverage >= 80% on new
   packages.

--- a/doc/plan/05-protocol-processors.adoc
+++ b/doc/plan/05-protocol-processors.adoc
@@ -1,0 +1,135 @@
+= Plan 05 -- Protocol Processors (WebSocket + gRPC)
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Replace Plan 04's boot-time rejections for `protocol: websocket` and `protocol: grpc` with
+real processors: WebSocket upgrade proxying (the full pipeline applied to the handshake, then
+bidirectional stream relay) and gRPC proxying over upstream HTTP/2 including trailer relay
+(`grpc-status`). Both ride the ADR-0008 Vert.x transport, which was chosen precisely for
+upgrade streams and trailers. GraphQL needs nothing here -- it reuses the HTTP processor
+(Plan 04). Completing this plan closes the link:../adr/0002-initial-scope.adoc[ADR-0002]
+protocol promise and, with it, the link:../variants/01-base-gateway.adoc[Variant 1] scope.
+
+== Required Reading (before implementation)
+
+. link:../architecture.adoc#_protocol_support[Architecture -- Protocol Support] -- the
+  per-protocol handling table: handshake-time auth for WebSocket, HTTP/2-metadata-only
+  handling for gRPC (no protobuf inspection), the L4/L7 passthrough boundary.
+. link:../adr/0008-data-plane-transport.adoc[ADR-0008] -- the Vert.x client provides the
+  upgrade streams and trailer relay this plan depends on.
+. link:../configuration.adoc[Configuration Model], section "Protocols" -- the per-route
+  `protocol` enum semantics.
+. Plan 04 (delivered by then) -- the `ProtocolProcessor` registry and the stage pipeline the
+  processors slot into.
+
+== Prerequisites
+
+* Plan 04 delivered: the pipeline runs HTTP routes end-to-end; `grpc`/`websocket` routes are
+  boot-rejected by the registry this plan extends.
+
+== Design Decisions
+
+=== D1 -- WebSocket processor: full pipeline on the handshake, opaque relay after 101
+
+* The upgrade request is an ordinary HTTP request until `101`: stages 0-5 apply unchanged --
+  basic checks, route selection, verb gate, thorough checks, *authentication on the
+  handshake* (effective auth; `bearer` now, `session` works automatically once Plan 07
+  lands), zero-trust forward policy on the handshake headers.
+* After the upstream confirms the upgrade, the established stream is relayed bidirectionally
+  (Vert.x WebSocket/`NetSocket` pipes with backpressure, both directions). *No per-message
+  filtering* -- the security filter operates on HTTP metadata only
+  (architecture doc); `max_body_bytes` does not apply to frames. Close frames and ping/pong
+  relay transparently; a half-close on either side closes both.
+* Upgrade failure mapping: upstream refuses the upgrade -> the refusal status relays;
+  upstream unreachable -> the standard `502`/`504` contract *before* `101`.
+
+=== D2 -- gRPC processor: HTTP/2 metadata proxying with trailer relay
+
+* gRPC is the HTTP processor plus three deltas: the upstream connection must be HTTP/2
+  (`h2`/`h2c` via the shared per-tuple Vert.x client), response *trailers* relay to the
+  client (`grpc-status`/`grpc-message` live there), and request/response bodies stream as
+  opaque length-prefixed frames (no protobuf inspection -- explicitly out of scope).
+* *Gateway-rejection mapping for gRPC routes*: a gRPC client cannot consume
+  `application/problem+json`. Rejections on `protocol: grpc` routes are emitted as
+  trailers-only gRPC responses with the canonical mapping -- `UNAUTHENTICATED` (401),
+  `PERMISSION_DENIED` (403), `NOT_FOUND`/`UNIMPLEMENTED` (404/405), `INVALID_ARGUMENT`
+  (400), `UNAVAILABLE` (502/503), `DEADLINE_EXCEEDED` (504). *Doc-first*: this mapping is
+  added to the link:../architecture.adoc#_error_contract[error contract] in the same PR --
+  the doc governs.
+* Streaming RPCs (client-, server-, bidi-streaming) need no special handling beyond
+  streaming both directions without buffering -- which is the ADR-0006/0008 default.
+
+=== D3 -- Test upstreams
+
+Per Plan 01 D2 research: WebSocket ITs use go-httpbin's `/websocket/echo` (already in the
+compose stack). gRPC ITs use a *tiny in-repo Quarkus gRPC echo service* under
+`integration-tests/` (reactor-built, ~50 lines; `moul/grpcbin` is dead) exposing unary +
+server-streaming echo methods, plus an intentionally failing method for trailer/status relay
+assertions.
+
+== Work Breakdown
+
+. *WebSocket processor* (D1) -- handshake-through-pipeline, relay, close semantics; unit
+  tests for auth-on-handshake (401 before upgrade, upstream never dialed), forward-policy
+  filtering of handshake headers, relay in both directions.
+. *gRPC processor* (D2) -- h2 upstream enforcement (boot error when the resolved alias
+  cannot speak h2 where declared), trailer relay, the rejection-mapping table; unit tests
+  per mapping row.
+. *Error-contract doc update* (D2, same PR) -- the gRPC status mapping into
+  `architecture.adoc`; new LogRecords into `doc/LogMessages.adoc`.
+. *gRPC echo upstream* (D3) -- the in-repo echo service, wired into docker-compose with a
+  healthcheck.
+. *Integration tests* (per the link:README.adoc[convention]: complete in this plan) --
+  WebSocket: authenticated echo round-trip through the gateway, unauthenticated handshake
+  rejected `401` before any upstream contact, unmatched WS path `404`; gRPC: unary + streaming
+  echo through the gateway with metadata injection asserted, `grpc-status` relay from the
+  failing method, `UNAUTHENTICATED` trailers-only rejection on a bearer gRPC route without a
+  token.
+. *Benchmarks* (README convention) -- a WebSocket echo benchmark (connection + message
+  round-trip throughput through the gateway vs. direct-to-upstream) and a gRPC unary echo
+  benchmark against the in-repo echo service. *Tooling note*: `wrk` speaks HTTP/1.1 only --
+  neither WebSocket nor gRPC load can ride the existing lua scripts. Use `ghz` (pinned
+  container) for gRPC and a pinned WebSocket load tool (or a small in-repo Vert.x load
+  driver) for WS, emitting the same `=== BENCHMARK METADATA ===` block so the existing
+  post-processor and pages pipeline consume them unchanged; tool choice is recorded in this
+  plan as an amendment when made.
+. *Docs* -- variant-1 doc note that the protocol scope is complete; README sweep.
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-05-protocol-processors`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+== Acceptance Criteria
+
+* `protocol: websocket` and `protocol: grpc` routes boot and serve; the boot-time rejections
+  are gone for these two (the `session` rejection remains until Plan 07).
+* Handshake rejections never reach the upstream (asserted via upstream request counting).
+* gRPC trailer relay proven end-to-end; every rejection-mapping row unit-tested; the
+  architecture error contract documents the mapping.
+* Integration-test suite green locally and on CI, covering every behaviour above (convention:
+  never deferred).
+* The WebSocket and gRPC benchmarks run in the benchmark profile and publish via the pages
+  pipeline.
+* Quality gate + full verify pass; coverage >= 80% on new packages.
+
+== Out of Scope (explicit)
+
+* Per-message/frame content filtering, protobuf or GraphQL AST inspection (not a WAF).
+* `require: session` on WS/gRPC routes (works automatically after Plan 07; boot-rejected
+  until then).
+* gRPC-Web translation, gRPC reflection, WebSocket subprotocol negotiation policies.
+* TLS passthrough interaction (passthrough connections never reach these processors --
+  Plan 06).

--- a/doc/plan/06-tls-edge.adoc
+++ b/doc/plan/06-tls-edge.adoc
@@ -1,0 +1,137 @@
+= Plan 06 -- TLS Edge: SNI Passthrough + mTLS
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Activate the parsed-but-inert `tls` configuration blocks: `passthrough_sni` (connections
+whose SNI matches a configured hostname are relayed as opaque TCP at L4, without decryption,
+to the topology-resolved backend) and `mtls` (client-certificate verification on terminated
+connections). Deliver the two guards that keep the L4/L7 split unambiguous, and wire
+Toxiproxy into the integration stack for stream-level fault injection.
+
+== Required Reading (before implementation)
+
+. link:../configuration.adoc[Configuration Model], the `tls` field reference -- *the
+  authoritative spec*: SNI selection at accept time, case-insensitive exact matching, the
+  no-base-path alias rule, the two guards (boot-time `match.host` collision; runtime `404`
+  for terminated requests whose `Host` names a passthrough SNI), mTLS on terminated
+  connections only, no wildcard SNI entries initially.
+. link:../architecture.adoc[Architecture] -- the TLS edge in the component model; the
+  reserved-host `404` row of the error contract; "connections whose SNI is listed in
+  `tls.passthrough_sni` ... never reach the route table".
+. link:../adr/0004-topology-indirection.adoc[ADR-0004] (+ Amendment A1) -- passthrough
+  targets resolve through the same alias indirection routes use.
+. Plan 04 (delivered by then) -- the terminated listener and pipeline this plan fronts.
+
+== Prerequisites
+
+* Plan 04 delivered. Plan 05 is *not* required (independent tracks).
+* Coordination: if the Plan-02 gap-fix effort has not yet landed the two passthrough
+  *validation* rules (SNI/`match.host` collision, passthrough-alias-no-base-path), they are
+  delivered here; if it has, this plan only consumes them. Check before starting -- never
+  implement twice.
+
+== Design Decisions
+
+=== D1 -- Accept-time SNI split in a front listener
+
+The split happens *before* HTTP exists: a front TCP listener reads the TLS ClientHello
+(cleartext by design, RFC 6066), extracts the SNI, and decides:
+
+* *SNI mapped in `passthrough_sni`* -> pure L4 relay: the entire byte stream, ClientHello
+  included, is piped (Vert.x `NetSocket` <-> `NetSocket`, backpressured both ways) to the
+  `host:port` resolved from the alias at boot. The gateway never handshakes; the backend
+  presents its own certificate.
+* *Any other SNI, or none* -> hand the connection to the terminated stack (certificate,
+  `min_version`, `alpn`, `mtls`) and the full L7 pipeline.
+
+Implementation spike (first work item): choose between (a) a Vert.x `NetServer` front that
+parses the ClientHello and hands terminated connections to the HTTP stack over an internal
+channel, and (b) the Netty `SniHandler` integration point if Quarkus exposes one cleanly.
+The *behaviour* above is fixed either way; only the wiring is open. When `passthrough_sni`
+is empty (the default), the front listener is bypassed entirely -- zero cost for
+non-passthrough deployments.
+
+=== D2 -- mTLS on terminated connections
+
+`tls.mtls.enabled` + `client_ca` map to the terminated listener's client-auth options
+(require-and-verify against the configured CA). Passthrough connections are untouched -- the
+gateway never participates in that handshake (config spec). Failed client auth terminates the
+handshake; there is no HTTP-level fallback and no partial "optional mTLS" mode initially.
+
+=== D3 -- The two guards
+
+* *Boot*: a route whose `match.host` equals (case-insensitively) a passthrough SNI fails the
+  boot; every passthrough alias must resolve to a URL with no base-path. (`ConfigValidator`
+  rules -- here or already landed, see Prerequisites.)
+* *Runtime*: a *terminated* request whose `Host` header names a passthrough SNI is rejected
+  `404` before route selection -- the Host-smuggling guard, a new pipeline pre-check in
+  stage 2, with its own EventType.
+
+=== D4 -- Toxiproxy
+
+`ghcr.io/shopify/toxiproxy` (pinned) joins docker-compose between gateway and upstreams
+(anticipated by Plan 01 D2): needed here for stream-level fault tests (mid-stream reset on a
+passthrough relay) and available onward for breaker/timeout ITs.
+
+== Work Breakdown
+
+. *Spike + decision* (D1): ClientHello/SNI wiring approach; record the choice in this plan
+  doc (amendment) and, if architecturally relevant, in `architecture.adoc`.
+. *Passthrough relay* (D1) -- accept-time split, L4 pipe with backpressure, connection
+  lifecycle (half-close, abort propagation), boot-time alias resolution; unit tests with raw
+  TLS clients against a TLS-enabled test backend.
+. *mTLS* (D2) -- listener options from config; handshake accept/reject tests (valid client
+  cert, wrong CA, no cert).
+. *Guards* (D3) -- validator rules (if still open) + the runtime Host guard; negative tests
+  for both; LogRecords documented.
+. *Toxiproxy* (D4) -- compose service (pinned, healthcheck), scripts extended.
+. *Integration tests* (per the link:README.adoc[convention]: complete in this plan) --
+  end-to-end TLS through the passthrough relay to a TLS-enabled backend container (client
+  verifies the *backend's* certificate, proving the gateway never terminated); terminated
+  traffic on the same listener still fully served; Host-smuggle request -> `404`; mTLS
+  handshake accepted with the provisioned client cert and rejected without; mid-stream fault
+  via Toxiproxy propagates as connection abort, not a hang.
+. *Benchmarks* (README convention) -- a passthrough-relay WRK benchmark (wrk -> gateway L4
+  relay -> TLS backend) next to the terminated plain-proxy benchmark, so relay overhead is
+  measured; plus the empty-`passthrough_sni` no-regression comparison against the Plan 04
+  baseline used in the acceptance criteria.
+. *Docs* -- `doc/LogMessages.adoc`; any deviations back into the `tls` field reference
+  (doc-first rule).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-06-tls-edge`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+== Acceptance Criteria
+
+* A connection with a mapped SNI reaches the backend without gateway termination (asserted
+  by certificate identity end-to-end); everything else terminates and serves L7 as before.
+* Empty `passthrough_sni` -> measurably zero-overhead path (benchmark comparison against the
+  Plan 04 baseline; no regression beyond noise).
+* Both guards enforced with negative tests; mTLS accept/reject proven at handshake level.
+* Integration-test suite green locally and on CI, covering every behaviour above.
+* The passthrough-relay benchmark runs in the benchmark profile and publishes via the pages
+  pipeline.
+* Quality gate + full verify pass; coverage >= 80% on new packages.
+
+== Out of Scope (explicit)
+
+* Wildcard SNI entries (config spec: list each host).
+* Per-SNI/per-route mTLS policies (global `tls.mtls` only).
+* Optional/want-style client auth, certificate-to-identity mapping (no L7 identity is
+  derived from client certs in this plan).
+* PROXY-protocol emission on the passthrough relay (revisit if a passthrough backend needs
+  client IPs).

--- a/doc/plan/07-bff-server-session.adoc
+++ b/doc/plan/07-bff-server-session.adoc
@@ -1,0 +1,189 @@
+= Plan 07 -- BFF Foundation + Variant 2 (Server Session)
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Build the Backend-For-Frontend foundation and the *stateful* shape first
+(link:../variants/02-bff-session.adoc[Variant 2], operator decision 2026-07-15): API Sheriff
+becomes a full OIDC confidential client driving the `token-sheriff-client` engine -- auth-code
++ PKCE login, server-side token store, opaque `__Host-` session cookie, `require: session`
+runtime with content negotiation, fixed CSRF defence, transparent refresh, RP-initiated +
+back-channel logout, and RFC 9470 step-up. Plan 08 adds the stateless cookie shape as a
+delta on this foundation.
+
+== Required Reading (before implementation)
+
+. link:../variants/02-bff-session.adoc[Variant 2 -- BFF, Session-based] -- *entire document*;
+  it is the behavioural spec this plan implements (login, store, CSRF, logout incl. the
+  logout-`state` cookie and the back-channel logout-token checks, refresh, step-up).
+. `TokenSheriff/doc/client` (`CLIENT-1..22`) -- *authoritative for all BFF concerns*; where
+  it and anything else differ, `doc/client` governs (see `doc/README.adoc`).
+. link:../architecture.adoc#_authentication_layer[Architecture -- Authentication Layer] --
+  the canonical engine-dependency statement: the engine performs the OAuth legs (auth-code +
+  PKCE, refresh/rotation, RFC 7009 revocation, step-up legs, logout triggering) and wires
+  `token-sheriff-validation` internally; API Sheriff implements *only* the browser-facing
+  side. Do not re-implement flow legs in gateway code.
+. link:../configuration.adoc#_oidc[Configuration -- `oidc`] -- every field of the block
+  (parsed and validated since Plan 02), the reserved-gateway-paths rule (exact match, OIDC
+  host only, *before* the route table), and the `require: session` content-negotiation
+  semantics.
+. link:../variants/03-bff-cookie.adoc[Variant 3] -- read for the shared/delta boundary, so
+  the foundation built here keeps the binding step pluggable.
+
+== Prerequisites
+
+* Plans 03 + 04 delivered (anchors give the `bff` namespace floor; the pipeline provides
+  stage 4 and the reserved-path hook). Plans 05/06 are *not* required.
+* Keycloak in the compose stack (present since Plan 01, so far unused -- "the `integration`
+  realm finally earns its keep" moves here if Plan 04's bearer ITs left anything unclaimed).
+
+== Design Decisions
+
+=== D1 -- Engine dependency (requires dependency approval)
+
+[IMPORTANT]
+====
+New dependencies -- *require explicit user approval before adding*:
+
+* `de.cuioss.sheriff.token:token-sheriff-client-quarkus:0.9.1` (direct; the core
+  `token-sheriff-client` engine arrives transitively). Released line, no snapshots.
+====
+
+The engine owns: authorization-request construction (PKCE, `state`, `nonce`, mix-up
+defence), the code exchange, token validation wiring, refresh with rotation + reuse
+detection, RFC 7009 revocation, step-up authorization legs, end-session URL construction.
+The gateway owns: the reserved HTTP endpoints, the session store, the cookie, CSRF, content
+negotiation, and the back-channel logout receiver's *logout-token checks* (the validation
+library has no logout-token pipeline -- variant doc, Logout).
+
+=== D2 -- Reserved gateway paths
+
+`oidc.redirect_uri` path, `oidc.logout.path`, its return path, and
+`oidc.logout.backchannel_path` are matched *exactly, before the route table, only on the
+OIDC host* (configuration doc). Registered ahead of the catch-all in the edge layer; a proxy
+route `path_prefix: /auth` never swallows `/auth/callback`.
+
+=== D3 -- Session store (`mode: server`)
+
+In-memory store keyed by opaque session id, holding access + refresh + raw ID token and
+metadata (`expiry`, `acr`, `auth_time`, `sid`); secondary index by `sid`/`sub` for O(1)
+back-channel destruction (variant doc, Token Storage). `memory` is the only store --
+single-node / sticky-session deployments; a shared store is deliberately unsupported.
+TTL (`ttl_seconds`) is absolute from login. Session cookie: `HttpOnly`, `Secure`,
+`SameSite=Lax`, `__Host-` prefix, opaque id only.
+
+=== D4 -- `require: session` runtime (stage 4)
+
+Replaces Plan 04's boot-time rejection: resolve session -> token near expiry? refresh
+(single-flight per session) -> inject `Authorization: Bearer` (the automatic injection,
+never configured); enforce `required_scopes` against the *mediated* token's granted scopes
+(-> `403`). Unauthenticated: content negotiation -- a *navigation* request (accepts
+`text/html`) is redirected into the auth-code flow; anything else gets `401`
+`application/problem+json` (configuration doc `require: session`).
+
+=== D5 -- CSRF (fixed behaviour, no knob)
+
+Per the variant doc CSRF section, verbatim: `Origin` exact-match against
+`session.csrf.trusted_origins` on unsafe methods; `Sec-Fetch-Site: same-origin` accepted
+when `Origin` absent; everything else `403` + `CSRF_REJECTED` event.
+
+=== D6 -- Logout, both channels
+
+RP-initiated per the variant doc: revoke (engine), destroy session, expire cookie, redirect
+to `end_session_endpoint` with `id_token_hint` + exact-match `post_logout_redirect_uri` +
+session-bound `state` carried in the short-lived single-use `+__Host-sheriff-logout+`
+cookie; verify on the return leg, then `final_redirect`. Back-channel: signature via the
+issuer/JWKS infrastructure, then the gateway-code logout-token checks (`events` contains the
+back-channel event, `nonce` absent, `sub`/`sid` present), destroy via the secondary index.
+
+=== D7 -- Refresh and step-up
+
+Refresh within `leeway_seconds` through the engine, single-flighted per session; reuse
+detection -> family revoked; failure -> destroy session + `on_failure` semantics. Step-up
+(RFC 9470): parse `insufficient_user_authentication` challenges, attempt silent
+satisfaction, else re-drive the code flow with elevated parameters and replay -- engine legs,
+gateway orchestration.
+
+=== D8 -- Readiness
+
+Extend readiness: for `mode: server`, issuer reachability at startup (architecture, Health)
+via the engine/validation health checks -- reuse, don't rebuild.
+
+== Work Breakdown
+
+. *Dependency* (D1, after approval); verify the engine API surface against 0.9.1 before
+  coding (the docs were verified against pre-release source).
+. *Reserved endpoints* (D2) -- callback, logout, logout-return, back-channel; exact-match
+  registration + unit tests proving a `/auth` proxy route does not swallow them.
+. *Session store + cookie* (D3) -- store contract + memory implementation (TTL eviction,
+  secondary index), cookie codec; unit tests incl. expiry and O(1) back-channel lookup.
+. *Login flow* (D1/D2) -- engine-driven code flow; state/nonce round-trip; session creation.
+. *Stage 4 session auth* (D4) -- negotiation, injection, scope enforcement; remove the
+  boot-time `session` rejection.
+. *CSRF* (D5) -- fixed check + events; parameterized positive/negative tests
+  (trusted origin, untrusted, `Sec-Fetch-Site` variants, absent both).
+. *Logout* (D6) -- both channels; unit tests incl. logout-token check matrix and the
+  logout-`state` cookie round-trip.
+. *Refresh + step-up* (D7) -- single-flight, failure semantics; step-up orchestration.
+. *Readiness* (D8) + metrics/LogRecords for the new events (`CSRF_REJECTED`, session
+  lifecycle, refresh outcomes); document in `doc/LogMessages.adoc`.
+. *Integration tests* (per the link:README.adoc[convention]: complete in this plan) --
+  scripted (browser-less) auth-code flow against compose Keycloak: follow the `302` chain
+  with a cookie jar, submit the Keycloak login form, land on the callback, assert the
+  session cookie; steady-state call through a `require: session` route asserting the echo
+  upstream received the injected bearer and *no* session cookie; XHR-style unauthenticated
+  call -> `401` problem+json, navigation -> `302` to the IdP; CSRF rejection (`403`) on an
+  unsafe method with a foreign `Origin`; RP-initiated logout round-trip ending at
+  `final_redirect` with the session gone; back-channel logout post destroying the session
+  (next call unauthenticated); refresh exercised via a short-token-lifetime realm client.
+  Step-up: unit/mock-level mandatory; Keycloak-level IT only if the realm supports ACR
+  step-up cleanly (record the decision either way).
+. *Benchmarks* (README convention) -- a session-mediated proxied-route WRK benchmark
+  (pre-established session cookie, steady-state mediation: cookie -> store lookup -> bearer
+  injection -> upstream), so BFF mediation overhead is measured against the Plan 04 bearer
+  and plain-proxy baselines. Login-flow throughput is *not* benchmarked (IdP-bound, not
+  gateway hot path).
+. *Docs* -- deviations discovered during implementation go into the variant doc /
+  `configuration.adoc` in the same PR (docs govern).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-07-bff-server-session`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+If the plan has to be split into multiple PRs (likely -- it is the largest plan), the
+workflow applies to each PR and the build must be green after every one; the boot-time
+`session` rejection falls only in the PR that completes stage 4.
+
+== Acceptance Criteria
+
+* A browser-shaped client completes login -> steady-state mediated calls -> logout against
+  compose Keycloak, entirely through the gateway; the upstream only ever sees the injected
+  bearer.
+* All fixed security behaviours (CSRF, state verification both flows, exact
+  `post_logout_redirect_uri`, logout-token checks) have negative tests.
+* No OAuth leg is implemented in gateway code (review checklist item -- the engine boundary
+  from the architecture doc holds).
+* Integration-test suite green locally and on CI, covering every behaviour above.
+* The session-mediation benchmark runs in the benchmark profile and publishes via the pages
+  pipeline.
+* Quality gate + full verify pass; coverage >= 80% on new packages.
+
+== Out of Scope (explicit)
+
+* `session.mode: cookie` -- Plan 08 (the binding step is kept pluggable here).
+* Shared/external session stores (deliberate non-feature -- variant doc trade-off).
+* `token-sheriff-client` BFF UI/legs beyond what the engine ships (no custom consent pages,
+  no IdP admin).
+* Multi-IdP / per-route OIDC (one global `oidc` block -- one deployment, one BFF shape).

--- a/doc/plan/08-bff-cookie.adoc
+++ b/doc/plan/08-bff-cookie.adoc
@@ -1,0 +1,121 @@
+= Plan 08 -- Variant 3 (Cookie, Stateless)
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Add the *stateless* BFF shape (link:../variants/03-bff-cookie.adoc[Variant 3],
+`session.mode: cookie`) as a delta on the Plan 07 foundation: the token set travels only
+inside an AES-256-GCM encrypted `HttpOnly` cookie, decrypted per request -- no store, no
+sticky sessions, instances share only the encryption key. Login flow, CSRF, refresh,
+step-up, and RP-initiated logout are the *shared* foundation; this plan delivers the cookie
+token binding, key rotation, the concurrent-refresh mitigation, and the deliberate
+back-channel differences.
+
+== Required Reading (before implementation)
+
+. link:../variants/03-bff-cookie.adoc[Variant 3 -- BFF, Cookie-based] -- *entire document*:
+  cookie design (contents incl. the raw ID token, attributes, key management, ~4 KB size
+  budget), statelessness properties, the concurrent-refresh race and its mitigation ladder,
+  the disabled back-channel and its consequences.
+. link:../variants/02-bff-session.adoc[Variant 2] + the delivered Plan 07 code -- the
+  shared/delta boundary; this plan must not fork the foundation.
+. link:../configuration.adoc#_oidc[Configuration -- `oidc.session`] -- cookie-mode
+  conditionals (`encryption_key` required, `previous_key` decrypt-only; `store` is
+  server-mode-only), already validated since Plan 02.
+
+== Prerequisites
+
+* Plan 07 delivered. No new Maven dependencies expected (AES-256-GCM via the JDK; the engine
+  is already wired) -- if one shows up, the approval rule applies.
+
+== Design Decisions
+
+=== D1 -- Token binding behind an interface
+
+Plan 07's binding step (store + opaque id) and this plan's (seal/unseal cookie) implement
+one gateway-side `SessionBinding` seam chosen at boot from `session.mode` -- the rest of the
+BFF (login, stage 4, CSRF, logout orchestration, refresh, step-up) is shared code and must
+stay shared (review checklist item).
+
+=== D2 -- Cookie codec
+
+AES-256-GCM authenticated encryption; plaintext = access + refresh + raw ID token (needed as
+`id_token_hint` -- a stateless gateway cannot drive RP-initiated logout without it) +
+minimal metadata; value = ciphertext + nonce + tag. Tamper -> authentication failure ->
+treated as no session. Keys by env indirection (`encryption_key`; the secrets rule applies);
+rotation: `previous_key` is decrypt-only, accepted cookies re-seal with the current key on
+next write. *Size budget*: the sealed cookie must stay within ~4 KB; exceeding it at seal
+time fails the login with a clear, logged error (no silent truncation; cookie splitting is a
+documented deployment consideration, not implemented).
+
+=== D3 -- Refresh under statelessness
+
+Per the variant doc, verbatim: single-flight per session *per instance*; a refreshed token
+re-seals into a new `Set-Cookie`; refresh-reuse rejection is an ordinary refresh failure
+(session ends, `on_failure` drives re-auth); IdP-side reuse tolerance is documented as an
+operator trade-off (availability vs. RFC 9700 theft detection), never a gateway default.
+
+=== D4 -- Back-channel logout is disabled (`404`)
+
+In `mode: cookie` the `backchannel_path` returns `404` -- there is no session to destroy,
+and accepting posts the gateway cannot act on is dead attack surface. IdP-side termination
+takes effect at the next refresh; the mitigation (short `ttl_seconds` / short access-token
+lifetimes) and the "choose Variant 2 for instant revocation" guidance stay documented.
+
+== Work Breakdown
+
+. *`SessionBinding` seam* (D1) -- extract from Plan 07 if not already shaped that way;
+  boot-time selection from validated config.
+. *Cookie codec* (D2) -- seal/unseal, rotation, size budget; unit tests: round-trip, tamper
+  rejection (flipped byte in each of ciphertext/nonce/tag), previous-key acceptance +
+  re-seal, oversized-set rejection, key material never logged.
+. *Refresh delta* (D3) -- re-seal on refresh, single-flight, reuse-as-failure path; unit
+  tests incl. a simulated concurrent-refresh race.
+. *Back-channel disable* (D4) + the cookie-mode readiness delta (no store health; issuer
+  reachability stays).
+. *Integration tests* (per the link:README.adoc[convention]: complete in this plan) -- the
+  Plan 07 IT suite re-run in cookie mode via a cookie-mode config set (login, steady-state
+  mediation, negotiation, CSRF, RP-initiated logout); plus cookie-specific ITs: a second
+  gateway instance (no shared state) serves a session created by the first (statelessness
+  proof); key rotation across a restart with `previous_key` keeps the session alive and
+  re-seals; tampered cookie -> unauthenticated, never `500`; `backchannel_path` -> `404` in
+  cookie mode.
+. *Benchmarks* (README convention) -- the Plan 07 session-mediation benchmark re-run in
+  cookie mode (per-request decrypt -> bearer injection), published as its own suite entry so
+  the store-lookup vs. decrypt-per-request cost comparison is visible.
+. *Docs* -- LogMessages additions; deviations back into the variant doc (docs govern).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-08-bff-cookie`.
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+== Acceptance Criteria
+
+* Both `session.mode` values run the same foundation code path except the binding seam
+  (asserted structurally -- no duplicated flow logic).
+* Statelessness proven by the two-instance IT; rotation proven across restart.
+* Tampering and oversized token sets fail *safe* (unauthenticated / clear login error),
+  never as server errors or partial sessions.
+* Integration-test suite green locally and on CI in *both* modes.
+* The cookie-mode mediation benchmark runs in the benchmark profile and publishes via the
+  pages pipeline (comparable side by side with the Plan 07 server-mode entry).
+* Quality gate + full verify pass; coverage >= 80% on new packages.
+
+== Out of Scope (explicit)
+
+* Cookie splitting for oversized token sets (documented deployment consideration).
+* Shared caches/stores of any kind (the point of the variant).
+* Cross-instance refresh coordination (accepted trade-off per the variant doc; residual
+  effect is a rare forced re-login).

--- a/doc/plan/09-release-readiness.adoc
+++ b/doc/plan/09-release-readiness.adoc
@@ -1,0 +1,93 @@
+= Plan 09 -- Release Readiness (1.0 Cut)
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Turn the feature-complete gateway (Plans 01-08) into a releasable 1.0: an operator-facing
+configuration guide (none exists today -- `doc/` is design documentation), the deliberate
+ADR-0005 module-structure checkpoint, a full security-audit sweep over the finished surface,
+benchmark-suite completion with per-variant overhead numbers, native-image and container
+hardening, and the versioned release itself. This plan adds *no features*; anything
+discovered here that is feature-shaped becomes its own follow-up.
+
+== Required Reading (before implementation)
+
+. link:../adr/0005-module-structure.adoc[ADR-0005], section "Revisit When" -- the explicit
+  criteria for extracting the framework-agnostic core module; this plan executes that
+  checkpoint.
+. link:../configuration.adoc[Configuration Model] + the shipped sample configs -- the source
+  material for the operator guide.
+. link:../architecture.adoc[Architecture] -- the security-audit scope map (trust boundaries,
+  error contract, forwarding, the no-response-cache rule).
+. link:README.adoc[Plan README] -- the conventions the release must retrospectively satisfy
+  (integration-test completeness per plan, pre-1.0 rules end here: 1.0 starts API stability).
+
+== Prerequisites
+
+* Plans 05-08 delivered; all integration suites green on `main`.
+
+== Work Breakdown
+
+. *Operator configuration guide* -- a task-oriented "configuring API Sheriff" document
+  (new top-level doc or `doc/guide/`): first boot with a minimal config, adding an endpoint,
+  anchors, topology + `${VAR:-default}` overrides in containers, TLS/mTLS/passthrough,
+  choosing and configuring a BFF variant, reading the boot log / effective-posture output,
+  every LogRecord an operator may see (link to `doc/LogMessages.adoc`). Seeded from the
+  integration sample configs so every snippet is *tested* configuration. The design docs
+  stay design docs; the guide never duplicates normative rules, it links them.
+. *ADR-0005 checkpoint* -- measure the framework-agnostic surface (package sizes, arch-gate
+  history); decide extract-vs-reaffirm with the user; record the outcome as an ADR-0005
+  amendment (and execute the mechanical extraction if chosen -- the arch-gate has kept it
+  package-to-module by construction).
+. *Security-audit sweep* -- full-surface audit (config validation gaps, header handling,
+  cookie/CSRF/logout flows, forwarding trust, error-detail leakage, container posture);
+  every finding triaged: fixed here, or explicitly risk-accepted with rationale. Fresh
+  dependency + container-image CVE pass.
+. *Benchmark consolidation* -- the per-plan benchmarks (README convention: each hot-path
+  plan shipped its own) are consolidated into one side-by-side report -- baseline
+  (`/q/health`), plain proxy, bearer, WebSocket, gRPC, passthrough relay, BFF mediation
+  (server + cookie) -- published via the existing pages pipeline, with regression thresholds
+  recorded as the baseline contract for post-1.0 work. This item creates *no* missing
+  coverage; a gap found here is a defect of the plan that skipped it.
+. *Native + container hardening* -- native build + ITs against the native image in CI
+  (not only JVM mode) if not already the default; distroless image review (user, filesystem,
+  exposed ports, JFR variant), resource-limit guidance measured (heap ceilings under the
+  benchmark load).
+. *Release mechanics* -- version 1.0.0, release notes generated from the plan/ADR trail,
+  tag + publish per cuioss release conventions; `doc/plan/README.adoc` updated to mark the
+  sequence delivered; declare the end of the pre-1.0 break-freely rules in `CLAUDE.md`
+  (from 1.0 on, breaking changes need deprecation strategy -- the rule flips).
+
+== Execution Workflow
+
+. Create a feature branch from up-to-date `main`: `feature/plan-09-release-readiness`
+  (several PRs expected -- guide, audit fixes, benchmarks, release -- each following the
+  standard workflow below).
+. Implement the work breakdown above.
+. Verify everything locally -- both must pass with zero errors/warnings:
+  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+== Acceptance Criteria
+
+* An operator can bring up a configured gateway (any variant) using only the guide and the
+  sample configs -- verified by walking the guide against a clean environment.
+* The ADR-0005 decision is recorded (amendment), and the codebase matches it.
+* Zero open unaccepted security findings; the audit report is archived in the repo.
+* Benchmark pages publish all suite results with recorded baselines.
+* Native-image integration tests green in CI; 1.0.0 tagged and released.
+
+== Out of Scope (explicit)
+
+* Any new gateway feature (rate limiting stays out of scope entirely; dynamic config and
+  HTTP/3 stay deferred per link:../adr/0002-initial-scope.adoc[ADR-0002]).
+* OpenTelemetry tracing (post-MVP hook per the architecture doc).
+* Multi-node/HA guidance beyond what the variants already document.

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -27,16 +27,68 @@ The plans build strictly on one another:
   config mounted into the integration containers.
 | Plan 01
 
-| link:03-request-pipeline.adoc[03 -- Request Pipeline]
+| link:03-endpoint-anchors.adoc[03 -- Endpoint Anchors]
+| Namespace-scoped policy (link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007]): `anchors` in
+  `gateway.yaml` owning disjoint path namespaces, declared membership, wholesale-replacement
+  inheritance with a non-weakenable auth floor, all materialized into the route table at boot.
+  Plus: transparent in-file `${ENV_VAR:-default}` substitution replacing the convention-named
+  Java-level env overrides (amends ADR-0004's override channel).
+| Plans 01 + 02
+
+| link:04-request-pipeline.adoc[04 -- Request Pipeline]
 | The data plane for standard HTTP verbs: cui-http inbound filtering (basic + per-route),
   route selection, protocol-processor loading, offline bearer validation, zero-trust forward
   policy with regenerated forwarding headers (cui-http:2.1), dispatch with
   retry/circuit breaker, plus the event system, metrics, logging, and RFC 9457 error edge.
-| Plans 01 + 02
+| Plans 01 + 02 + 03
+
+| link:05-protocol-processors.adoc[05 -- Protocol Processors]
+| WebSocket upgrade proxying (full pipeline on the handshake, then bidirectional relay) and
+  gRPC over upstream h2 with *trailer* relay + a gRPC-status rejection mapping -- both native
+  to the ADR-0008 Vert.x transport. GraphQL already rides the HTTP processor. In-repo Quarkus
+  gRPC echo upstream for ITs. Closes the ADR-0002 protocol promise and with it the
+  link:../variants/01-base-gateway.adoc[Variant 1] scope.
+| Plan 04
+
+| link:06-tls-edge.adoc[06 -- TLS Edge: SNI Passthrough + mTLS]
+| Accept-time SNI split: `passthrough_sni` connections relayed as opaque L4 TCP to the
+  topology-resolved backend, everything else terminated with `mtls` client-CA verification;
+  the two L4/L7 guards (boot collision rule, runtime Host-smuggle `404`); Toxiproxy joins
+  the compose stack.
+| Plan 04 (independent of 05)
+
+| link:07-bff-server-session.adoc[07 -- BFF Foundation + Variant 2 (Server Session)]
+| The headline differentiator, *stateful shape first* (operator decision 2026-07-15):
+  `token-sheriff-client` 0.9.1 as the OIDC confidential-client engine; reserved gateway
+  paths; in-memory session store + opaque `__Host-` cookie; `require: session` runtime with
+  content negotiation; fixed CSRF defence; transparent refresh; RP-initiated + back-channel
+  logout; RFC 9470 step-up (link:../variants/02-bff-session.adoc[Variant 2]).
+| Plans 03 + 04; consumes `oidc` config from Plan 02
+
+| link:08-bff-cookie.adoc[08 -- Variant 3 (Cookie, Stateless)]
+| The token-binding delta on the Plan 07 foundation: AES-256-GCM encrypted token cookie,
+  `previous_key` rotation, single-flight refresh with the reuse-as-failure rule,
+  back-channel endpoint deliberately `404`
+  (link:../variants/03-bff-cookie.adoc[Variant 3]).
+| Plan 07
+
+| link:09-release-readiness.adoc[09 -- Release Readiness (1.0 cut)]
+| The operator configuration guide, the ADR-0005 module-extraction checkpoint, a
+  full-surface security audit, benchmark completion with per-variant baselines, native +
+  container hardening, the 1.0.0 release (and the flip of the pre-1.0 rules).
+| All of 05-08
 |===
 
-Later plans (not yet written): WebSocket + gRPC processors, TLS passthrough/mTLS, the two
-BFF variants (`token-sheriff-client`), rate limiting.
+Sequencing rationale: 05 and 06 are small increments on a freshly-built pipeline and transport
+(do them while that knowledge is hot; 05 also completes what ADR-0002 promises for the initial
+scope). The BFF track (07 -> 08) is the largest and riskiest block and lands on a stabilized
+data plane; within it the *stateful* server-session shape comes first (operator decision,
+2026-07-15), the stateless cookie variant is its delta. 05 and 06 are mutually independent
+and independent of the BFF track -- they can be reordered or interleaved freely if priorities
+shift (e.g. pull 07 forward for a BFF demo); within that block the only hard edges are
+08 -> 07 and 09 -> everything (all of 05-07 already require 04, and 07 additionally 03). Explicitly *not* on the roadmap: *rate limiting* (out of scope -- the `rate_limit`
+config stays reserved/accepted-and-ignored, no `429` is produced), and, deferred by
+link:../adr/0002-initial-scope.adoc[ADR-0002], dynamic configuration/discovery and HTTP/3.
 
 == Conventions
 
@@ -46,8 +98,19 @@ BFF variants (`token-sheriff-client`), rate limiting.
   reviewers and watch checks -> handle *every* review comment (fix or justified reply, then
   resolve) -> merge -> `git checkout main && git pull`. Builds must be green after every PR,
   not only at plan completion.
+* *Integration tests are part of the plan, never deferred*: a plan is complete only when
+  every behaviour it delivers is exercised by the `integration-tests` suite (positive and
+  negative paths) and the full integration profile is green -- locally and on CI -- before
+  the plan's final merge. A follow-up plan may *extend* coverage; it never *supplies* missing
+  coverage for a predecessor.
+* *Benchmarks follow the same rule for the hot path*: every plan that adds a runtime
+  data-plane behaviour ships a WRK benchmark for it in the same plan (following the existing
+  lua/sh + metadata conventions so the pages pipeline picks it up unchanged), so regressions
+  stay attributable to the plan that caused them. Boot-time-only plans (02, 03) are exempt --
+  nothing on the hot path to measure. Plan 09 consolidates baselines and regression
+  thresholds; it does not create missing coverage.
 * *Dependency approvals*: every new Maven dependency a plan needs is flagged inside the plan
   with an IMPORTANT block and requires explicit user approval before it is added
-  (CLAUDE.md rule). The remaining snapshot dependency (`token-sheriff-*:1.0.0-SNAPSHOT`)
-  additionally needs a CI-resolvability check before merge.
+  (CLAUDE.md rule). TokenSheriff artifacts use the released line (currently `0.9.1`), never
+  snapshots.
 * Pre-1.0 rules apply throughout: delete instead of deprecate, break freely, keep APIs clean.

--- a/doc/technical_aspects.adoc
+++ b/doc/technical_aspects.adoc
@@ -39,8 +39,11 @@ right for the *control plane* -- the small, bounded JSON calls the gateway makes
 discovery, JWKS, token exchange, revocation) -- but it is *not* used for the *data plane*:
 proxied client bodies (large responses, downloads, SSE, chunked/long-lived streams) are
 *streamed* with backpressure and never buffered into an `HttpResult<byte[]>`/`HttpResult<String>`.
-The boundary, and the competitor evidence behind it, is
-link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006].
+The whole cui-http client stack described in this section -- `HttpHandler`,
+`ResilientHttpAdapter`, `ETagAwareHttpAdapter` -- is *control-plane only*; the proxied data
+plane runs on the Vert.x `HttpClient` with per-route fault-tolerance guards. The boundary,
+and the evidence behind it, is link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006] +
+link:adr/0008-data-plane-transport.adoc[ADR-0008].
 
 == HTTP Security Validation
 

--- a/doc/variants/01-base-gateway.adoc
+++ b/doc/variants/01-base-gateway.adoc
@@ -125,9 +125,10 @@ Startup (once, shared):
   TokenValidator.builder().issuerConfig(...).build()
 
 Per request on a bearer route:
-  AccessTokenRequest.of(bearerToken, requestHeaders, requestUri, requestMethod)
-      // URI + method are REQUIRED when a DPoP proof is present: DpopProofValidator
-      // hard-fails htu/htm validation without them -- never use the 2-arg form here
+  new AccessTokenRequest(bearerToken, requestHeaders, requestUri, requestMethod)
+      // the 4-component record constructor (the of(..) factories exist only in 1- and
+      // 2-arg forms and omit URI/method). URI + method are REQUIRED when a DPoP proof is
+      // present: DpopProofValidator hard-fails htu/htm validation without them
   AccessTokenContent token = validator.createAccessToken(request)   // offline, cached JWKS
   token.providesScopes(route.requiredScopes)           // 403 if missing
   -> forward upstream


### PR DESCRIPTION
## Summary

Documentation-only evolution of the design and plan set. Three threads, landed coherently:

### New design decisions
- **ADR-0007 — Endpoint Anchors** (proposed): namespace-scoped policy in `gateway.yaml` — anchors own disjoint path prefixes (`/api`, `/bff`), carry a policy floor (`auth`, `security_filter`, `security_headers`, `allowed_methods`), membership is declared per endpoint/route and validated both ways, inheritance is wholesale replacement with a non-weakenable auth floor, and everything is erased into the materialized route table at boot. Backed by a survey of Kong/APISIX/Traefik/Gateway-API/Azure-APIM inheritance models.
- **ADR-0008 — Data-Plane Transport** (accepted): the proxied data plane runs on the Vert.x `HttpClient` (streams, trailers for gRPC, upgrades for WebSocket), one shared client per upstream tuple; resilience is per-route **programmatic SmallRye Fault-Tolerance guards** with a stream-aware retry gate (idempotent AND zero body bytes sent); gateway-side response caching is **rejected** (cross-user cache-leak class); `not_modified.enabled` becomes end-to-end conditional pass-through; the cui-http client stack (`HttpHandler`/`ResilientHttpAdapter`/`ETagAwareHttpAdapter` — materializing by construction) is scoped to the control plane; the whole-second timeout rule is dropped.
- **ADR-0004 Amendment A1**: environment overrides become visible in-file `${VAR:-default}` placeholders, superseding the convention-named `TOPOLOGY_<ALIAS>` / `ENDPOINT_<ID>_ENABLED` code-level lookups (implementation lands with Plan 03).

### Plan set completed 01→09
- Plan 03 (anchors + `${ENV_VAR}` substitution) written; request pipeline renumbered 03→04 and updated (anchor-aware stages, Vert.x dispatch through FT guards, ADR-0005 arch-gate as a deliverable, TokenSheriff **0.9.1 released** — no snapshots).
- Plans 05–09 written: protocol processors (WS + gRPC incl. gRPC-status rejection mapping), TLS edge (accept-time SNI passthrough + mTLS), BFF **server-session first** (operator decision), BFF cookie as a delta, release readiness (operator guide, ADR-0005 checkpoint, security audit, 1.0 cut).
- Conventions hardened: integration tests **and** hot-path benchmarks ship complete in every plan, never deferred; rate limiting is **out of scope**.

### Full-doc-set consistency pass
Four-dimension review (configuration / architecture+variants / plans / ADRs+index) with all findings fixed: the anchors resolution chain propagated into every `allowed_methods`/`auth` copy; `security_headers` pinned to gateway→anchor scope (pre-routing responses resolve the anchor by path prefix); architecture gained the security-headers/CORS stage and anchor-aware wording; `AccessTokenRequest` corrected to the 4-component constructor (the `of(..)` factories omit the URI/method DPoP needs); features-analysis and technical_aspects aligned with ADR-0008; product-origin references removed from final design docs. All AsciiDoc links/anchors verified by script.

## Verification
- Docs-only change — no build impact.
- Mechanical link/anchor check over all 27 non-archive `.adoc` files: green.