### PR TITLE
ci: bump benchmark and claude workflows to JDK 25

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,10 +50,10 @@ jobs:
           fetch-depth: 0  # Fetch all history for proper versioning
           persist-credentials: false  # Prevent token from overriding app token during deploy
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Run Claude Code


### PR DESCRIPTION
## What

Bump `setup-java` from JDK 21 to JDK 25 in two workflows:

- `.github/workflows/benchmark.yml` (Performance Benchmark)
- `.github/workflows/claude.yml` (Claude)

## Why

The project baseline is Java 25 (ADR-0001 `java25-runtime-baseline`; root pom `<release>25`), but these two peripheral workflows still provisioned JDK 21. Any run that compiles the project fails at the compiler:

```
[ERROR] ...maven-compiler-plugin:compile... Fatal error compiling:
error: release version 25 not supported
```

This was observed on the post-merge Performance Benchmark run for PR #64 (the benchmark workflow triggers on `pull_request: closed` + `merged==true` and deploys results). `build.yml` already runs the 25 + 26 matrix and is green; only these two lagged.

## Scope

Two-line change per file; no code touched. Brings the peripheral workflows in line with the Java 25 baseline.