### PR TITLE
docs: threat model + CVE-derived validation baseline, plan hardening, IT compose resolver

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -61,6 +61,11 @@ together*.
 | link:configuration.adoc[Configuration Model]
 | The static, immutable YAML mapping schema: routing, URL/parameter whitelisting,
   security filtering, TLS (termination and passthrough), and per-route limits.
+
+| link:security-threat-model.adoc[Threat Model & CVE-Derived Validation Baseline]
+| Trust boundaries and STRIDE, plus a failure catalogue where every class that produced a
+  real CVE in a comparable gateway/proxy or OAuth/OIDC stack is mapped to an API Sheriff
+  control, a status, and a testable assertion. Doubles as the 1.0 security release gate.
 |===
 
 == Deployment Variants
@@ -90,7 +95,8 @@ configuration. Each has its own design section:
 
 Sequenced plans for building what these documents describe live under
 link:plan/README.adoc[`plan/`]: base implementation and configuration management (delivered),
-then endpoint anchors, the request pipeline, protocol processors, the TLS edge, the two BFF
+a doc/code reconciliation & quality-debt sweep, then endpoint anchors, the request pipeline,
+protocol processors, the TLS edge, the two BFF
 variants (server-session first), and release readiness -- the full sequence to the 1.0 cut.
 Rate limiting is out of scope. Each plan names the design documents that must be read before
 implementing it.
@@ -151,6 +157,8 @@ implementing it.
 . link:features-analysis.adoc[Feature Analysis] -- what to build and what not to.
 . link:architecture.adoc[Architecture] -- how the runtime fits together.
 . link:configuration.adoc[Configuration] -- the YAML contract.
+. link:security-threat-model.adoc[Threat Model] -- the trust boundaries and the CVE-derived
+  controls every variant must satisfy.
 . The link:variants/01-base-gateway.adoc[three variant sections] -- deployment modes.
 . link:technical_aspects.adoc[Technical Aspects] -- the CUI library APIs behind the design.
 . The link:adr/0001-java25-runtime-baseline.adoc[ADRs] -- the recorded decisions and their

--- a/doc/plan/02b-reconciliation.adoc
+++ b/doc/plan/02b-reconciliation.adoc
@@ -1,0 +1,157 @@
+= Plan 02b -- Doc/Code Reconciliation & Quality Debt
+:toc:
+:toclevels: 3
+:sectnums:
+
+== Goal
+
+Bring the design documentation and the delivered code back into agreement, and clear the
+test/benchmark quality debt surfaced by the 2026-07-17 adversarial review -- *before*
+Plan 03 builds on either. This plan adds no features; every item is a correction of
+something that already claims to exist, a deletion of something worthless, or a repair of a
+measurement instrument. It is independent of link:03-endpoint-anchors.adoc[Plan 03] (no
+overlapping files beyond trivial doc passages) and can land before it or in parallel.
+
+Scope guard: everything Plan 03 explicitly owns stays there -- the `${VAR:-default}`
+placeholder mechanism, the `EndpointEnablementResolver`/`TOPOLOGY_<ALIAS>` removal, anchors,
+prefix normalization, CIDR/scheme/secrets validator hardening. This plan must not touch
+those.
+
+== Required Reading (before implementation)
+
+. The review findings condensed into this plan (each work item cites its evidence inline).
+. link:../adr/0008-data-plane-transport.adoc[ADR-0008] -- documents the whole-second
+  timeout rule as *removed*; item 1 below makes that true.
+. link:../adr/0009-asymmetric-alias-resolution-failure.adoc[ADR-0009] -- fully implemented,
+  still marked Proposed; item 2 flips it.
+
+== Work Breakdown
+
+=== Code-side: make the docs' past tense true
+
+. *Remove `validateWholeSecondTimeouts`* (and its tests) from `ConfigValidator`. ADR-0008
+  (Accepted) and the `configuration.adoc` validation summary both state the rule was
+  removed and "millisecond-precision timeouts become legal configuration" -- the code still
+  rejects `read_timeout_ms: 2500` today. Add a positive test: a non-whole-second timeout
+  boots.
+. *Flip ADR-0009 to Accepted* -- `TopologyResolver` + `validatePassthroughAliasResolvable`
+  implement it word for word; update the status line and the ADR index table in
+  `doc/README.adoc`.
+. *Remove `jwks.source: inline`* from the schema enum, `IssuerConfig.Jwks`, and
+  `configuration.adoc`: the option is selectable but no field can carry inline key material,
+  so it is a dead branch (pre-1.0 rule: delete). Re-add with a content field only if an
+  air-gapped deployment need materializes.
+
+=== Documentation corrections (doc-vs-code, doc-vs-doc)
+
+. *Root `README.adoc` ports*: `/q/health` and `/q/metrics` live on the management port
+  `9000` (plain HTTP), not `8443` -- fix the endpoint/port table and the `docker run`
+  example (map 9000); remove the duplicated OAuthSheriff metrics link.
+. *Library-dependency claims*: `architecture.adoc` §Library Dependencies and
+  `technical_aspects.adoc` §Library Summary both state the token-sheriff stack is a future,
+  approval-pending addition and that core jars arrive only transitively -- the pom has all
+  three modules as *direct* dependencies at 0.9.2 today. Fix both statements, then
+  *deduplicate*: `technical_aspects.adoc` owns the coordinates table, `architecture.adoc`
+  links it (the duplicated table is how the same error got into two files).
+. *`doc/README.adoc`*: drop the stale "No production code is described as existing here"
+  sentence (the same file says Plans 01/02 are delivered).
+. *Upstream-project naming*: reconcile `TokenSheriff` / `OAuthSheriff` / `token-sheriff` --
+  the repo is `cuioss/TokenSheriff`; retarget the OAuthSheriff links in the root README and
+  `benchmarks/doc/performance-scoring.adoc`, and give the many bare `TokenSheriff/doc/client`
+  references one resolvable URL (state it once in `doc/README.adoc`, link there elsewhere).
+. *`doc/LogMessages.adoc` identifiers*: rendered IDs are not zero-padded
+  (`ApiSheriff-1:`, not `ApiSheriff-001:`); fix the IDs and range headings so an operator
+  grepping logs finds them.
+. *Version references*: ADR-0001 names `cui-java-parent:1.5.0`; the pom says `1.5.1` (and
+  `CLAUDE.md` still says `1.4.4` -- update it in the same PR). Verify against the pom at
+  edit time.
+. *`architecture.adoc` §Metrics attribution*: port 9000 is the Quarkus management-interface
+  default, not something set in `application.properties` -- correct the sentence.
+. *Configuration-location facts* in `configuration.adoc`: document the `sheriff.config.dir`
+  property (the knob that locates the whole config set), fix the sample tree's `conf/` to
+  the shipped default `config`, and document the `.yaml`-only endpoint-file listing and the
+  `[A-Z][A-Z0-9_]*` topology alias-name constraint as current behaviour (Plan 03 hardens
+  both; until then the doc must not hide them).
+. *`forwarded.trusted_proxies` "MANDATORY" ambiguity*: the field is required *within* a
+  `forwarded` block, but the block itself is optional -- say so explicitly (a config with no
+  `forwarded` block is legal and means "no inbound forwarding headers are trusted").
+. *Session-store requiredness*: the validator requires `store` when `session.mode: server`;
+  the doc implies `memory` is a default. Decide doc-first and align -- keep the code's
+  explicit-store requirement and document it (an explicit store keeps the config
+  self-describing).
+. *Violation-aggregation wording*: qualify the "every violation ... reported together,
+  never one at a time" claim in `configuration.adoc` §Schemas per the ADR-0009 asymmetry
+  (an unresolvable enabled-endpoint alias and, until Plan 03 moves it, same-prefix
+  disjointness abort individually).
+. *Terminology*: `technical_aspects.adoc` titles the upstream-call section "Downstream API
+  Communication" while the config model says `upstream` throughout -- rename the section
+  and sweep the remaining downstream/upstream mismatches.
+
+=== Test hygiene
+
+. *Delete vacuous tests*: `ApiSheriffTest.shouldCreateInstance`, `ApiSheriffProducerTest`
+  (constructor-only assertions), and `ValidationRuleTest` (all four tests exercise lambdas
+  the test itself defines -- they verify Java, not production code).
+. *Resolve the Hamcrest contradiction*: the forbidden-frameworks rule bans Hamcrest, yet
+  every REST-assured test imports `org.hamcrest.Matchers`. Migrate the five affected
+  classes to `.extract()` + JUnit assertions; new tests follow the same style (Plan 04
+  already mandates it for its ITs).
+. *Wire `verify-invalid-config-fails.sh` into the `integration-tests` profile*
+  (exec-maven-plugin execution): it is the only automated proof of the "never serve on
+  partial configuration" property and is currently referenced by nothing. Wire or delete
+  `verify-environment.sh` in the same pass.
+. *Small gaps*: add the `::/0` trust-all negative case to `ConfigValidatorTest` (only the
+  IPv4 form is tested); assert that `MissingVariableException`/binding messages never
+  contain a resolved secret *value* (pins today's behaviour; Plan 03 D5 extends it);
+  convert `WrkResultPostProcessorTest`'s CWD-relative resource paths to classpath loading;
+  drop the unused `awaitility` dependency from `integration-tests/pom.xml`.
+
+=== Benchmark harness correctness
+
+. *Fix the wrk counter aggregation*: `done()` runs in a fresh Lua state, so the per-thread
+  `success_count`/`non_200_count` the scripts print are not aggregated totals -- plumb
+  counters via `setup()`/the thread table in all three scripts, delete the never-used
+  `error_count`, and make the run *fail* above an error-rate threshold (today a gateway
+  that starts serving 404s benchmarks as an improvement).
+. *`WrkResultPostProcessor` matching*: replace the bidirectional-`contains()` metadata
+  matching (nondeterministic on overlapping names) with an exact naming contract; reconcile
+  the `*.txt` vs `*-results.txt` suffix handling; add value-asserting tests (the synthetic
+  fixtures have known numbers -- P50, RPS -- that no test currently checks, so a unit
+  conversion bug would pass).
+
+=== Optional stopgap (explicitly optional, throwaway)
+
+* The interim proxy (`ProxyRoute`, replaced wholesale by Plan 04) buffers unbounded bodies
+  and has no request timeout. If Plan 04 is not imminent when this plan lands, add the
+  two-line mitigations (a `BodyHandler` size limit, an `HttpRequest` timeout) as disposable
+  insurance. Skip if Plan 04 starts right after.
+
+== Execution Workflow
+
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-02b-reconciliation`. One PR is expected.
+
+== Acceptance Criteria
+
+* A config with `read_timeout_ms: 2500` boots (test); the whole-second rule and its tests
+  are gone.
+* ADR-0009 reads Accepted, and the `doc/README.adoc` index agrees.
+* No documentation places `/q/*` on 8443; the library coordinates table exists exactly
+  once; no doc claims the token-sheriff modules are pending approval.
+* `jwks.source: inline` no longer exists in schema, model, or doc.
+* Zero `org.hamcrest` imports in the repository; the vacuous test classes are deleted.
+* `verify -Pintegration-tests` executes the invalid-config negative script and fails if the
+  container accepts an invalid config.
+* A benchmark run with an induced non-2xx upstream fails the run; the post-processor tests
+  assert concrete metric values.
+* Quality gate + full verify pass.
+
+== Out of Scope (explicit)
+
+* Everything Plan 03 owns: placeholder substitution, convention-env-lookup removal, anchors,
+  validator hardening (CIDR parsing, scheme allowlist, prefix normalization, secrets-rule
+  enforcement, `.yml` rejection, binding-message redaction).
+* Every runtime enforcement gap of the interim proxy (auth, verb gate, forward policy,
+  streaming, timeouts from config) -- Plan 04 replaces that edge; only the optional stopgap
+  above may touch it.
+* The `sheriff.config.dir`-related *behaviour* (only its documentation is in scope).

--- a/doc/plan/03-endpoint-anchors.adoc
+++ b/doc/plan/03-endpoint-anchors.adoc
@@ -170,12 +170,15 @@ Boot-time fixes that belong to the config plan; each is small and none changes t
 shape:
 
 . *`trusted_proxies` CIDR validation* -- parse every entry as a real CIDR at validation time
-  (malformed entries rejected with file/pointer context). The trust-all guard stops being a
-  string comparison: reject any entry (or combination-equivalent single entry such as
-  `0.0.0.0/1`) whose parsed prefix length is `0`, and boot-WARN on very broad prefixes
-  (shorter than `/8`). Today `0.0.0.0/1` + `128.0.0.0/1` passes as full-internet trust and
-  garbage CIDRs are accepted silently. The parsed form is kept -- Plan 04's TCP-peer gate
-  consumes it instead of re-parsing strings per request.
+  (malformed entries rejected with file/pointer context). The trust-all guard is defined by
+  *address-space coverage, not prefix length*: compute the union of the parsed ranges per
+  address family and reject the config when that union covers the *entire* IPv4 or IPv6 space
+  -- this catches a single full-space CIDR (`0.0.0.0/0`, `::/0`) *and* complementary
+  combinations that sum to the whole space (e.g. `0.0.0.0/1` + `128.0.0.0/1`, or `::/1` +
+  `8000::/1`). Boot-WARN on individually very broad prefixes (shorter than `/8` v4 or `/32`
+  v6) that are broad but not total. Test matrix: single full-space prefix, complementary /1
+  pairs, malformed CIDR, and both families. The parsed range set is kept -- Plan 04's TCP-peer
+  gate consumes it instead of re-parsing strings per request.
 . *Upstream scheme allowlist* -- `TopologyResolver` currently accepts any URI scheme
   (`ftp://host` resolves, then fails per-request at dispatch); restrict resolved alias URLs
   to `http`/`https` at boot.

--- a/doc/plan/03-endpoint-anchors.adoc
+++ b/doc/plan/03-endpoint-anchors.adoc
@@ -36,21 +36,24 @@ here:
   link:../configuration.adoc#_anchors[Anchors] section, the updated `gateway.yaml` and
   endpoint exhibits, and the updated
   link:../configuration.adoc#_configuration_validation_rules_summary[validation-rules summary].
-. Plan 02 (delivered; document archived under
-  `.plan/local/archived-plans/2026-07-13-implement-configuration-management/`) -- the config
-  subsystem this plan extends: loading pipeline, `ConfigValidator` conventions
-  (collect *all* violations), `RouteTableBuilder` materialization, fail-fast CDI wiring.
+. Plan 02 (delivered; its plan document is not kept in the repository -- the delivered
+  config subsystem itself is the reference) -- the subsystem this plan extends: loading
+  pipeline, `ConfigValidator` conventions (collect *all* violations), `RouteTableBuilder`
+  materialization, fail-fast CDI wiring.
 . link:../architecture.adoc[Architecture], section "Configuration Subsystem" -- immutability
   as a security property, refuse-to-start semantics.
 
 == Prerequisites
 
 * Plan 02 delivered (it is): schemas, loader, `ConfigValidator`, `RouteTable`, fail-fast boot.
-* The Plan-02 landing-gap fixes (separate plan, in flight). *Coordination note:* that plan
-  wires `EndpointEnablementResolver` into the producer; D4 below *replaces* the
-  convention-named env-override mechanism entirely (the resolver classes' env lookups are
-  removed). If this plan starts before the gap-fix plan merges, drop the enablement-wiring
-  item there instead of wiring code D4 deletes.
+* The Plan-02 landing-gap fixes are merged (PR #64). Note their end state:
+  `EndpointEnablementResolver` was left *unwired* -- `ConfigProducer` filters on the
+  file-resolved `enabled` value only, so the `ENDPOINT_<ID>_ENABLED` lookup is dead code
+  today (while `configuration.adoc` still advertises it). D4 below deletes that machinery
+  outright and makes the documented placeholder form the real mechanism.
+* link:02b-reconciliation.adoc[Plan 02b] (doc/code reconciliation) landed or running in
+  parallel -- it owns the doc-only fixes and quality-debt sweep; nothing in it overlaps
+  this plan's scope.
 
 == Design Decisions
 
@@ -128,6 +131,19 @@ enabled: ${ENDPOINT_APP1_ENABLED:-true}
 ----
 APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
 ----
+** *Grammar pinned down* (implementation directives; document them in `configuration.adoc`
+   in the same PR): placeholder syntax is `${NAME}` / `${NAME:-default}` with
+   `NAME` = `[A-Za-z_][A-Za-z0-9_]*`; the default is everything between the first `:-` and
+   the closing `}` (no nesting, no escaping inside the default); one scalar may contain
+   multiple placeholders; there is *no escape syntax* -- a scalar containing `${` that does
+   not match the grammar fails the boot with a clear error (a loud failure beats a silently
+   un-substituted literal).
+** *Secrets are classified on the pre-substitution value*: the loader must retain the raw
+   scalar so the secrets rule can verify that a secret-classified field was written as a
+   bare `${VAR}` reference (no default, no literal) -- after substitution the forms are
+   indistinguishable. This also closes a today-gap found in review: the documented secrets
+   rule is currently *unenforced* (a literal `client_secret` passes validation); implement
+   it as a D3-style validator rule with negative tests.
 * *The convention-named Java-level lookups are removed* (`TOPOLOGY_<ALIAS>` inside
   `TopologyResolver`, the `ENDPOINT_<ID>_ENABLED` machinery). The familiar variable *names*
   survive as a documented convention in the sample configs; the *mechanism* is the visible
@@ -138,16 +154,60 @@ APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
   type-invalid value fails the schema gate with the usual file/pointer error.
 * *Secrets rule unchanged*: fields classified as secrets must still be `${VAR}` references
   (no default, no literal).
-* *Doc-first cascade (same PR)*: amend link:../adr/0004-topology-indirection.adoc[ADR-0004]
-  (the single-URL-per-alias decision *stands*; the override channel changes from convention
-  env var to in-file placeholder) and rewrite the affected `configuration.adoc` passages
-  (topology env-override section, endpoint `enabled` comment, validation-rules bullets that
-  name `TOPOLOGY_<ALIAS>` / `ENDPOINT_<ID>_ENABLED`).
+* *Doc side already landed (2026-07-15)*:
+  link:../adr/0004-topology-indirection.adoc[ADR-0004] Amendment A1 and the affected
+  `configuration.adoc` passages (topology override section, endpoint `enabled` exhibit,
+  validation-rules bullets) already describe the placeholder mechanism -- the docs ran
+  doc-first and currently *over-state* the shipped behaviour (today only bare `${VAR}` is
+  substituted, and only as the secrets pass). The doc work remaining in this plan is
+  therefore verification plus caveat removal: implement the mechanism, drop the
+  "implementation lands with Plan 03" caveat, add the grammar rules above, and confirm every
+  passage matches the implemented semantics field-for-field.
+
+=== D5 -- Config-subsystem hardening (2026-07-17 adversarial review)
+
+Boot-time fixes that belong to the config plan; each is small and none changes the plan's
+shape:
+
+. *`trusted_proxies` CIDR validation* -- parse every entry as a real CIDR at validation time
+  (malformed entries rejected with file/pointer context). The trust-all guard stops being a
+  string comparison: reject any entry (or combination-equivalent single entry such as
+  `0.0.0.0/1`) whose parsed prefix length is `0`, and boot-WARN on very broad prefixes
+  (shorter than `/8`). Today `0.0.0.0/1` + `128.0.0.0/1` passes as full-internet trust and
+  garbage CIDRs are accepted silently. The parsed form is kept -- Plan 04's TCP-peer gate
+  consumes it instead of re-parsing strings per request.
+. *Upstream scheme allowlist* -- `TopologyResolver` currently accepts any URI scheme
+  (`ftp://host` resolves, then fails per-request at dispatch); restrict resolved alias URLs
+  to `http`/`https` at boot.
+. *Prefix normalization before disjointness* -- `path_prefix` values are compared byte-equal
+  today (`/api` vs `/api/` escape the same-prefix disjointness rule yet overlap at match
+  time); normalize (require leading `/`, strip trailing `/`) before every disjointness or
+  containment check -- the anchor rules of D3 inherit the same normalization. Additionally,
+  move the same-prefix route disjointness check out of `RouteTableBuilder` (which throws on
+  the first hit) into the all-violations `ConfigValidator` pass, per the
+  link:../adr/0009-asymmetric-alias-resolution-failure.adoc[ADR-0009] single-reporter
+  principle -- this also makes the "all violations reported together" claim in
+  `configuration.adoc` true.
+. *Endpoint file extension* -- a `*.yml` file in `endpoints/` is silently ignored today (a
+  formerly-protected route disappears without any error); fail the boot on stray `.yml`
+  files with a "rename to `.yaml`" message, and document the `.yaml`-only rule.
+. *Binding-error redaction* -- binding failures currently copy raw Jackson messages into
+  `ConfigError`s, which can echo resolved values (including secrets) into the boot log;
+  sanitize/truncate binding messages so no resolved scalar value is ever logged. Negative
+  test: a bind failure adjacent to a resolved secret never surfaces the secret text.
+. *YAML parse limits* -- apply explicit `StreamReadConstraints` / alias-expansion limits to
+  the YAML loader (defence-in-depth against config-file expansion bombs).
+. *Header-matcher disjointness reconciliation (doc-first)* -- the code accepts opposite
+  `present: true` / `present: false` matchers on the same header as disjoint; the doc says
+  only differing exact values disjoin. The code's semantics are sound (the two can never
+  match the same request) -- amend `configuration.adoc` (Route ordering) to match, same PR.
 
 == Work Breakdown
 
 . *Schemas* (D1) -- extend both schema files; refactor shared block definitions into `$defs`.
   Review field-by-field against link:../configuration.adoc[the doc]; the doc governs.
+  Note: the doc's Schemas section already lists `anchors`/`anchor` as if shipped -- this
+  plan makes that description true.
 . *Model records* (D2) -- `AnchorConfig`, extended `GatewayConfig`/`EndpointConfig`/
   `RouteConfig`/`ResolvedRoute`; contract tests via the established `cui-test-value-objects` /
   `cui-test-generator` patterns; `package-info.java` untouched packages excepted.
@@ -161,6 +221,7 @@ APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
   fields still reject literals and defaults.
 . *Validator rules* (D3) -- each rule with valid + violating fixtures; all violations
   collected in one pass with file/pointer context, per the Plan 02 convention.
+. *Hardening* (D5) -- the seven fixes above, each with positive and negative tests.
 . *RouteTable materialization* (D2) -- chain resolution, effective-value materialization,
   weakening WARNs, per-route effective-posture INFO log (new LogRecord, documented in
   `doc/LogMessages.adoc`).
@@ -188,17 +249,8 @@ APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-03-endpoint-anchors`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-03-endpoint-anchors`.
 
 == Acceptance Criteria
 
@@ -212,9 +264,15 @@ APP1=${TOPOLOGY_APP1:-https://app1.internal:8443/app1}
 * Per-route effective-posture INFO log emitted and documented in `doc/LogMessages.adoc`.
 * `${VAR}` / `${VAR:-default}` substitution works across all three artifacts with the D4 test
   matrix green; no convention-named env lookup remains in Java code (grep for
-  `TOPOLOGY_`/`ENDPOINT_` env access is clean); ADR-0004 amended and `configuration.adoc`
-  consistent with the placeholder mechanism.
-* `./mvnw -Ppre-commit clean verify -DskipTests` and `./mvnw clean install` pass; coverage of
+  `TOPOLOGY_`/`ENDPOINT_` env access is clean); `configuration.adoc` matches the implemented
+  placeholder semantics (grammar documented, "lands with Plan 03" caveat removed; ADR-0004
+  Amendment A1 already records the decision and needs no change).
+* D5 hardening in place: malformed or full-space `trusted_proxies` entries rejected
+  (negative tests include the `0.0.0.0/1` + `128.0.0.0/1` pair), non-http(s) alias schemes
+  fail the boot, `/api` vs `/api/` collide in the disjointness rules, a stray `.yml`
+  endpoint file fails the boot, the secrets rule rejects literal secret values, and binding
+  errors never echo resolved values.
+* Quality gate + full verify pass (canonical build commands, CLAUDE.md); coverage of
   the changed `config` packages >= 80%; integration tests (including the anchor-violation
   negative script) pass locally and on CI.
 * ADR-0007 status flipped to Accepted.

--- a/doc/plan/04-request-pipeline.adoc
+++ b/doc/plan/04-request-pipeline.adoc
@@ -214,14 +214,19 @@ catalogue ID and a testable assertion.
 * *GW-01 -- single-canonical-path invariant.* cui-http's `URLPathValidationPipeline` returns a
   canonical path; the gateway MUST route, verb-gate, auth-select, `allowed_paths`-match, and
   compute the upstream remainder from *that same* value, never the raw `ctx.request().uri()`.
-  Two residuals cui-http leaves open: (a) *encoded-slash policy* -- cui-http decodes `%2f` to a
-  structural `/`; pick reject (default, safest for prefix isolation) and apply it before
-  routing; (b) *matrix-param (`;`) handling* -- strip or reject `;` segments before matching.
-  Test with cui-http's traversal/encoding attack corpus PLUS encoded-slash and matrix-param
-  cases: every variant is rejected at stage 1 or routed+authorized+forwarded on one identical
-  path (upstream count = 0 on any bypass attempt). This is the dominant gateway CVE class
-  (Traefik x6, APISIX CVE-2021-43557, Kong CVE-2021-27306, Envoy CVE-2021-29492) and the fix
-  for the interim-proxy raw-vs-normalized finding.
+  Two residuals cui-http leaves open, both *pinned to reject* (deterministic, consistent with
+  deny-by-default; a legitimate backend that needs these can be added later behind an explicit
+  opt-in): (a) *encoded-slash* -- cui-http decodes `%2f` to a structural `/`; a request whose
+  raw path contained an encoded slash is *rejected* at stage 1 (400) rather than silently
+  routed on the decoded form; (b) *matrix params* -- a path segment containing `;` is
+  *rejected* at stage 1 (400). Both decisions and the resulting canonical value are recorded
+  doc-first in `configuration.adoc` and mirrored in the threat model (GW-01) so the corpus has
+  one expected outcome. Test with cui-http's traversal/encoding attack corpus PLUS
+  encoded-slash and matrix-param cases: every variant is rejected at stage 1 or
+  routed+authorized+forwarded on one identical path (upstream count = 0 on any bypass attempt).
+  This is the dominant gateway CVE class (Traefik x6, APISIX CVE-2021-43557, Kong
+  CVE-2021-27306, Envoy CVE-2021-29492) and the fix for the interim-proxy raw-vs-normalized
+  finding.
 * *GW-02 -- HTTP framing / anti-smuggling gate.* cui-http is explicitly out of scope for
   framing, so this is gateway/Vert.x: reject a request carrying both `Content-Length` and
   `Transfer-Encoding`, a body on a bodyless method (HEAD/GET-with-body), and any
@@ -296,7 +301,7 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
   is gone before wiring millisecond timeouts.
 . *Stages 0-3 + D3b GW-01/GW-02* -- security headers + CORS preflight, basic pipelines,
   the canonical-path invariant (route+verb-gate+auth+allowed_paths+remainder all on the one
-  canonical path; encoded-slash rejected; matrix `;` stripped/rejected), the framing gate,
+  canonical path; encoded-slash and matrix `;` both rejected -> 400), the framing gate,
   route selection, the `allowed_methods` verb gate (stage 2b -> 405 + `Allow`), thorough
   checks, allowed_paths matcher, body cap. Unit tests reuse the cui-http *attack databases*
   (`OWASPTop10AttackDatabase`, Apache/Nginx/IIS-CVE databases, plus the legitimate-pattern

--- a/doc/plan/04-request-pipeline.adoc
+++ b/doc/plan/04-request-pipeline.adoc
@@ -58,26 +58,31 @@ the event system, metrics, structured logging, and the RFC 9457 error contract.
 
 == Design Decisions
 
-=== D1 -- cui-http 2.1 (mandatory)
+=== D1 -- cui-http 2.1.0 (mandatory)
 
 The `de.cuioss.http.forwarded` package (`ForwardedHeaderResolver`, `ResolvedForwarding`,
-`ForwardedResolverConfig`) exists only in `de.cuioss:cui-http:2.1` -- *it is absent from the
-released 2.0.0 jar*. This plan therefore pins `cui-http:2.1`.
+`ForwardedResolverConfig`) exists only in `de.cuioss:cui-http:2.1.0` (released 2026-07-11,
+the current latest) -- *it is absent from the released 2.0.0 jar*. This plan therefore pins
+`cui-http:2.1.0`.
+
+*Already present* (landed with PR #68, versions managed by `token-sheriff-bom:0.9.2`): the
+entire TokenSheriff stack -- `token-sheriff-validation-quarkus` *and* the BFF engine modules
+(`token-sheriff-client`, `token-sheriff-client-quarkus`) are direct dependencies of
+`api-sheriff` today, and the validation extension is live (the `%it` profile configures an
+issuer; its JWKS readiness check gates the ITs). This plan adds *no* TokenSheriff
+dependency -- it wires what is already on the classpath. The engine modules stay unused
+until Plan 07.
 
 [IMPORTANT]
 ====
 Dependency changes -- *require explicit user approval before adding*:
 
-* `de.cuioss:cui-http:2.1` (inbound security pipelines, forwarded resolver; its client stack
-  serves the control plane only -- ADR-0008).
-* `de.cuioss.sheriff.token:token-sheriff-validation-quarkus:0.9.1` (direct; core
-  `token-sheriff-validation` arrives transitively). 0.9.1 is the released TokenSheriff line --
-  no snapshot repository needed.
+* `de.cuioss:cui-http:2.1.0` (inbound security pipelines, forwarded resolver; its client
+  stack serves the control plane only -- ADR-0008).
 * `io.quarkus:quarkus-smallrye-fault-tolerance` (version from the Quarkus BOM) -- the
-  programmatic per-route resilience guards of ADR-0008.
-
-The BFF engine modules (`token-sheriff-client*`) are *not* added here -- they belong to the
-later variant plans.
+  programmatic per-route resilience guards of ADR-0008 (`Guard`/`TypedGuard` are the
+  current, non-deprecated programmatic surface; the older `FaultTolerance` API is
+  deprecated for removal in SmallRye FT 7).
 ====
 
 === D2 -- Edge implementation: Vert.x route handler, not a JAX-RS resource
@@ -96,7 +101,22 @@ over a `@Path("{p:.*}")` RESTEasy resource:
   CPU work on that thread.
 
 Plan 01's placeholder `GatewayResource`/`ApiSheriff` and their tests are *removed* in this
-plan (pre-1.0 rule: delete, don't deprecate) once the pipeline serves real routes.
+plan (pre-1.0 rule: delete, don't deprecate) once the pipeline serves real routes -- this
+also removes the always-UP `/api/health` and the version-leaking `/api/info` from the public
+port. Once no JAX-RS resource remains, evaluate dropping `quarkus-resteasy`/
+`quarkus-resteasy-jackson` (check first whether `token-sheriff-client-quarkus`'s RFC 9457
+exception mapper needs them -- if so, keep and note why in the pom).
+
+*Edge hardening (same PR as the edge).* The listener itself must be bounded, not only the
+pipeline: explicit Vert.x `HttpServerOptions` limits (max header size, max initial-line
+length, max chunk size), an inbound idle/read timeout (slowloris guard), and a documented
+max-concurrent-requests bound (admission control before virtual-thread dispatch -- today
+nothing caps in-flight requests). Values come from `security_defaults` where the config
+models them and from fixed secure defaults where it does not (doc-first: record the chosen
+defaults in `configuration.adoc`). Graceful shutdown is part of the edge contract: on
+SIGTERM stop accepting, drain in-flight requests within the Quarkus shutdown timeout --
+the config-rollout story (restart-based, architecture doc) depends on it; assert draining
+in an IT.
 
 *Protocol processors.* The per-route `protocol` field selects a `ProtocolProcessor`
 (loaded per route at boot, from a small registry keyed by the config enum):
@@ -118,12 +138,22 @@ inbound request (virtual thread)
      including rejections); CORS preflight answered here, BEFORE auth
   1. BASIC CHECKS (gateway.yaml `security_defaults` profile, cui-http):
      PipelineFactory.createCommonPipelines(config, securityEventCounter)
-       - URLPathValidationPipeline on the raw path
+       - URLPathValidationPipeline on the raw path -> returns the CANONICAL path
+         (cui-http decodes %-encoding, collapses ../ and //, rejects
+         traversal/%00/overlong/backslash); this canonical value is the ONE
+         path used by every later stage (D3b GW-01 invariant)
        - URLParameterValidationPipeline / header pipelines on names+values
+         (header CR/LF/NUL rejected unconditionally by cui-http)
        - RequestCollectionValidator: header/parameter/cookie counts
+       - FRAMING GATE (gateway edge, D3b GW-02): reject CL+TE both present,
+         a body on a bodyless method, and any Connection-list attempt to strip
+         a framing/trust header
      violation -> 400 problem+json, INPUT_VALIDATION event                   [stage 1]
-  2. ROUTE SELECTION: RouteTable candidate match (path prefix AND methods AND
-     host AND headers), longest prefix wins; no candidate -> 404             [stage 2]
+  2. ROUTE SELECTION: RouteTable candidate match on the CANONICAL path (path
+     prefix AND methods AND host AND headers), longest prefix wins; no
+     candidate -> 404. Routing, the verb gate, auth, allowed_paths, and the
+     stage-6 remainder ALL consume this same canonical path -- never the raw
+     request-URI (D3b GW-01)                                                  [stage 2]
   2b. VERB GATE: matched route's effective allowed_methods (the anchor-aware
       effective set materialized at boot into ResolvedRoute); method outside
       it -> 405 + Allow header, INPUT_VALIDATION event                       [stage 2b]
@@ -173,6 +203,46 @@ inbound request (virtual thread)
 Every rejection path returns `application/problem+json` per the
 link:../architecture.adoc#_error_contract[error contract] table and never calls the upstream.
 
+=== D3b -- Threat-model hardening (2026-07-17 CVE review; see doc/security-threat-model.adoc)
+
+These are the gateway-owned controls the survey of real gateway CVEs demands. `cui-http` and
+the token-sheriff stack own large parts of the pipeline already (per-component
+canonicalization, header CR/LF/NUL rejection, collection limits, the forwarded resolver, JWT
+validation); D3b is the residual those libraries deliberately leave to the gateway. Each has a
+catalogue ID and a testable assertion.
+
+* *GW-01 -- single-canonical-path invariant.* cui-http's `URLPathValidationPipeline` returns a
+  canonical path; the gateway MUST route, verb-gate, auth-select, `allowed_paths`-match, and
+  compute the upstream remainder from *that same* value, never the raw `ctx.request().uri()`.
+  Two residuals cui-http leaves open: (a) *encoded-slash policy* -- cui-http decodes `%2f` to a
+  structural `/`; pick reject (default, safest for prefix isolation) and apply it before
+  routing; (b) *matrix-param (`;`) handling* -- strip or reject `;` segments before matching.
+  Test with cui-http's traversal/encoding attack corpus PLUS encoded-slash and matrix-param
+  cases: every variant is rejected at stage 1 or routed+authorized+forwarded on one identical
+  path (upstream count = 0 on any bypass attempt). This is the dominant gateway CVE class
+  (Traefik x6, APISIX CVE-2021-43557, Kong CVE-2021-27306, Envoy CVE-2021-29492) and the fix
+  for the interim-proxy raw-vs-normalized finding.
+* *GW-02 -- HTTP framing / anti-smuggling gate.* cui-http is explicitly out of scope for
+  framing, so this is gateway/Vert.x: reject a request carrying both `Content-Length` and
+  `Transfer-Encoding`, a body on a bodyless method (HEAD/GET-with-body), and any
+  `Connection`-list attempt to strip a framing header; re-validate framing after any header
+  mutation; do not pool an upstream connection whose framing was not fully validated. Assert
+  against a CL.TE/TE.CL/TE.TE/CL.0 corpus: zero desyncs. Justified because API Sheriff sits
+  behind other proxies by design (the forwarded-header model assumes it).
+* *GW-03 tie-in -- hop-by-hop cannot strip trust.* Header CR/LF/NUL is cui-http's job (done);
+  the gateway ensures a client `Connection: X-Forwarded-For`/`Content-Length` never causes the
+  regenerated forwarding header or a framing header to be dropped (shares the GW-02 gate).
+* *GW-08 -- HTTP/2 abuse bounds (terminated h2).* Verify and pin: stream-creation/reset rate
+  limiting (Rapid Reset, CVE-2023-44487), CONTINUATION frame count/size bounds (CERT
+  VU#421644), and that client `Upgrade: h2c`/`Connection` headers are never forwarded upstream.
+  Assert a Rapid-Reset/CONTINUATION load does not exhaust CPU/memory (connection dropped).
+  Quarkus/Netty ship partial mitigation -- this item *verifies and tests* it rather than
+  assuming it. (gRPC's forced-h2 upstream inherits this in Plan 05.)
+* *GW-07 tie-in -- the edge bounds* (header/line-size limits, inbound idle timeout, in-flight
+  admission cap, graceful drain) are in the edge-hardening work-breakdown item; cui-http does
+  *not* provide a streaming body limiter, so `max_body_bytes` stays the gateway stream counter
+  (stages 3/6).
+
 === D4 -- Event system, metrics, logging (built here, low base package)
 
 * `de.cuioss.sheriff.api.events`: `EventCategory` (failure categories per architecture doc),
@@ -201,9 +271,8 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
 
 == Work Breakdown
 
-. *Dependencies* (after approval): cui-http 2.1,
-  token-sheriff-validation-quarkus 0.9.1 (released), quarkus-smallrye-fault-tolerance
-  (Quarkus BOM).
+. *Dependencies* (after approval): cui-http 2.1.0 and quarkus-smallrye-fault-tolerance
+  (Quarkus BOM). The TokenSheriff stack is already present (0.9.2 via `token-sheriff-bom`).
 . *Arch-gate* (ADR-0005 -- mandatory from this first pipeline PR): the ArchUnit rule
   asserting the framework-agnostic packages (`config.model`, `config.validation`, `events`,
   `routing`, `forward`, `pipeline`) carry no `io.quarkus..`, `io.vertx..`,
@@ -222,21 +291,31 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
   `SecurityConfiguration`/pipeline set per distinct profile shape, one Vert.x client
   (+ connection pool) per distinct upstream-target tuple -- routes sharing a shape/target
   share the instance, not a copy. Boot-time rejection of `grpc`/`websocket`/`session` (this
-  plan's scope guard). Remove the whole-second-timeout `ConfigValidator` rule and its tests
-  (obsolete per ADR-0008 -- millisecond timeouts are native now).
-. *Stages 0-3* -- security headers + CORS preflight, basic pipelines, route selection, the
-  `allowed_methods` verb gate (stage 2b -> 405 + `Allow`), thorough checks, allowed_paths
-  matcher, body cap. Unit tests use the cui-http *attack databases* (`OWASPTop10AttackDatabase`,
-  CVE databases, plus the legitimate-pattern databases for false-positive guarding) via
-  `@GeneratorsSource`-style parameterized tests; add a verb-gate test (method outside the
-  effective set -> 405 with the correct `Allow` set, upstream never called).
+  plan's scope guard). The whole-second-timeout `ConfigValidator` rule is removed by
+  link:02b-reconciliation.adoc[Plan 02b] (ADR-0008 already documents it as gone); verify it
+  is gone before wiring millisecond timeouts.
+. *Stages 0-3 + D3b GW-01/GW-02* -- security headers + CORS preflight, basic pipelines,
+  the canonical-path invariant (route+verb-gate+auth+allowed_paths+remainder all on the one
+  canonical path; encoded-slash rejected; matrix `;` stripped/rejected), the framing gate,
+  route selection, the `allowed_methods` verb gate (stage 2b -> 405 + `Allow`), thorough
+  checks, allowed_paths matcher, body cap. Unit tests reuse the cui-http *attack databases*
+  (`OWASPTop10AttackDatabase`, Apache/Nginx/IIS-CVE databases, plus the legitimate-pattern
+  databases for false-positive guarding) via `@ArgumentsSource`/`@GeneratorsSource` -- these
+  ship in cui-http's *test-jar* (add the `test-jar`/`tests`-classifier dependency, an approval
+  item). Add: a GW-01 divergence corpus (encoded-traversal / `%2f` / matrix-param / trailing
+  slash) asserting no authorize-as-public / dispatch-to-protected split (upstream count = 0);
+  a GW-02 smuggling corpus (CL+TE, HEAD-with-body, `Connection`-strip) asserting 400 and zero
+  desyncs; a verb-gate test (method outside the effective set -> 405 with the correct `Allow`
+  set, upstream never called).
 . *Stage 4* -- TokenValidator producer wiring from `token_validation` config (single shared
   validator at startup), bearer extraction, scope enforcement; tests with
-  `token-sheriff-validation`'s `generators` test-jar key material; JWKS over
+  `token-sheriff-validation`'s `generators`-classifier artifact
+  (`token-sheriff-validation-0.9.2-generators.jar`) for key material; JWKS over
   `cui-test-mockwebserver-junit5`.
 . *Stage 5* -- forward-policy filtering; TCP-peer gate + resolver wiring + regeneration
   (assert: spoofed inbound `X-Forwarded-For` from a non-trusted peer is ignored; chains are
-  regenerated, never appended).
+  regenerated, never appended). The gate consumes the CIDR list parsed at boot by Plan 03
+  D5 -- no per-request string parsing.
 . *Stage 6 + 7* -- dispatch via the shared Vert.x client through the route's FT guard,
   hop-by-hop header stripping, *body streaming with backpressure* (Vert.x
   `ReadStream.pipeTo`/`Pipe` in both directions -- no `HttpResult<byte[]>` materialization of
@@ -257,33 +336,30 @@ when any bearer route exists, the `TokenValidator`'s issuer/JWKS loading status
     exactly the allow-listed headers/params + regenerated `X-Forwarded-*` and nothing else;
   * bearer route: real Keycloak token accepted (the `integration` realm finally earns its
     keep), tampered/expired token -> 401 problem+json, missing scope -> 403;
-  * filter rejection -> 400; unmatched route -> 404; upstream down -> 502; timeout -> 504;
-    breaker -> 503 with Retry-After (fault injection per the infrastructure chosen in
-    Plan 01);
+  * filter rejection -> 400; unmatched route -> 404; upstream down -> 502 (stopped upstream
+    container); timeout -> 504 (go-httpbin `/delay/<n>` beyond the route's read timeout);
+    breaker -> 503 with Retry-After (induced consecutive failures) -- no Toxiproxy needed
+    here, it joins the stack in Plan 06;
+  * graceful shutdown: SIGTERM during an in-flight request completes the response, then the
+    process exits within the shutdown timeout;
   * `/q/metrics` shows the `sheriff_*` meters moving.
+  * Assertion style: REST-assured's Hamcrest matchers conflict with the project's
+    forbidden-frameworks rule -- new ITs use `.extract()` + JUnit assertions (Plan 02b
+    migrates the existing ones).
 . *Benchmarks* -- extend the WRK suite with a bearer-validated proxied route (wrk ->
   gateway -> echo upstream) alongside Plan 01's plain-proxy benchmark, so validation overhead
-  is measured separately from proxy overhead.
+  is measured separately from proxy overhead. Precondition (Plan 02b): the lua error
+  counters aggregate correctly and runs fail above an error threshold -- without that, a
+  gateway that starts rejecting requests would benchmark as *faster*.
 . *Docs* -- update `doc/LogMessages.adoc`; note any deliberate deviations discovered during
   implementation back into `architecture.adoc` (the doc governs; deviations need a doc PR,
   not silent drift).
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-04-request-pipeline`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
-
-If the plan has to be split into multiple PRs, this workflow applies to each PR; the build
-must be green after every one.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-04-request-pipeline`. A multi-PR split is acceptable; the workflow
+applies to each PR and the build must be green after every one.
 
 == Acceptance Criteria
 
@@ -296,9 +372,16 @@ must be green after every one.
 * Bearer validation works offline against Keycloak-issued tokens in ITs; upstream is never
   called on any rejection (assert via echo-side request counting).
 * Metrics/eventing surface matches the names in `architecture.adoc`.
+* Edge bounds enforced: header/line-size limits, inbound idle timeout, in-flight admission
+  cap, and graceful drain on SIGTERM -- each with a test; the chosen defaults are recorded
+  in `configuration.adoc` (doc-first).
+* D3b threat-model hardening (link:../security-threat-model.adoc[catalogue] GW-01/02/03/08)
+  each has a passing test: the single-canonical-path invariant (no bypass corpus reaches an
+  upstream), the framing/anti-smuggling gate (zero desyncs), and the HTTP/2 abuse bounds
+  (Rapid-Reset/CONTINUATION load stays bounded; client `h2c`/`Connection` never forwarded).
 * The ADR-0005 arch-gate rule exists, runs in the quality gate, and fails on a deliberate
   violation (verified once, then reverted).
-* `./mvnw -Ppre-commit clean verify -DskipTests`, `./mvnw clean install`, integration-tests
+* Quality gate + full verify (canonical build commands, CLAUDE.md), integration-tests
   profile, and the benchmark profile all pass locally and on CI; coverage >= 80% on new
   packages.
 
@@ -307,5 +390,5 @@ must be green after every one.
 * `require: session` / OIDC / BFF behaviour (variant plans; engine modules not yet added).
 * WebSocket upgrade and gRPC streaming processors (config-visible, boot-rejected here).
 * TLS `passthrough_sni` L4 relay and `mtls` (separate plan; needs listener-level work).
-* Rate limiting (deferred feature, reserved config).
+* Rate limiting (out of scope entirely, reserved config -- plan README).
 * HTTP/3 (ADR-0002).

--- a/doc/plan/05-protocol-processors.adoc
+++ b/doc/plan/05-protocol-processors.adoc
@@ -45,17 +45,27 @@ protocol promise and, with it, the link:../variants/01-base-gateway.adoc[Variant
   `Origin` against an allowlist and reject unknown origins *before* the upstream is dialed.
   For `require: session` WS routes (Plan 07) this reuses the BFF's
   `session.csrf.trusted_origins` set -- the WS Origin check and the stage-0 CORS/CSRF posture
-  are the same trust decision; a bearer WS route uses a configured `allowed_origins` (add the
-  field doc-first if a route needs it). Never authenticate a socket on the ambient session
-  cookie alone.
+  are the same trust decision. For a *bearer* WS route the origin allowlist is a new
+  `security_headers`-adjacent field, `allowed_origins`, defined *doc-first* in
+  `configuration.adoc` (schema, field reference, validation-rules summary) before
+  implementation with these fixed semantics: a list of *exact-match* origin strings
+  (scheme+host+port, no wildcards); matching is case-insensitive on host only; and the check
+  is *fail-closed* -- a WS upgrade on a bearer route whose `allowed_origins` is absent or empty
+  is rejected (there is no "any origin" default). The acceptance criteria assert the
+  missing/empty-allowlist rejection. Never authenticate a socket on the ambient session cookie
+  alone.
 * After the upstream confirms the upgrade, the established stream is relayed bidirectionally
   (Vert.x WebSocket/`NetSocket` pipes with backpressure, both directions). *No per-message
   filtering* -- the security filter operates on HTTP metadata only
   (architecture doc); `max_body_bytes` does not apply to frames. Close frames and ping/pong
   relay transparently; a half-close on either side closes both. Long-lived relays are still
-  bounded resources: they count against the Plan 04 edge connection/in-flight accounting,
-  and an idle-timeout policy for established relays is decided (and documented) here --
-  a silently dead socket must not live forever.
+  bounded resources: they count against the Plan 04 edge connection/in-flight accounting, and
+  an established relay is reclaimed after a *bounded idle timeout* -- pinned here as a
+  configurable per-route `websocket.idle_timeout_seconds` (default 300s), where "idle" means
+  no frame in *either* direction. WebSocket ping/pong counts as activity, so an application
+  that keeps the socket warm with heartbeats is never reclaimed -- the timeout only reaps
+  genuinely dead sockets. An IT asserts an idle established relay is closed after the timeout
+  while a heartbeated one survives. (Defined doc-first in `configuration.adoc`.)
 * Upgrade failure mapping: upstream refuses the upgrade -> the refusal status relays;
   upstream unreachable -> the standard `502`/`504` contract *before* `101`.
 
@@ -108,7 +118,9 @@ assertions.
 . *Integration tests* (per the link:README.adoc[convention]: complete in this plan) --
   WebSocket: authenticated echo round-trip through the gateway, unauthenticated handshake
   rejected `401` before any upstream contact, *foreign-`Origin` handshake rejected before any
-  upstream contact* (GW-09), unmatched WS path `404`; gRPC: unary + streaming
+  upstream contact* (GW-09), *bearer WS route with missing/empty `allowed_origins` rejected*
+  (fail-closed), *an idle established relay reclaimed after `idle_timeout_seconds` while a
+  heartbeated relay survives*, unmatched WS path `404`; gRPC: unary + streaming
   echo through the gateway with metadata injection asserted, `grpc-status` relay from the
   failing method, `UNAUTHENTICATED` trailers-only rejection on a bearer gRPC route without a
   token.

--- a/doc/plan/05-protocol-processors.adoc
+++ b/doc/plan/05-protocol-processors.adoc
@@ -38,20 +38,37 @@ protocol promise and, with it, the link:../variants/01-base-gateway.adoc[Variant
   basic checks, route selection, verb gate, thorough checks, *authentication on the
   handshake* (effective auth; `bearer` now, `session` works automatically once Plan 07
   lands), zero-trust forward policy on the handshake headers.
+* *`Origin` validation on the upgrade (GW-09, doc/security-threat-model.adoc).* The
+  Same-Origin Policy does *not* restrict cross-origin WebSocket connections -- only
+  server-side `Origin` checking does, so an accept-any-origin upgrader is a cross-site
+  hijack (CSWSH: Nginx-UI CVE-2026-34403, Dozzle CVE-2026-44985). Validate the handshake
+  `Origin` against an allowlist and reject unknown origins *before* the upstream is dialed.
+  For `require: session` WS routes (Plan 07) this reuses the BFF's
+  `session.csrf.trusted_origins` set -- the WS Origin check and the stage-0 CORS/CSRF posture
+  are the same trust decision; a bearer WS route uses a configured `allowed_origins` (add the
+  field doc-first if a route needs it). Never authenticate a socket on the ambient session
+  cookie alone.
 * After the upstream confirms the upgrade, the established stream is relayed bidirectionally
   (Vert.x WebSocket/`NetSocket` pipes with backpressure, both directions). *No per-message
   filtering* -- the security filter operates on HTTP metadata only
   (architecture doc); `max_body_bytes` does not apply to frames. Close frames and ping/pong
-  relay transparently; a half-close on either side closes both.
+  relay transparently; a half-close on either side closes both. Long-lived relays are still
+  bounded resources: they count against the Plan 04 edge connection/in-flight accounting,
+  and an idle-timeout policy for established relays is decided (and documented) here --
+  a silently dead socket must not live forever.
 * Upgrade failure mapping: upstream refuses the upgrade -> the refusal status relays;
   upstream unreachable -> the standard `502`/`504` contract *before* `101`.
 
 === D2 -- gRPC processor: HTTP/2 metadata proxying with trailer relay
 
-* gRPC is the HTTP processor plus three deltas: the upstream connection must be HTTP/2
-  (`h2`/`h2c` via the shared per-tuple Vert.x client), response *trailers* relay to the
-  client (`grpc-status`/`grpc-message` live there), and request/response bodies stream as
-  opaque length-prefixed frames (no protobuf inspection -- explicitly out of scope).
+* gRPC is the HTTP processor plus three deltas: the upstream connection is forced to HTTP/2
+  (`h2`/`h2c` via the shared per-tuple Vert.x client -- note the protocol version thereby
+  joins the "distinct upstream target tuple" that keys client sharing), response *trailers*
+  relay to the client (`grpc-status`/`grpc-message` live there), and request/response bodies
+  stream as opaque length-prefixed frames (no protobuf inspection -- explicitly out of
+  scope). Whether the upstream actually speaks h2 is unknowable at boot (it is a remote
+  capability, not config); an upstream that fails h2 negotiation at dispatch maps to
+  `UNAVAILABLE` per the rejection table below.
 * *Gateway-rejection mapping for gRPC routes*: a gRPC client cannot consume
   `application/problem+json`. Rejections on `protocol: grpc` routes are emitted as
   trailers-only gRPC responses with the canonical mapping -- `UNAUTHENTICATED` (401),
@@ -61,6 +78,11 @@ protocol promise and, with it, the link:../variants/01-base-gateway.adoc[Variant
   the doc governs.
 * Streaming RPCs (client-, server-, bidi-streaming) need no special handling beyond
   streaming both directions without buffering -- which is the ADR-0006/0008 default.
+* *HTTP/2 abuse bounds carry over (GW-08).* The forced-h2 upstream and the terminated h2
+  edge inherit Plan 04 D3b's Rapid-Reset / CONTINUATION-flood limits; verify they hold on the
+  gRPC path too (a gRPC client opens many streams by nature -- the per-connection
+  stream-reset rate limit must not misfire on legitimate streaming, but must still bound an
+  abusive reset loop).
 
 === D3 -- Test upstreams
 
@@ -73,10 +95,11 @@ assertions.
 == Work Breakdown
 
 . *WebSocket processor* (D1) -- handshake-through-pipeline, relay, close semantics; unit
-  tests for auth-on-handshake (401 before upgrade, upstream never dialed), forward-policy
-  filtering of handshake headers, relay in both directions.
-. *gRPC processor* (D2) -- h2 upstream enforcement (boot error when the resolved alias
-  cannot speak h2 where declared), trailer relay, the rejection-mapping table; unit tests
+  tests for auth-on-handshake (401 before upgrade, upstream never dialed), *Origin validation
+  on the handshake* (GW-09: foreign origin rejected before any upstream dial; only allowlisted
+  origins complete), forward-policy filtering of handshake headers, relay in both directions.
+. *gRPC processor* (D2) -- forced-h2 upstream client wiring (negotiation failure at
+  dispatch -> `UNAVAILABLE`), trailer relay, the rejection-mapping table; unit tests
   per mapping row.
 . *Error-contract doc update* (D2, same PR) -- the gRPC status mapping into
   `architecture.adoc`; new LogRecords into `doc/LogMessages.adoc`.
@@ -84,33 +107,26 @@ assertions.
   healthcheck.
 . *Integration tests* (per the link:README.adoc[convention]: complete in this plan) --
   WebSocket: authenticated echo round-trip through the gateway, unauthenticated handshake
-  rejected `401` before any upstream contact, unmatched WS path `404`; gRPC: unary + streaming
+  rejected `401` before any upstream contact, *foreign-`Origin` handshake rejected before any
+  upstream contact* (GW-09), unmatched WS path `404`; gRPC: unary + streaming
   echo through the gateway with metadata injection asserted, `grpc-status` relay from the
   failing method, `UNAUTHENTICATED` trailers-only rejection on a bearer gRPC route without a
   token.
 . *Benchmarks* (README convention) -- a WebSocket echo benchmark (connection + message
   round-trip throughput through the gateway vs. direct-to-upstream) and a gRPC unary echo
-  benchmark against the in-repo echo service. *Tooling note*: `wrk` speaks HTTP/1.1 only --
-  neither WebSocket nor gRPC load can ride the existing lua scripts. Use `ghz` (pinned
-  container) for gRPC and a pinned WebSocket load tool (or a small in-repo Vert.x load
-  driver) for WS, emitting the same `=== BENCHMARK METADATA ===` block so the existing
-  post-processor and pages pipeline consume them unchanged; tool choice is recorded in this
-  plan as an amendment when made.
+  benchmark against the in-repo echo service. *Tooling (decided, research 2026-07-17)*:
+  `wrk` speaks HTTP/1.1 only -- neither WebSocket nor gRPC load can ride the existing lua
+  scripts. gRPC load uses `ghz` via its official image `ghcr.io/bojand/ghz` (pin the
+  current release, e.g. `0.121.0`); WebSocket load uses `k6` via `grafana/k6` (pinned tag;
+  the `k6/websockets` module -- the old third-party `obvionaoe/ghz` Docker Hub image is
+  stale, do not use it). Both wrappers emit the same `=== BENCHMARK METADATA ===` block so
+  the existing post-processor and pages pipeline consume them unchanged.
 . *Docs* -- variant-1 doc note that the protocol scope is complete; README sweep.
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-05-protocol-processors`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-05-protocol-processors`.
 
 == Acceptance Criteria
 

--- a/doc/plan/06-tls-edge.adoc
+++ b/doc/plan/06-tls-edge.adoc
@@ -153,8 +153,12 @@ branch `feature/plan-06-tls-edge`.
 * Per-SNI/per-route mTLS policies (global `tls.mtls` only).
 * Optional/want-style client auth, certificate-to-identity mapping (no L7 identity is
   derived from client certs in this plan).
-* Client-certificate revocation checking (CRL/OCSP) -- not performed initially; rotating the
-  `client_ca` (restart, per the immutable-config model) is the revocation mechanism.
-  Documented as an operator consideration.
+* Client-certificate revocation checking (CRL/OCSP) -- not performed initially. There is
+  therefore *no selective per-certificate revocation*. The only lever is *emergency
+  trust-root replacement*: swapping `client_ca` (restart, per the immutable-config model)
+  invalidates the *entire* old trust root at once -- every client cert issued by it stops
+  being accepted, not just a compromised one -- so its blast radius is global and it forces
+  re-issuance for all legitimate clients. Documented as an operator consideration with that
+  blast radius stated explicitly; genuine per-cert revocation (CRL/OCSP) is future work.
 * PROXY-protocol emission on the passthrough relay (revisit if a passthrough backend needs
   client IPs).

--- a/doc/plan/06-tls-edge.adoc
+++ b/doc/plan/06-tls-edge.adoc
@@ -23,15 +23,19 @@ Toxiproxy into the integration stack for stream-level fault injection.
   `tls.passthrough_sni` ... never reach the route table".
 . link:../adr/0004-topology-indirection.adoc[ADR-0004] (+ Amendment A1) -- passthrough
   targets resolve through the same alias indirection routes use.
+. link:../adr/0009-asymmetric-alias-resolution-failure.adoc[ADR-0009] -- an unresolvable
+  passthrough alias is *skipped* by the resolver and reported by the validator's
+  passthrough-alias-resolvable rule; the relay wiring must consume the resolved map
+  accordingly (a missing entry means the validator already failed the boot).
 . Plan 04 (delivered by then) -- the terminated listener and pipeline this plan fronts.
 
 == Prerequisites
 
 * Plan 04 delivered. Plan 05 is *not* required (independent tracks).
-* Coordination: if the Plan-02 gap-fix effort has not yet landed the two passthrough
-  *validation* rules (SNI/`match.host` collision, passthrough-alias-no-base-path), they are
-  delivered here; if it has, this plan only consumes them. Check before starting -- never
-  implement twice.
+* The passthrough *validation* rules are already delivered (Plan-02 gap fixes, PR #64):
+  SNI/`match.host` collision, passthrough-alias-resolvable (ADR-0009 ownership), and
+  passthrough-alias-no-base-path all live in `ConfigValidator`. This plan only consumes
+  them -- do not implement them twice.
 
 == Design Decisions
 
@@ -47,12 +51,32 @@ The split happens *before* HTTP exists: a front TCP listener reads the TLS Clien
 * *Any other SNI, or none* -> hand the connection to the terminated stack (certificate,
   `min_version`, `alpn`, `mtls`) and the full L7 pipeline.
 
-Implementation spike (first work item): choose between (a) a Vert.x `NetServer` front that
-parses the ClientHello and hands terminated connections to the HTTP stack over an internal
-channel, and (b) the Netty `SniHandler` integration point if Quarkus exposes one cleanly.
-The *behaviour* above is fixed either way; only the wiring is open. When `passthrough_sni`
-is empty (the default), the front listener is bypassed entirely -- zero cost for
-non-passthrough deployments.
+[IMPORTANT]
+====
+*Fail-closed SNI (GW-06, doc/security-threat-model.adoc).* A fragmented ClientHello whose SNI
+cannot yet be read must NOT fall through to a permissive path -- Traefik CVE-2026-32305 is
+exactly this: split ClientHello -> empty SNI -> default TLS config that did not require client
+certs -> mTLS bypassed. Therefore: (a) reassemble the *full* ClientHello before deciding the
+SNI split (do not decide on a partial TLS record); (b) an empty/unresolved SNI takes the
+*terminated, strict* path (never a passthrough and never a no-client-cert default) or is
+rejected; (c) every security-gating boolean here (`mtls.enabled`, upstream/`min_version`) gets
+a *behaviour* test -- a real handshake fails when the control says it must -- not merely a
+config-parsed assertion (Traefik CVE-2025-66491 was an *inverted* verify flag that passed
+config parsing for ~5 months). The punycode host-normalization collision (KrakenD
+CVE-2026-39821) is covered by the same case-insensitive SNI/`match.host` collision rule
+applied to normalized hostnames.
+====
+
+Wiring approach (pre-decided, research 2026-07-17): Quarkus exposes *no* clean listener-level
+Netty `SniHandler` integration point for custom SNI-based TCP routing -- its SNI support is
+limited to TLS certificate selection on the HTTP server, and raw-TCP-listener support is an
+open feature request (quarkus#38873; the documented guidance is "inject the managed `Vertx`
+and create your own `NetServer`", discussion #25609). Option (a) it is: a Vert.x `NetServer`
+front that parses the ClientHello and hands terminated connections to the HTTP stack over an
+internal channel. The first work item is therefore a *wiring validation spike* of that
+approach (internal-handoff mechanics, port ownership), not an A/B decision. When
+`passthrough_sni` is empty (the default), the front listener is bypassed entirely -- zero
+cost for non-passthrough deployments.
 
 === D2 -- mTLS on terminated connections
 
@@ -72,14 +96,15 @@ handshake; there is no HTTP-level fallback and no partial "optional mTLS" mode i
 
 === D4 -- Toxiproxy
 
-`ghcr.io/shopify/toxiproxy` (pinned) joins docker-compose between gateway and upstreams
+`ghcr.io/shopify/toxiproxy` (pin the current release, e.g. `2.12.0`) joins docker-compose
+between gateway and upstreams
 (anticipated by Plan 01 D2): needed here for stream-level fault tests (mid-stream reset on a
 passthrough relay) and available onward for breaker/timeout ITs.
 
 == Work Breakdown
 
-. *Spike + decision* (D1): ClientHello/SNI wiring approach; record the choice in this plan
-  doc (amendment) and, if architecturally relevant, in `architecture.adoc`.
+. *Wiring-validation spike* (D1): prove the `NetServer`-front handoff mechanics (approach
+  pre-decided above); record anything architecturally relevant in `architecture.adoc`.
 . *Passthrough relay* (D1) -- accept-time split, L4 pipe with backpressure, connection
   lifecycle (half-close, abort propagation), boot-time alias resolution; unit tests with raw
   TLS clients against a TLS-enabled test backend.
@@ -103,17 +128,8 @@ passthrough relay) and available onward for breaker/timeout ITs.
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-06-tls-edge`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-06-tls-edge`.
 
 == Acceptance Criteria
 
@@ -122,6 +138,10 @@ passthrough relay) and available onward for breaker/timeout ITs.
 * Empty `passthrough_sni` -> measurably zero-overhead path (benchmark comparison against the
   Plan 04 baseline; no regression beyond noise).
 * Both guards enforced with negative tests; mTLS accept/reject proven at handshake level.
+* GW-06 fail-closed SNI proven: a fragmented/empty-SNI ClientHello does not reach a
+  passthrough or a no-client-cert default (terminated-strict or rejected); enabling mTLS
+  makes a real no-cert handshake fail (behaviour test, not a flag-read); the punycode
+  normalization case is caught by the SNI/`match.host` collision rule.
 * Integration-test suite green locally and on CI, covering every behaviour above.
 * The passthrough-relay benchmark runs in the benchmark profile and publishes via the pages
   pipeline.
@@ -133,5 +153,8 @@ passthrough relay) and available onward for breaker/timeout ITs.
 * Per-SNI/per-route mTLS policies (global `tls.mtls` only).
 * Optional/want-style client auth, certificate-to-identity mapping (no L7 identity is
   derived from client certs in this plan).
+* Client-certificate revocation checking (CRL/OCSP) -- not performed initially; rotating the
+  `client_ca` (restart, per the immutable-config model) is the revocation mechanism.
+  Documented as an operator consideration.
 * PROXY-protocol emission on the passthrough relay (revisit if a passthrough backend needs
   client IPs).

--- a/doc/plan/07-bff-server-session.adoc
+++ b/doc/plan/07-bff-server-session.adoc
@@ -78,13 +78,27 @@ provide: persistence, a return-URL field, and single-use enforcement (its single
 it *persists and guards* the engine's `FlowContext`.
 
 Decision: a *pending-authorization record* wrapping the engine `FlowContext`, gateway-side,
-keyed by `state`: short fixed TTL (minutes), strictly single-use (consumed or expired, never
-retried -- the enforcement the engine leaves open), plus the original request URL for the
-post-login redirect (same-origin-validated -- never an open redirect). Storage follows the
-binding seam: bounded in-memory map in this plan (oldest-eviction -- unauthenticated browsers
-create these records, so the bound is a DoS guard), sealed short-lived `__Host-` login cookie
-in the cookie variant (Plan 08). *Doc-first*: record the chosen design in the variant doc's
-Login Flow section in the same PR.
+with short fixed TTL (minutes), strictly single-use (consumed or expired, never retried -- the
+enforcement the engine leaves open), plus the original request URL for the post-login redirect
+(same-origin-validated -- never an open redirect).
+
+*Browser-bound, not `state`-keyed alone (security-critical).* A record retrievable by `state`
+value is not tied to the browser that started the flow -- an attacker could begin a flow and
+deliver its callback URL to a victim (login CSRF / code delivery to the wrong browser). So the
+record is *bound to the initiating browser* by a short-lived `HttpOnly`, `Secure`,
+`SameSite=Lax`, `__Host-` *binding cookie* set at redirect time, carrying an unguessable
+handle (server mode: the record id; cookie mode: the sealed record itself). The callback is
+valid only when *both* the returned `state` matches *and* the binding cookie resolves to the
+*same* record -- a callback arriving in a browser without the matching binding cookie is
+rejected. This is the pre-session analogue of the session cookie and composes with the engine's
+constant-time `state` check. Test: a callback replayed in a *different* browser (no binding
+cookie) is rejected even with a valid `state`.
+
+Storage follows the binding seam: bounded in-memory map in this plan (oldest-eviction --
+unauthenticated browsers create these records, so the bound is a DoS guard) with the binding
+cookie holding the record id; in the cookie variant (Plan 08) the binding cookie *is* the
+sealed record, so there is no server map. *Doc-first*: record the chosen design (incl. the
+binding cookie) in the variant doc's Login Flow section in the same PR.
 
 === D2c -- Threat-model residuals the engine leaves to the gateway (2026-07-17 CVE review)
 
@@ -143,8 +157,12 @@ RP-initiated per the variant doc: revoke (engine), destroy session, expire cooki
 to `end_session_endpoint` with `id_token_hint` + exact-match `post_logout_redirect_uri` +
 session-bound `state` carried in the short-lived single-use `+__Host-sheriff-logout+`
 cookie; verify on the return leg, then `final_redirect`. Back-channel: signature via the
-issuer/JWKS infrastructure, then the gateway-code logout-token checks (`events` contains the
-back-channel event, `nonce` absent, `sub`/`sid` present), destroy via the secondary index.
+issuer/JWKS infrastructure, then the *full* gateway-code logout-token checks -- validate
+`iss` and `aud` like an ID token, require `iat` within a short freshness window (replay
+guard), require `events` to contain the back-channel-logout event, require `nonce` *absent*,
+require `sub`/`sid` present -- then destroy via the secondary index. (The `iss`/`aud`/`iat`
+requirements match threat-model BFF-09; omitting freshness would let a captured valid logout
+token be replayed later.)
 
 === D7 -- Refresh and step-up
 
@@ -172,16 +190,19 @@ via the engine/validation health checks -- reuse, don't rebuild.
   duplicate-`code`-rejected test.
 . *Session store + cookie* (D3) -- store contract + memory implementation (TTL eviction,
   secondary index), cookie codec; unit tests incl. expiry and O(1) back-channel lookup.
-. *Pending-authorization record* (D2b) -- bounded single-use store + tests (TTL expiry,
-  single-use consumption, bound eviction, return-URL same-origin validation).
+. *Pending-authorization record* (D2b) -- bounded single-use store + browser-binding cookie
+  + tests (TTL expiry, single-use consumption, bound eviction, return-URL same-origin
+  validation, *cross-browser callback rejection* -- a valid `state` without the matching
+  binding cookie is refused).
 . *Login flow* (D1/D2/D2b) -- engine-driven code flow; state/nonce round-trip via the
   pending-authorization record; session creation; post-login redirect to the recorded URL.
 . *Stage 4 session auth* (D4) -- negotiation, injection, scope enforcement; remove the
   boot-time `session` rejection.
 . *CSRF* (D5) -- fixed check + events; parameterized positive/negative tests
   (trusted origin, untrusted, `Sec-Fetch-Site` variants, absent both).
-. *Logout* (D6) -- both channels; unit tests incl. logout-token check matrix and the
-  logout-`state` cookie round-trip.
+. *Logout* (D6) -- both channels; unit tests incl. the full logout-token check matrix
+  (`iss`/`aud` wrong, `iat` outside the freshness window, `events` missing, `nonce` present,
+  `sub`/`sid` absent -- each rejected) and the logout-`state` cookie round-trip.
 . *Refresh + step-up* (D7) -- single-flight, failure semantics; step-up orchestration.
 . *Readiness* (D8) + metrics/LogRecords for the new events (`CSRF_REJECTED`, session
   lifecycle, refresh outcomes); document in `doc/LogMessages.adoc`.

--- a/doc/plan/07-bff-server-session.adoc
+++ b/doc/plan/07-bff-server-session.adoc
@@ -36,20 +36,18 @@ delta on this foundation.
 
 * Plans 03 + 04 delivered (anchors give the `bff` namespace floor; the pipeline provides
   stage 4 and the reserved-path hook). Plans 05/06 are *not* required.
-* Keycloak in the compose stack (present since Plan 01, so far unused -- "the `integration`
-  realm finally earns its keep" moves here if Plan 04's bearer ITs left anything unclaimed).
+* Keycloak in the compose stack (present since Plan 01; Plan 04's bearer ITs already
+  exercise its `integration` realm -- this plan adds the full browser-shaped OIDC flows on
+  top).
 
 == Design Decisions
 
-=== D1 -- Engine dependency (requires dependency approval)
+=== D1 -- Engine dependency (already on the classpath)
 
-[IMPORTANT]
-====
-New dependencies -- *require explicit user approval before adding*:
-
-* `de.cuioss.sheriff.token:token-sheriff-client-quarkus:0.9.1` (direct; the core
-  `token-sheriff-client` engine arrives transitively). Released line, no snapshots.
-====
+The engine modules are *already direct dependencies* of `api-sheriff`:
+`token-sheriff-client` and `token-sheriff-client-quarkus` landed with PR #68 at 0.9.2
+(versions managed by `token-sheriff-bom`), unused until this plan. No dependency change is
+expected here; if one shows up (e.g. a session-store helper), the approval rule applies.
 
 The engine owns: authorization-request construction (PKCE, `state`, `nonce`, mix-up
 defence), the code exchange, token validation wiring, refresh with rotation + reuse
@@ -65,14 +63,64 @@ library has no logout-token pipeline -- variant doc, Logout).
 OIDC host* (configuration doc). Registered ahead of the catch-all in the edge layer; a proxy
 route `path_prefix: /auth` never swallows `/auth/callback`.
 
+=== D2b -- Transient pre-login state (gap closed 2026-07-17)
+
+Neither the variant doc nor the configuration doc says where `state`, `nonce`, the PKCE
+verifier, and the post-login return URL live *between* the redirect to the IdP and the
+callback -- before any session exists.
+
+*Confirmed engine reality (0.9.2 source review):* the engine's `FlowContext` *is* the
+transaction DTO -- it bundles `state` (32-byte SecureRandom) + `nonce` + `PkceChallenge`
+(verifier, S256-only) + `redirect_uri` (+ optional `acr_values`/`max_age`), and verifies
+`state`/`nonce` constant-time on callback, fail-closed. What it deliberately does *not*
+provide: persistence, a return-URL field, and single-use enforcement (its single-use is a
+*caller contract*, not enforced by the type). So the gateway does not re-invent the record --
+it *persists and guards* the engine's `FlowContext`.
+
+Decision: a *pending-authorization record* wrapping the engine `FlowContext`, gateway-side,
+keyed by `state`: short fixed TTL (minutes), strictly single-use (consumed or expired, never
+retried -- the enforcement the engine leaves open), plus the original request URL for the
+post-login redirect (same-origin-validated -- never an open redirect). Storage follows the
+binding seam: bounded in-memory map in this plan (oldest-eviction -- unauthenticated browsers
+create these records, so the bound is a DoS guard), sealed short-lived `__Host-` login cookie
+in the cookie variant (Plan 08). *Doc-first*: record the chosen design in the variant doc's
+Login Flow section in the same PR.
+
+=== D2c -- Threat-model residuals the engine leaves to the gateway (2026-07-17 CVE review)
+
+The engine and validation lib own almost every OIDC control fail-closed (see
+link:../security-threat-model.adoc[the threat model]: PKCE `S256`-only, `state`/`nonce`
+constant-time verify, RFC 9207 `iss` mix-up, alg pinning incl. an in-library
+CVE-2022-21449 guard, JWKS `jku`/`x5u` ignored behind an SSRF egress policy, refresh
+rotation + family reuse-revoke, RP-initiated logout with *exact-match*
+`post_logout_redirect_uri`). Do *not* re-implement any of these. Three residuals are
+genuinely the gateway's and must be built/wired correctly:
+
+* *Callback HPP (BFF-13)* -- the engine's `CallbackParameters.parse(rawQuery)` rejects
+  duplicate `code`/`state` (Keycloak CVE-2026-9689 class), but *only* when fed the *raw*
+  query string; the `of(Map)` overload cannot re-detect duplicates a map already collapsed.
+  The callback endpoint MUST call `parse(rawQuery)`. Test a duplicate-`code` callback is
+  rejected.
+* *Scope enforcement* -- the validation lib exposes `providesScopes()`/`getScopes()` but
+  enforces *nothing*; the gateway enforces `required_scopes` against the mediated token
+  (`403 SCOPE_MISSING`) itself (already Plan 04 stage 4 for bearer; the same call here for
+  session).
+* *Back-channel logout-token checks* -- no library support at all (confirmed: the engine
+  ships RP-initiated logout but no logout-token pipeline); the gateway implements the
+  `events`-required / `sub`|`sid`-required / `nonce`-forbidden validation (D6), reusing the
+  validation pipeline only for the signature/`iss`/`aud`.
+
 === D3 -- Session store (`mode: server`)
 
 In-memory store keyed by opaque session id, holding access + refresh + raw ID token and
 metadata (`expiry`, `acr`, `auth_time`, `sid`); secondary index by `sid`/`sub` for O(1)
 back-channel destruction (variant doc, Token Storage). `memory` is the only store --
 single-node / sticky-session deployments; a shared store is deliberately unsupported.
-TTL (`ttl_seconds`) is absolute from login. Session cookie: `HttpOnly`, `Secure`,
-`SameSite=Lax`, `__Host-` prefix, opaque id only.
+TTL (`ttl_seconds`) is absolute from login; eviction is lazy on access plus a periodic
+sweep (no per-session timer threads), and the store carries a documented max-session bound
+(sessions are created only after a successful IdP login, but the ceiling still belongs in
+the operator's capacity math). Session cookie: `HttpOnly`, `Secure`, `SameSite=Lax`,
+`__Host-` prefix, opaque id only.
 
 === D4 -- `require: session` runtime (stage 4)
 
@@ -102,9 +150,10 @@ back-channel event, `nonce` absent, `sub`/`sid` present), destroy via the second
 
 Refresh within `leeway_seconds` through the engine, single-flighted per session; reuse
 detection -> family revoked; failure -> destroy session + `on_failure` semantics. Step-up
-(RFC 9470): parse `insufficient_user_authentication` challenges, attempt silent
-satisfaction, else re-drive the code flow with elevated parameters and replay -- engine legs,
-gateway orchestration.
+(RFC 9470): parse `insufficient_user_authentication` challenges from the *upstream's*
+`WWW-Authenticate` response header, attempt silent satisfaction, else re-drive the code
+flow with the challenge's `acr_values`/`max_age` and replay -- engine legs, gateway
+orchestration.
 
 === D8 -- Readiness
 
@@ -113,13 +162,20 @@ via the engine/validation health checks -- reuse, don't rebuild.
 
 == Work Breakdown
 
-. *Dependency* (D1, after approval); verify the engine API surface against 0.9.1 before
-  coding (the docs were verified against pre-release source).
-. *Reserved endpoints* (D2) -- callback, logout, logout-return, back-channel; exact-match
-  registration + unit tests proving a `/auth` proxy route does not swallow them.
+. *Engine verification* (D1) -- the modules are already on the classpath (0.9.2); verify
+  the engine API surface against the shipped 0.9.2 jars before coding (the design docs were
+  verified against pre-release source), including whether a pending-authorization
+  abstraction exists (D2b).
+. *Reserved endpoints* (D2/D2c) -- callback, logout, logout-return, back-channel; exact-match
+  registration + unit tests proving a `/auth` proxy route does not swallow them; the callback
+  parses the *raw* query via `CallbackParameters.parse(rawQuery)` (BFF-13) with a
+  duplicate-`code`-rejected test.
 . *Session store + cookie* (D3) -- store contract + memory implementation (TTL eviction,
   secondary index), cookie codec; unit tests incl. expiry and O(1) back-channel lookup.
-. *Login flow* (D1/D2) -- engine-driven code flow; state/nonce round-trip; session creation.
+. *Pending-authorization record* (D2b) -- bounded single-use store + tests (TTL expiry,
+  single-use consumption, bound eviction, return-URL same-origin validation).
+. *Login flow* (D1/D2/D2b) -- engine-driven code flow; state/nonce round-trip via the
+  pending-authorization record; session creation; post-login redirect to the recorded URL.
 . *Stage 4 session auth* (D4) -- negotiation, injection, scope enforcement; remove the
   boot-time `session` rejection.
 . *CSRF* (D5) -- fixed check + events; parameterized positive/negative tests
@@ -150,21 +206,10 @@ via the engine/validation health checks -- reuse, don't rebuild.
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-07-bff-server-session`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
-
-If the plan has to be split into multiple PRs (likely -- it is the largest plan), the
-workflow applies to each PR and the build must be green after every one; the boot-time
-`session` rejection falls only in the PR that completes stage 4.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-07-bff-server-session`. A multi-PR split is likely (this is the
+largest plan); the boot-time `session` rejection falls only in the PR that completes
+stage 4.
 
 == Acceptance Criteria
 
@@ -172,7 +217,9 @@ workflow applies to each PR and the build must be green after every one; the boo
   compose Keycloak, entirely through the gateway; the upstream only ever sees the injected
   bearer.
 * All fixed security behaviours (CSRF, state verification both flows, exact
-  `post_logout_redirect_uri`, logout-token checks) have negative tests.
+  `post_logout_redirect_uri`, logout-token checks) have negative tests; the D2c residuals
+  (BFF-13 duplicate-`code` rejected via `parse(rawQuery)`; session-route scope enforcement ->
+  `403`) each have a test.
 * No OAuth leg is implemented in gateway code (review checklist item -- the engine boundary
   from the architecture doc holds).
 * Integration-test suite green locally and on CI, covering every behaviour above.

--- a/doc/plan/08-bff-cookie.adoc
+++ b/doc/plan/08-bff-cookie.adoc
@@ -43,7 +43,13 @@ stay shared (review checklist item).
 
 AES-256-GCM authenticated encryption; plaintext = access + refresh + raw ID token (needed as
 `id_token_hint` -- a stateless gateway cannot drive RP-initiated logout without it) +
-minimal metadata; value = ciphertext + nonce + tag. Tamper -> authentication failure ->
+minimal metadata. Codec specifics (implementation directives): a fresh random 96-bit nonce
+per seal (never derived, never counter-based -- GCM nonce reuse under one key is
+catastrophic); the cookie value is `version || key-id || nonce || ciphertext || tag`,
+base64url-encoded, with `version` (one byte, format evolution) and `key-id` (which of
+current/previous sealed it -- deterministic key selection instead of try-both decryption)
+bound into the GCM *associated data* together with the cookie name, so a value cannot be
+replayed under a different format version or cookie. Tamper -> authentication failure ->
 treated as no session. Keys by env indirection (`encryption_key`; the secrets rule applies);
 rotation: `previous_key` is decrypt-only, accepted cookies re-seal with the current key on
 next write. *Size budget*: the sealed cookie must stay within ~4 KB; exceeding it at seal
@@ -57,6 +63,18 @@ re-seals into a new `Set-Cookie`; refresh-reuse rejection is an ordinary refresh
 (session ends, `on_failure` drives re-auth); IdP-side reuse tolerance is documented as an
 operator trade-off (availability vs. RFC 9700 theft detection), never a gateway default.
 
+*Why "per instance" is a hard boundary (BFF-08, confirmed by 0.9.2 source review).* The
+engine's reuse detection (`RefreshTokenFamily` / `TokenLifecycleManager`) is fail-closed but
+its family map is *in-memory per instance* (a bounded LRU). In the stateless cookie shape --
+multiple instances, no shared state by design -- a family therefore *cannot* be tracked
+across instances: an RT rotated on instance A and replayed against instance B is not seen as
+reuse by B. This is inherent to the variant, not a defect; the mitigations are exactly the
+documented ones (short `ttl_seconds` / short access-token lifetimes; IdP-side reuse tolerance
+as the operator's availability-vs-detection call). If cross-instance detection is ever
+required, the engine's `TokenStore` SPI is the seam for a shared family store -- but that
+reintroduces the external dependency the variant exists to avoid, so it stays out of scope
+(choose Variant 2 for instant, node-spanning revocation).
+
 === D4 -- Back-channel logout is disabled (`404`)
 
 In `mode: cookie` the `backchannel_path` returns `404` -- there is no session to destroy,
@@ -68,6 +86,11 @@ lifetimes) and the "choose Variant 2 for instant revocation" guidance stay docum
 
 . *`SessionBinding` seam* (D1) -- extract from Plan 07 if not already shaped that way;
   boot-time selection from validated config.
+. *Pre-login state delta* (Plan 07 D2b) -- the pending-authorization record travels as a
+  sealed, short-lived `__Host-` login cookie (same codec, separate cookie name in the AAD);
+  the callback requires the returned `state` to match the cookie's. Strict single-use is
+  unattainable statelessly -- the short TTL bounds the replay window; document that
+  trade-off next to the variant doc's statelessness properties.
 . *Cookie codec* (D2) -- seal/unseal, rotation, size budget; unit tests: round-trip, tamper
   rejection (flipped byte in each of ciphertext/nonce/tag), previous-key acceptance +
   re-seal, oversized-set rejection, key material never logged.
@@ -89,17 +112,8 @@ lifetimes) and the "choose Variant 2 for instant revocation" guidance stay docum
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-08-bff-cookie`.
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-08-bff-cookie`.
 
 == Acceptance Criteria
 

--- a/doc/plan/08-bff-cookie.adoc
+++ b/doc/plan/08-bff-cookie.adoc
@@ -75,6 +75,12 @@ required, the engine's `TokenStore` SPI is the seam for a shared family store --
 reintroduces the external dependency the variant exists to avoid, so it stays out of scope
 (choose Variant 2 for instant, node-spanning revocation).
 
+*Release risk acceptance (BFF-08, threat model).* This per-instance limitation is an
+*explicit, documented accepted risk* of the stateless variant, not an open defect: the 1.0
+release records it as risk-accepted (with the short-lifetime mitigations above) rather than
+gating on a shared coordination store. The threat model's BFF-08 status is split accordingly
+(COVERED server / PARTIAL-accepted cookie).
+
 === D4 -- Back-channel logout is disabled (`404`)
 
 In `mode: cookie` the `backchannel_path` returns `404` -- there is no session to destroy,
@@ -87,10 +93,13 @@ lifetimes) and the "choose Variant 2 for instant revocation" guidance stay docum
 . *`SessionBinding` seam* (D1) -- extract from Plan 07 if not already shaped that way;
   boot-time selection from validated config.
 . *Pre-login state delta* (Plan 07 D2b) -- the pending-authorization record travels as a
-  sealed, short-lived `__Host-` login cookie (same codec, separate cookie name in the AAD);
-  the callback requires the returned `state` to match the cookie's. Strict single-use is
-  unattainable statelessly -- the short TTL bounds the replay window; document that
-  trade-off next to the variant doc's statelessness properties.
+  sealed, short-lived `__Host-` login cookie (same codec, separate cookie name in the AAD),
+  which *is* the browser binding (it is `HttpOnly`+`Secure`+`__Host-`); the callback requires
+  the returned `state` to match the cookie's *and* the cookie to be present. Strict single-use
+  is unattainable statelessly -- the short TTL bounds the replay window. *Release risk
+  acceptance (BFF-02):* record this bounded-replay-window as an explicit accepted risk next to
+  the variant doc's statelessness properties (server mode gives true single-use; cookie mode
+  accepts the minutes-long window). The threat model's BFF-02 status is split accordingly.
 . *Cookie codec* (D2) -- seal/unseal, rotation, size budget; unit tests: round-trip, tamper
   rejection (flipped byte in each of ciphertext/nonce/tag), previous-key acceptance +
   re-seal, oversized-set rejection, key material never logged.

--- a/doc/plan/09-release-readiness.adoc
+++ b/doc/plan/09-release-readiness.adoc
@@ -34,17 +34,24 @@ discovered here that is feature-shaped becomes its own follow-up.
   (new top-level doc or `doc/guide/`): first boot with a minimal config, adding an endpoint,
   anchors, topology + `${VAR:-default}` overrides in containers, TLS/mTLS/passthrough,
   choosing and configuring a BFF variant, reading the boot log / effective-posture output,
-  every LogRecord an operator may see (link to `doc/LogMessages.adoc`). Seeded from the
+  every LogRecord an operator may see (link to `doc/LogMessages.adoc`), and the
+  observability surface: metrics, health, and how to enable per-request access logging
+  (the Quarkus HTTP access log -- the gateway deliberately ships events + metrics, not its
+  own access-log implementation; say so explicitly). Seeded from the
   integration sample configs so every snippet is *tested* configuration. The design docs
   stay design docs; the guide never duplicates normative rules, it links them.
 . *ADR-0005 checkpoint* -- measure the framework-agnostic surface (package sizes, arch-gate
   history); decide extract-vs-reaffirm with the user; record the outcome as an ADR-0005
   amendment (and execute the mechanical extraction if chosen -- the arch-gate has kept it
   package-to-module by construction).
-. *Security-audit sweep* -- full-surface audit (config validation gaps, header handling,
-  cookie/CSRF/logout flows, forwarding trust, error-detail leakage, container posture);
-  every finding triaged: fixed here, or explicitly risk-accepted with rationale. Fresh
-  dependency + container-image CVE pass.
+. *Security-audit sweep* -- full-surface audit driven by
+  link:../security-threat-model.adoc[the Threat Model & CVE-Derived Validation Baseline]:
+  every COVERED/PARTIAL catalogue assertion must have a passing test, and every GAP row must
+  be closed or explicitly risk-accepted with rationale (config validation gaps, header
+  handling, cookie/CSRF/logout flows, forwarding trust, error-detail leakage, container
+  posture are all catalogue entries). Fresh dependency + container-image CVE pass; any new
+  CVE in a comparable gateway/OAuth stack is triaged into a new catalogue row. Consider a
+  short ADR recording that this baseline is a 1.0 release gate.
 . *Benchmark consolidation* -- the per-plan benchmarks (README convention: each hot-path
   plan shipped its own) are consolidated into one side-by-side report -- baseline
   (`/q/health`), plain proxy, bearer, WebSocket, gRPC, passthrough relay, BFF mediation
@@ -53,8 +60,10 @@ discovered here that is feature-shaped becomes its own follow-up.
   coverage; a gap found here is a defect of the plan that skipped it.
 . *Native + container hardening* -- native build + ITs against the native image in CI
   (not only JVM mode) if not already the default; distroless image review (user, filesystem,
-  exposed ports, JFR variant), resource-limit guidance measured (heap ceilings under the
-  benchmark load).
+  exposed ports, JFR variant, the default `quarkus.log.file.path` working under a read-only
+  root), resource-limit guidance measured (heap ceilings under the benchmark load);
+  graceful-shutdown drain re-verified under load (the Plan 04 behaviour, now with the full
+  feature set); SBOM generation for the released image as part of the CVE pass.
 . *Release mechanics* -- version 1.0.0, release notes generated from the plan/ADR trail,
   tag + publish per cuioss release conventions; `doc/plan/README.adoc` updated to mark the
   sequence delivered; declare the end of the pre-1.0 break-freely rules in `CLAUDE.md`
@@ -62,19 +71,9 @@ discovered here that is feature-shaped becomes its own follow-up.
 
 == Execution Workflow
 
-. Create a feature branch from up-to-date `main`: `feature/plan-09-release-readiness`
-  (several PRs expected -- guide, audit fixes, benchmarks, release -- each following the
-  standard workflow below).
-. Implement the work breakdown above.
-. Verify everything locally -- both must pass with zero errors/warnings:
-  `./mvnw -Ppre-commit clean verify -DskipTests` (quality gate) and `./mvnw clean install`.
-. Commit and push the branch.
-. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
-. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
-  checks are green.
-. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
-  reason for not fixing + resolve; when uncertain, ask the user before acting.
-. Merge the PR, then `git checkout main && git pull`.
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/plan-09-release-readiness`. Several PRs are expected -- guide, audit fixes,
+benchmarks, release -- each following the standard workflow.
 
 == Acceptance Criteria
 

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -24,8 +24,18 @@ The plans build strictly on one another:
 | 02 -- Configuration Management (delivered)
 | JSON Schemas for `gateway.yaml` / `endpoints/*.yaml`, the loading/resolution/validation
   pipeline (topology indirection, fail-fast boot), immutable `GatewayConfig` + `RouteTable`,
-  config mounted into the integration containers.
+  config mounted into the integration containers. (The landing-gap fixes -- enablement
+  filter, passthrough validation rules, ADR-0009 asymmetry -- merged separately, PR #64.)
 | Plan 01
+
+| link:02b-reconciliation.adoc[02b -- Doc/Code Reconciliation & Quality Debt]
+| The 2026-07-17 adversarial-review sweep: docs and delivered code re-agree (whole-second
+  timeout rule actually removed, ADR-0009 flipped Accepted, README ports fixed, library
+  claims deduplicated, dead `jwks: inline` deleted), test hygiene (vacuous tests deleted,
+  Hamcrest removed, the invalid-config negative script wired into the build), and the
+  benchmark harness made trustworthy (aggregated error counters, error-rate gating,
+  value-asserting parser tests). No features.
+| Plans 01 + 02 (independent of 03; land before or alongside it)
 
 | link:03-endpoint-anchors.adoc[03 -- Endpoint Anchors]
 | Namespace-scoped policy (link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007]): `anchors` in
@@ -38,8 +48,9 @@ The plans build strictly on one another:
 | link:04-request-pipeline.adoc[04 -- Request Pipeline]
 | The data plane for standard HTTP verbs: cui-http inbound filtering (basic + per-route),
   route selection, protocol-processor loading, offline bearer validation, zero-trust forward
-  policy with regenerated forwarding headers (cui-http:2.1), dispatch with
-  retry/circuit breaker, plus the event system, metrics, logging, and RFC 9457 error edge.
+  policy with regenerated forwarding headers (cui-http:2.1.0), dispatch with
+  retry/circuit breaker, hardened edge limits + graceful drain, plus the event system,
+  metrics, logging, and RFC 9457 error edge.
 | Plans 01 + 02 + 03
 
 | link:05-protocol-processors.adoc[05 -- Protocol Processors]
@@ -59,10 +70,11 @@ The plans build strictly on one another:
 
 | link:07-bff-server-session.adoc[07 -- BFF Foundation + Variant 2 (Server Session)]
 | The headline differentiator, *stateful shape first* (operator decision 2026-07-15):
-  `token-sheriff-client` 0.9.1 as the OIDC confidential-client engine; reserved gateway
-  paths; in-memory session store + opaque `__Host-` cookie; `require: session` runtime with
-  content negotiation; fixed CSRF defence; transparent refresh; RP-initiated + back-channel
-  logout; RFC 9470 step-up (link:../variants/02-bff-session.adoc[Variant 2]).
+  `token-sheriff-client` 0.9.2 as the OIDC confidential-client engine (already on the
+  classpath); reserved gateway paths; pending-authorization record; in-memory session store
+  + opaque `__Host-` cookie; `require: session` runtime with content negotiation; fixed
+  CSRF defence; transparent refresh; RP-initiated + back-channel logout; RFC 9470 step-up
+  (link:../variants/02-bff-session.adoc[Variant 2]).
 | Plans 03 + 04; consumes `oidc` config from Plan 02
 
 | link:08-bff-cookie.adoc[08 -- Variant 3 (Cookie, Stateless)]
@@ -79,7 +91,9 @@ The plans build strictly on one another:
 | All of 05-08
 |===
 
-Sequencing rationale: 05 and 06 are small increments on a freshly-built pipeline and transport
+Sequencing rationale: 02b is a pure correction sweep with no feature content -- it runs
+first (or alongside 03) so nothing later builds on documentation that contradicts the code
+or on a benchmark harness that cannot detect failure. 05 and 06 are small increments on a freshly-built pipeline and transport
 (do them while that knowledge is hot; 05 also completes what ADR-0002 promises for the initial
 scope). The BFF track (07 -> 08) is the largest and riskiest block and lands on a stabilized
 data plane; within it the *stateful* server-session shape comes first (operator decision,
@@ -90,14 +104,29 @@ shift (e.g. pull 07 forward for a BFF demo); within that block the only hard edg
 config stays reserved/accepted-and-ignored, no `429` is produced), and, deferred by
 link:../adr/0002-initial-scope.adoc[ADR-0002], dynamic configuration/discovery and HTTP/3.
 
+== Execution Workflow (every plan)
+
+The same fixed sequence applies to every plan (and to every PR, when a plan splits into
+several -- the build must be green after each one, not only at plan completion):
+
+. Create a feature branch from up-to-date `main` (each plan names its branch).
+. Implement the plan's work breakdown.
+. Verify locally -- both must pass with zero errors/warnings: the quality gate
+  (`verify -Ppre-commit`) and the full verify (`verify`), run via the canonical build
+  commands in `CLAUDE.md`.
+. Commit and push the branch.
+. Create the PR (`gh pr create --repo cuioss/API-Sheriff --base main ...`).
+. Wait ~5 minutes for the AI reviewers to complete, and `gh pr checks --watch` until all
+  checks are green.
+. Handle *every* review comment: fix + commit + push + reply + resolve, or reply with the
+  reason for not fixing + resolve; when uncertain, ask the user before acting.
+. Merge the PR, then `git checkout main && git pull`.
+
+Each plan's own *Execution Workflow* section only names its branch and any plan-specific
+deviation (e.g. an expected multi-PR split); it does not restate this sequence.
+
 == Conventions
 
-* Every plan carries an *Execution Workflow* section -- the same fixed sequence each time:
-  feature branch off `main` -> implement -> `./mvnw -Ppre-commit clean verify -DskipTests` +
-  `./mvnw clean install` (both green) -> commit -> push -> PR -> wait ~5 minutes for the AI
-  reviewers and watch checks -> handle *every* review comment (fix or justified reply, then
-  resolve) -> merge -> `git checkout main && git pull`. Builds must be green after every PR,
-  not only at plan completion.
 * *Integration tests are part of the plan, never deferred*: a plan is complete only when
   every behaviour it delivers is exercised by the `integration-tests` suite (positive and
   negative paths) and the full integration profile is green -- locally and on CI -- before
@@ -106,11 +135,14 @@ link:../adr/0002-initial-scope.adoc[ADR-0002], dynamic configuration/discovery a
 * *Benchmarks follow the same rule for the hot path*: every plan that adds a runtime
   data-plane behaviour ships a WRK benchmark for it in the same plan (following the existing
   lua/sh + metadata conventions so the pages pipeline picks it up unchanged), so regressions
-  stay attributable to the plan that caused them. Boot-time-only plans (02, 03) are exempt --
-  nothing on the hot path to measure. Plan 09 consolidates baselines and regression
+  stay attributable to the plan that caused them. Plans with no new hot-path behaviour
+  (02, 02b, 03) are exempt -- nothing to measure (02b instead repairs the harness itself). Plan 09 consolidates baselines and regression
   thresholds; it does not create missing coverage.
 * *Dependency approvals*: every new Maven dependency a plan needs is flagged inside the plan
   with an IMPORTANT block and requires explicit user approval before it is added
-  (CLAUDE.md rule). TokenSheriff artifacts use the released line (currently `0.9.1`), never
-  snapshots.
+  (CLAUDE.md rule). TokenSheriff artifacts use the released line (currently `0.9.2`, managed
+  by `token-sheriff-bom`), never snapshots -- the whole stack (validation + client modules)
+  is already in the build since PR #68, so Plans 04 and 07 wire existing dependencies rather
+  than adding them. The remaining approval-gated additions are `cui-http:2.1.0` and
+  `quarkus-smallrye-fault-tolerance` (Plan 04).
 * Pre-1.0 rules apply throughout: delete instead of deprecate, break freely, keep APIs clean.

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -95,12 +95,13 @@ Sequencing rationale: 02b is a pure correction sweep with no feature content -- 
 first (or alongside 03) so nothing later builds on documentation that contradicts the code
 or on a benchmark harness that cannot detect failure. 05 and 06 are small increments on a freshly-built pipeline and transport
 (do them while that knowledge is hot; 05 also completes what ADR-0002 promises for the initial
-scope). The BFF track (07 -> 08) is the largest and riskiest block and lands on a stabilized
+scope). The BFF track (07 then 08) is the largest and riskiest block and lands on a stabilized
 data plane; within it the *stateful* server-session shape comes first (operator decision,
 2026-07-15), the stateless cookie variant is its delta. 05 and 06 are mutually independent
 and independent of the BFF track -- they can be reordered or interleaved freely if priorities
-shift (e.g. pull 07 forward for a BFF demo); within that block the only hard edges are
-08 -> 07 and 09 -> everything (all of 05-07 already require 04, and 07 additionally 03). Explicitly *not* on the roadmap: *rate limiting* (out of scope -- the `rate_limit`
+shift (e.g. pull 07 forward for a BFF demo); within that block the only hard dependency edges
+are *08 depends on 07* and *09 depends on everything before it* (all of 05-07 already depend
+on 04, and 07 additionally on 03). Explicitly *not* on the roadmap: *rate limiting* (out of scope -- the `rate_limit`
 config stays reserved/accepted-and-ignored, no `429` is produced), and, deferred by
 link:../adr/0002-initial-scope.adoc[ADR-0002], dynamic configuration/discovery and HTTP/3.
 

--- a/doc/security-threat-model.adoc
+++ b/doc/security-threat-model.adoc
@@ -1,0 +1,1041 @@
+= API Sheriff -- Threat Model & CVE-Derived Validation Baseline
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectnumlevels: 2
+
+This document is the security contract API Sheriff validates *against*. It has three
+parts:
+
+. *Trust boundaries and STRIDE* -- the assets, the boundaries a request crosses, and the
+  threat categories per boundary.
+. *Failure catalogue* -- every failure class that has produced a real, cited CVE in a
+  comparable API gateway, reverse proxy, or OAuth/OIDC stack (the gateways surveyed in
+  link:archive/others/README.adoc[the competitive analysis] -- APISIX, Kong, Traefik,
+  KrakenD, Tyk, Gravitee -- plus the canonical proxy/JOSE CVEs). Each class carries the
+  transferable lesson, the API Sheriff control that defeats it, a *status*, and a *testable
+  assertion*.
+. *Validation matrix* -- every control mapped to the plan that owns it and the assertion
+  that proves it, so this document doubles as a release gate.
+
+[IMPORTANT]
+====
+*How to use this document.* It is normative for the security posture, not for behaviour --
+where a control's behaviour is specified, link:configuration.adoc[the configuration model]
+and link:architecture.adoc[the architecture] govern; this document names the *threat* the
+control exists to answer and the *assertion* that proves it still does. Every catalogue
+entry's assertion is meant to become a test (unit, integration, or benchmark) so a
+regression re-opens a known-historical hole loudly. Status values:
+
+* *COVERED* -- a plan, ADR, or delivered code owns the control; the assertion has (or will
+  have) a test.
+* *PARTIAL* -- the control exists but the assertion is not fully pinned, or only one half of
+  an equivalence class is closed.
+* *GAP* -- no plan yet owns this control; the "Gaps to bake in" section collects these as
+  recommended plan amendments (the original goal: learn from others' failures *before*
+  shipping the feature).
+* *ELIMINATED* -- the failure class does not apply because a design decision removed the
+  surface entirely (recorded so an audit can confirm the surface stays removed).
+====
+
+== Foundation libraries (what is already owned upstream)
+
+API Sheriff is not implementing these controls from scratch -- two audited libraries own
+large parts of the catalogue, and the residual gateway work is exactly the part they
+deliberately leave to the application. Attribution below reflects a 2026-07-17 source review
+of the local `cui-http` (2.1.0) and `TokenSheriff` (0.9.2) trees.
+
+*`cui-http` (inbound filtering + forwarded resolution) provides:* per-component path
+canonicalization returning a *normalized* path (`URLPathValidationPipeline` -- decodes
+percent-encoding, collapses `..`/dot-segments and duplicate slashes, rejects
+traversal/`%00`/overlong/backslash *unconditionally*); header name/value CR/LF/NUL rejection
+(`CharacterValidationStage`, unconditional); collection count + length limits
+(`RequestCollectionValidator`, `LengthValidationStage`); the forwarded-header trust engine
+(`ForwardedHeaderResolver` -- CIDR-validated `trustedProxies`, right-to-left drop-untrusted,
+per-value sanitization, canonical `X-Forwarded-*`/RFC 7239 regeneration, NiFi aliases); the
+shared `SecurityEventCounter`; and reusable attack corpora (OWASP/ZAP/ModSec-CRS/Apache/Nginx/
+IIS-CVE databases + encoding/traversal generators) shipped in its *test-jar*.
+
+*`cui-http` deliberately does NOT provide* (gateway/web-server owns): request-level *framing*
+/ smuggling defence (CL vs TE, chunked, HEAD-with-body, hop-by-hop `Connection` abuse) --
+explicitly "infrastructure layer"; a *streaming* body-size limiter (the `BODY` pipeline is
+removed; `max_body_bytes` must be a gateway stream counter); *matrix-param (`;`) handling*;
+an *encoded-slash policy* (`%2f` is decoded to `/`); and the *TCP-peer gate* (the resolver
+trusts headers, not the socket -- it never sees the peer address). It also does not reject
+`0.0.0.0/0`/`::/0` (Plan 03 D5 does).
+
+*`token-sheriff-validation` provides, fail-closed:* JWT algorithm pinning
+(`SignatureAlgorithmPreferences` -- allow-list, `none`/HMAC/embedded-`jwk` rejected, so
+RS256->HS256 key-confusion is structurally impossible), an *in-library* guard for the
+CVE-2022-21449 ECDSA "psychic signature" (`r|s == 0` rejected before the JDK verifier) and a
+<2048-bit RSA floor; `iss`/`aud`/`azp`/`exp`/`nbf`/`iat`(+skew)/`sub` validation; JWKS from
+the configured/discovered endpoint *only* (token-supplied `jku`/`x5u`/`jwk` ignored) behind
+an `EgressPolicy` that blocks loopback/link-local/cloud-metadata on the initial fetch *and
+every refresh* (DNS-rebinding-safe), with TTL cache, rotation grace, and unknown-`kid` that
+cannot drive a fetch storm; the 4-arg `AccessTokenRequest(token, headers, uri, method)` for
+DPoP; server-side DPoP proof validation + replay cache; a Quarkus JWKS-readiness health
+check; an RFC 9457 exception mapper that interpolates no secret/message. It ships a
+`generators`-classifier test-jar with adversarial token/key corpora (`JkuX5uAttackTest`,
+`PsychicSignatureAttackTest`, ...).
+
+*`token-sheriff-client` (BFF engine) provides, fail-closed:* auth-code + PKCE (`S256` only,
+`plain` not implementable); `FlowContext` bundling `state`+`nonce`+PKCE-verifier+`redirect_uri`
+(+`acr_values`/`max_age`) with constant-time `state`/`nonce` verification; RFC 9207 `iss`
+mix-up defence (incl. absent-`iss` rejection); refresh rotation with reuse detection ->
+family revocation + RFC 7009 revoke, single-flighted per session (`RefreshTokenFamily`,
+`TokenLifecycleManager`); RP-initiated logout with *exact-match* `post_logout_redirect_uri`
+and state verify (`PostLogoutRedirectValidator`); RFC 9470 step-up parsing/re-drive;
+callback HPP defence (`CallbackParameters.parse(rawQuery)` rejects duplicate `code`/`state`);
+DPoP/mTLS sender-constraint requesting with downgrade rejection.
+
+*The engine/validation libs deliberately leave to the gateway* (the true BFF residual): the
+*back-channel logout-token receiver and its `events`/`sub`/`sid`-required + `nonce`-forbidden
+checks* (no library support at all -- signature reuse only); *persistence* of the
+`FlowContext` (session-bound, single-use discard, return-URL -- the engine gives the DTO
+shape, not the store); the *concrete `TokenStore`* (server session vs encrypted cookie);
+*scope enforcement* (the lib exposes `providesScopes()`/`getScopes()` but enforces nothing);
+and calling `CallbackParameters.parse(rawQuery)` on the *raw* query (the `of(Map)` path cannot
+re-detect duplicates). The stateless cookie variant additionally cannot share the in-memory
+`RefreshTokenFamily` across instances (a documented Plan 08 trade-off).
+
+This attribution is folded into the *Owner* column of the validation matrix and the per-entry
+status below.
+
+== Assets
+
+What an attacker wants, ranked by blast radius:
+
+[cols="1,3"]
+|===
+| Asset | Why it matters
+
+| Upstream reachability
+| The gateway is the only sanctioned path to the backends. Reaching an upstream *without*
+  passing auth/filtering is the top-line failure -- every "auth bypass" CVE below is an
+  attack on this asset.
+
+| Mediated tokens (BFF variants)
+| Access / refresh / ID tokens held server-side (session mode) or inside the encrypted
+  cookie (cookie mode). Theft = account takeover; leakage to the browser defeats the entire
+  BFF rationale.
+
+| Session / flow secrets
+| Session-id cookie, the pending-authorization record (`state`/`nonce`/PKCE verifier), the
+  cookie encryption key(s). Forgery or replay = impersonation.
+
+| Client identity signal
+| The real client IP / scheme the gateway asserts to upstreams via regenerated forwarding
+  headers. Spoofing it corrupts every downstream IP-based decision.
+
+| Configuration integrity
+| The immutable route table and policy. There is no runtime mutation surface by design (see
+  GW-10); the boot-time config *is* the trust anchor.
+
+| Availability
+| A single process fronting everything. Resource-exhaustion classes (GW-07, GW-08) target
+  this.
+|===
+
+== Trust boundaries
+
+A request crosses these boundaries; each is a place a control must hold.
+
+[cols="1,2,3"]
+|===
+| # | Boundary | What is untrusted across it
+
+| B1
+| Client -> TLS edge
+| Everything: TLS ClientHello/SNI, all request bytes, framing, every header including
+  `Forwarded`/`X-Forwarded-*`/`Connection`, the raw path and its encoding, the body.
+
+| B2
+| TLS edge -> pipeline (terminated L7)
+| The normalized request. The boundary's job is to hand the pipeline *one* canonical form
+  and reject ambiguity (framing, encoding) here.
+
+| B3
+| Pipeline -> upstream (data plane)
+| The gateway is now the client. What it *emits* is trusted by the upstream, so the gateway
+  must strip inbound trust signals and regenerate its own (forwarding headers, mediated
+  bearer). The upstream's *response* is untrusted coming back.
+
+| B4
+| Gateway <-> IdP (control plane, BFF)
+| OIDC discovery/JWKS/token/revocation/logout traffic. Tokens and logout tokens received
+  here are untrusted until validated; JWKS key sources must be pinned (no token-supplied
+  `jku`).
+
+| B5
+| Browser <-> BFF session
+| The session cookie and any BFF-API request it authenticates. Cross-site requests carry the
+  cookie ambiently (CSRF); the cookie itself is a theft target.
+
+| B6
+| Operator -> configuration
+| Config files are operator-authored (semi-trusted) but env-substituted values and secrets
+  cross a boundary; a config that would serve traffic in a partially-valid state is a
+  failure (fail-closed boot).
+
+| B7
+| Data-plane network -> management surface
+| Health/metrics on the management port. Must not be reachable from, or confused with, the
+  public data-plane port; there is no admin/mutation API to expose (GW-10).
+|===
+
+.Boundary geometry
+----
+        B1                B2                      B3
+client ----> [ TLS edge ] --> [ L7 pipeline ] --------> upstream
+  |          (terminate/         (normalize,      (regenerated
+  |           SNI split)          filter, auth,     headers,
+  |                               forward policy)    mediated bearer)
+  |                                   |  ^
+  |  B5 (session cookie / BFF API)    |  | B4 (OIDC: discovery/JWKS/token/logout)
+  +-----------------------------------+  +--> IdP
+
+  B6 operator --> [ immutable config, fail-closed boot ]
+  B7 management port (health/metrics) -- never on the data-plane port, no mutation API
+----
+
+== STRIDE per boundary
+
+The threat categories that actually bite each boundary (empty cells omitted for brevity;
+"->" points at the catalogue entry that carries the control).
+
+[cols="1,4"]
+|===
+| Boundary | Principal STRIDE threats -> catalogue entry
+
+| B1 Client->edge
+| *Spoofing* forwarding identity -> <<gw-04>>. *Tampering* with framing/encoding ->
+  <<gw-02>>, <<gw-01>>. *DoS* (slowloris, h2 abuse, decompression) -> <<gw-07>>, <<gw-08>>.
+  *Info disclosure* via error paths -> <<gw-12>>.
+
+| B2 edge->pipeline
+| *Elevation* via path-confusion auth bypass -> <<gw-01>>. *Tampering* via header injection
+  / hop-by-hop abuse -> <<gw-03>>. *Repudiation* if the effective posture isn't logged
+  (boot posture log -> <<gw-01>>).
+
+| B3 pipeline->upstream
+| *Spoofing* the client to the upstream -> <<gw-04>>. *Elevation* via SSRF / upstream
+  redirect -> <<gw-05>>. *Tampering* via response injection on the return leg -> <<gw-03>>.
+
+| B4 gateway<->IdP
+| *Spoofing* tokens (alg confusion, `alg:none`, key confusion) -> <<bff-06>>. *Elevation*
+  via JWKS `jku`/`x5u` SSRF -> <<bff-07>>. *Tampering* IdP mix-up -> <<bff-05>>. *Info
+  disclosure* of secrets in error paths -> <<gw-12>>.
+
+| B5 browser<->BFF
+| *Spoofing* via CSRF on the cookie-authed API -> <<bff-11>>. *Tampering*/theft of the
+  cookie -> <<bff-10>>, <<bff-12>>. *Elevation* via `state`/code injection on the callback
+  -> <<bff-02>>, <<bff-03>>, <<bff-13>>. *Repudiation*/replay via missing `nonce` ->
+  <<bff-04>>; logout flaws -> <<bff-09>>.
+
+| B6 operator->config
+| *Tampering*/*Elevation* via env-substitution bypassing validation -> <<gw-11>>; secrets in
+  logs -> <<gw-12>>. *DoS* via config-expansion -> <<gw-07>>. Fail-closed boot is the
+  overarching control.
+
+| B7 network->management
+| *Info disclosure* / *Elevation* via an exposed control surface -> <<gw-10>>.
+|===
+
+== Gateway failure catalogue
+
+Each class: the mechanism, the *cited real CVEs* that prove it is not theoretical, the API
+Sheriff control, its status, and the assertion to test. CVE IDs marked *(unverified)* were
+sourced from advisory aggregators but not confirmed on an NVD/GHSA primary page during
+research -- cite the *class*, not the number, until confirmed.
+
+[#gw-01]
+=== GW-01 -- Path normalization / router-vs-enforcement desync (auth bypass)
+
+*The single most recurrent gateway CVE class.* The router matches on one representation of
+the path (raw, or partially decoded) while auth/block enforcement -- or the backend --
+acts on a different one, so a request skips the control bound to the path it ultimately
+reaches.
+
+*Evidence.* Traefik: CVE-2025-47952, CVE-2025-66490, CVE-2026-40912 (StripPrefixRegex
+Path/RawPath length desync), GHSA-xf64-8mw2-4gr2 (StripPrefix), GHSA-cxjq-mrr5-89rv
+(ReplacePathRegex) -- six-plus advisories in ~14 months. APISIX CVE-2021-43557 (`uri-blocker`
+checked raw `request_uri`, router matched normalized). Kong CVE-2021-27306 (JWT route bypass
+via `/public/../api`) and the external-authz path-traversal (Kong forwards un-normalized
+path, partial `%2E`/`%2F` decode). Envoy CVE-2021-29492 (`%2F`/`%5C` not decoded ->
+RBAC/JWT bypass). Systematized by Orange Tsai, "Breaking Parser Logic" (Black Hat 2018).
+
+*Control.* `cui-http`'s `URLPathValidationPipeline` already returns a *canonical* path
+(percent-decoded, dot-segments and duplicate slashes collapsed, traversal/`%00`/overlong/
+backslash rejected unconditionally). The gateway's residual job is the *invariant*: route,
+the `allowed_methods` verb gate, auth selection, `allowed_paths` matching, *and* the upstream
+remainder all consume that *same* canonical output -- byte-identical -- never the raw
+request-URI. Two things cui-http leaves to the gateway and this control must add: an
+*encoded-slash policy* (cui-http decodes `%2f` to a structural `/`; the gateway decides
+reject-vs-accept and applies it before routing) and *matrix-param (`;`) handling* (not
+touched by cui-http). This directly answers the code-review finding that the interim
+`ProxyRoute` looks the route up on the raw URI but relies on the router's normalized match
+(raw-vs-normalized divergence).
+
+*Status:* PARTIAL. Plan 04 stage 1 validates the raw path and stages 2-3 act on the
+normalized path, and Plan 03 D5 normalizes prefixes before disjointness -- but no plan yet
+states the *invariant* explicitly or tests the divergence. Recommend the assertion below be
+an explicit Plan 04 acceptance item (see Gaps).
+
+*Assertion.* For every encoded-traversal / encoded-slash / mixed-encoding / trailing-slash /
+matrix-param variant of a protected path: the request is either rejected at B2 or is
+routed, authorized, and forwarded against the *same* canonical path -- never authorized as
+public and dispatched to a protected upstream. Upstream request-count = 0 on every bypass
+attempt.
+
+[#gw-02]
+=== GW-02 -- HTTP request smuggling / desync
+
+Front-end and back-end disagree on where a request ends (CL vs TE, bare-LF chunk
+terminators, duplicate framing headers, HEAD-with-body, HTTP/2->1.1 downgrade), letting an
+attacker's body become a second request on a pooled connection.
+
+*Evidence.* HAProxy CVE-2021-40346 (htx integer overflow desync, all ACLs bypassed). Go
+`net/http` CVE-2025-22871 (bare-LF chunk terminator). Node/llhttp CVE-2022-35256. OpenResty
+`lua-nginx-module` CVE-2024-33452 (HEAD-with-body reinterpreted -- hit *both* Kong and
+APISIX). Kong CVE-2026-6338 (CL.0: attacker lists `Content-Length` in `Connection:` so Kong
+drops it). Netty CVE-2021-21295 (missing CL validation on h2->h1 downgrade). Context:
+PortSwigger "HTTP/1.1 Must Die" (2025).
+
+*Control.* Enforce a single unambiguous framing at B2: reject requests bearing both
+`Content-Length` and `Transfer-Encoding`; require strict CRLF and RFC-9112 chunk parsing;
+reject a body on a bodyless method; re-derive/validate framing after any header mutation
+(the `Connection`-list hop-by-hop cleanup must never remove `Content-Length`/
+`Transfer-Encoding` -- see GW-03); never pool an upstream connection whose framing wasn't
+fully validated. Prefer end-to-end HTTP/2 where possible.
+
+*Status:* GAP. Quarkus/Vert.x/Netty reject much of this by default, but API Sheriff sits
+*behind* other proxies (the whole forwarded-header design assumes it), so framing agreement
+is a first-class requirement, not an inherited default. No plan asserts it.
+
+*Assertion.* A request with both `Content-Length` and `Transfer-Encoding`, a HEAD/GET with a
+body, or a `Connection: Content-Length` cleanup attempt is rejected (400) and never produces
+two upstream requests; a smuggling test corpus (CL.TE/TE.CL/TE.TE/CL.0) run through the
+gateway produces zero desyncs.
+
+[#gw-03]
+=== GW-03 -- Header injection (CRLF) and hop-by-hop header abuse
+
+(i) CR/LF/NUL in a header name/value splits the message (response splitting). (ii) A client
+names a *trust* header inside `Connection:` so the proxy strips it before the backend sees
+it -- deleting the origin's client-IP or auth signal.
+
+*Evidence.* Apache httpd CVE-2022-31813 (client `Connection` handling suppresses
+`X-Forwarded-*` to origin, defeating backend IP-auth). Netty CVE-2022-41915 (`DefaultHttpHeaders`
+iterator path skipped value validation -> CRLF response splitting). Traefik CVE-2024-45410
+(client names Traefik's own `X-Forwarded-*` as hop-by-hop). Kong CVE-2026-6338 (framing-header
+strip abuse, GW-02).
+
+*Control.* cui-http's `CharacterValidationStage` rejects CR/LF/NUL in header names and values
+*unconditionally* (ingress); the gateway feeds every inbound header through it and re-applies
+it before writing any response. Keep an explicit, closed hop-by-hop list the gateway honors;
+never let a client `Connection:` header steer stripping of framing or trust headers. Build the
+forwarded header set by regeneration from an allowlist, never by editing the client's map (the
+zero-trust forward policy) -- which also means client `X_Forwarded_For`-style underscore
+variants that cui-http does not canonicalize are dropped by the deny-by-default allowlist
+rather than reaching the upstream.
+
+*Status:* PARTIAL. Header CR/LF/NUL is cui-http (COVERED); zero-trust regeneration is Plan 04
+stage 5; the hop-by-hop-abuse-cannot-strip-framing property (the GW-02 tie-in) is not
+asserted.
+
+*Assertion.* CR/LF in a header value is rejected; a client `Connection: X-Forwarded-For`
+(or `Content-Length`) does not cause the gateway to drop the regenerated forwarding header
+or the framing header; response headers are validated before write.
+
+[#gw-04]
+=== GW-04 -- X-Forwarded / trusted-proxy spoofing
+
+IP-based auth, rate limiting, or "internal caller" trust reads a client-settable forwarding
+header as source identity. Any client sets `X-Forwarded-For: 127.0.0.1` and becomes
+"internal".
+
+*Evidence.* APISIX CVE-2022-24112 -- the flagship gateway RCE: the `batch-requests` plugin
+let the caller set `X-Real-IP` on re-dispatched sub-requests, the Admin-API IP allowlist
+trusted it, loopback was forged, chained with the default admin token (GW-10) to
+unauthenticated RCE. ZooKeeper CVE-2024-51504 (`IPAuthenticationProvider` honors client
+`X-Forwarded-For` by default). Traefik CVE-2026-35051 / CVE-2026-54764 / CVE-2026-39858 /
+CVE-2026-54763 *(unverified)* -- a chain of *incomplete* forwarded-header-stripping fixes
+(each patched one spelling/case/underscore/alias variant while a sibling survived).
+OAuth2-Proxy CVE-2026-40575 *(unverified)*. The "too-broad-trust" bug the
+link:features-analysis.adoc[feature analysis] already calls out.
+
+*Control.* Never derive trust from a client-settable header. Gate `Forwarded`/`X-Forwarded-*`
+on a *TCP-peer* check against an explicit trusted-proxy CIDR list (ADR-0003), parse the chain
+right-to-left discarding untrusted entries, and *regenerate* canonical output -- never
+append. Validate the CIDR list at boot (reject `0.0.0.0/0`, `::/0`, and split-range
+trust-all equivalents like `0.0.0.0/1`+`128.0.0.0/1`; reject malformed CIDRs). Canonicalize
+header names across the *whole* equivalence class (case, `-`/`_`, aliases) before stripping,
+or the strip is incomplete -- the Traefik fix-chain is the cautionary tale.
+
+*Status:* COVERED. ADR-0003 + Plan 04 stage 5 (TCP-peer gate, drop-and-regenerate) + Plan 03
+D5 (CIDR parsing, split-range trust-all rejection). The name-equivalence-class stripping is
+the one nuance to make explicit in the Plan 04 test set.
+
+*Assertion.* A spoofed inbound `X-Forwarded-For`/`X-Real-IP`/`Forwarded` from a non-trusted
+peer is ignored; the emitted chain is regenerated, not appended; case/underscore/alias
+variants of forwarding headers are all stripped; a `0.0.0.0/1`+`128.0.0.0/1` config is
+rejected at boot.
+
+[#gw-05]
+=== GW-05 -- SSRF via proxy features / upstream control
+
+A proxy feature lets the attacker influence the upstream destination (path-injected target,
+user-supplied upstream, followed cross-host redirect) -> the gateway makes requests from its
+trusted position to internal services / cloud metadata.
+
+*Evidence.* Apache httpd mod_proxy CVE-2021-40438 (crafted URI-path selects attacker origin;
+CISA Known-Exploited). The Capital-One-class metadata SSRF pattern.
+
+*Control.* The upstream is a *fixed, boot-resolved topology alias* -- never influenced by
+request content (link:adr/0004-topology-indirection.adoc[ADR-0004]). Restrict resolved alias
+URLs to `http`/`https` at boot (Plan 03 D5). Redirect following is disabled
+(`followRedirects(NEVER)` -- an SSRF-limiting default in the interim proxy, to be preserved).
+On the *control plane* (B4 -- OIDC discovery/JWKS/token), `token-sheriff-validation`'s
+`EgressPolicy` already blocks loopback/link-local/site-local/cloud-metadata targets on the
+initial fetch and every refresh (DNS-rebinding-safe); keep its secure defaults and only widen
+via `allowedEgressHost` for a trusted IdP. Operators should egress-restrict the gateway and
+avoid pointing a topology alias at link-local/metadata ranges (guide note, Plan 09).
+
+*Status:* COVERED (design). No request-controlled upstream exists; scheme allowlist is Plan
+03 D5; redirect-follow-off is a documented default.
+
+*Assertion.* No request input (path, header, body) can change the resolved upstream host; a
+topology alias with a non-http(s) scheme fails boot; the data-plane client does not follow
+upstream 3xx to a new host.
+
+[#gw-06]
+=== GW-06 -- TLS/SNI fail-open, upstream cert verification, mTLS bypass
+
+Failure modes: empty/unresolved SNI falls back to a *permissive* default (mTLS not required);
+a verify flag is silently inverted; SAN matching ignores SAN type or over-matches wildcards.
+
+*Evidence.* Traefik CVE-2026-32305 (fragmented ClientHello -> empty SNI -> permissive default
+TLS config, mTLS bypassed). Traefik CVE-2025-66491 (ingress-nginx `proxy-ssl-verify: on`
+mapped to Go `InsecureSkipVerify: true` -- verification *off* for ~5 months). Envoy
+CVE-2022-21656 (SAN type ignored -> wrong-CA cert matches), CVE-2020-15104 (wildcard SAN
+matches nested subdomains). KrakenD CVE-2026-39821 (punycode `xn--example-.com` normalizes
+to `example.com` -> host-based rule bypass).
+
+*Control.* Fail *closed*: empty/unresolved SNI must take the strictest policy or reject,
+never a permissive default. Reassemble the full ClientHello before routing on SNI (the
+Plan 06 `NetServer` front must not decide on a partial record). For any security-gating
+boolean (mTLS require, upstream verify), *test the behaviour* -- a real handshake fails when
+it must -- not merely that the flag parsed. Verify upstream certs by default. Normalize
+security-decision hostnames with a spec-conformant, tested routine.
+
+*Status:* PARTIAL. Plan 06 owns SNI-split + mTLS and now pre-decides the `NetServer` front;
+the *fail-closed-on-empty-SNI* rule, *full-ClientHello reassembly before routing*, and
+*assert-behaviour-not-flag* discipline should be explicit Plan 06 items (see Gaps).
+
+*Assertion.* A fragmented/empty-SNI ClientHello does not reach a passthrough or a
+no-client-cert default -- it is terminated under the strict policy or rejected; enabling mTLS
+causes a real no-cert handshake to fail (behaviour test); a punycode host that normalizes to
+a passthrough SNI is caught by the same collision rule.
+
+[#gw-07]
+=== GW-07 -- Slowloris / connection & body-size exhaustion / decompression bombs
+
+Slow partial requests pin workers; unbounded body buffering or decompression exhausts
+memory; config-file expansion bombs exhaust boot memory.
+
+*Evidence.* Apache httpd CVE-2007-6750 (Slowloris, pre-`mod_reqtimeout`). Envoy CVE-2022-29225
+(decompressor with no output cap -> OOM). KrakenD-triaged Go stdlib DoS CVEs (CVE-2026-42504
+MIME quadratic, CVE-2025-61723 PEM quadratic). The code review's own finding: the interim
+`ProxyRoute` buffers unbounded request *and* response bodies with no timeout in a 512 MB
+container.
+
+*Control.* Bound everything an attacker inflates: inbound header/line-size limits, an
+inbound idle/read timeout (slowloris), a max-in-flight admission cap, `max_body_bytes` as a
+*streaming* counter (never buffer the body -- link:adr/0006-body-streaming-vs-httpresult.adoc[ADR-0006]),
+and streamed responses (never materialized). The gateway is an *opaque* passthrough -- it does
+not decode `Content-Encoding`, so it is not itself a decompression-bomb target, but it must
+still cap body bytes. Apply explicit YAML `StreamReadConstraints` at config load (Plan 03 D5).
+
+*Status:* PARTIAL/COVERED. Streaming + `max_body_bytes` counter is ADR-0006 + Plan 04
+stage 6; edge limits + idle timeout + admission cap + graceful drain were added to Plan 04's
+edge-hardening item; YAML limits are Plan 03 D5. The interim-proxy stopgap is the optional
+Plan 02b item.
+
+*Assertion.* A slow-drip request is evicted at the idle timeout; a body exceeding
+`max_body_bytes` aborts mid-stream without full buffering; concurrent large requests do not
+grow heap without bound (admission cap holds); an oversized/alias-bomb config fails boot
+gracefully.
+
+[#gw-08]
+=== GW-08 -- HTTP/2 & gRPC abuse (Rapid Reset, CONTINUATION flood, downgrade smuggling, h2c)
+
+Cheap multiplexed actions become expensive server work: open-then-`RST_STREAM` loops,
+endless CONTINUATION header frames, h2->h1 downgrade Content-Length smuggling, forwarded
+`Upgrade: h2c` bypassing controls.
+
+*Evidence.* CVE-2023-44487 (HTTP/2 Rapid Reset -- record DDoS, hit nginx/Envoy/Tomcat/Jetty/
+Go/gRPC/HAProxy/Node). Node CVE-2024-27983 and the CERT VU#421644 CONTINUATION-flood set
+(httpd CVE-2024-27316, Tomcat CVE-2024-24549, Envoy CVE-2024-27919, nghttp2 CVE-2024-28182,
+Go CVE-2023-45288). CVE-2019-9513 (PRIORITY flood). Netty CVE-2021-21295 (h2->h1 CL smuggling).
+
+*Control.* Rate-limit stream *creation and reset* per connection (not only concurrent
+streams); bound total CONTINUATION/header frame size and count per stream and drop
+over-limit connections; re-derive Content-Length on any downgrade; never forward client
+`Upgrade`/`Connection` (h2c) headers to the backend. API Sheriff terminates h2 via ALPN and
+proxies gRPC over upstream h2 (Plan 05) -- both the terminated and forced-h2-upstream sides
+inherit this requirement.
+
+*Status:* GAP. Quarkus/Netty ship some Rapid-Reset mitigation, but stream-reset rate limiting
+and CONTINUATION bounds must be verified and pinned, and h2c-upgrade non-forwarding asserted.
+Belongs to Plan 04 (terminated h2) and Plan 05 (gRPC h2 upstream).
+
+*Assertion.* A Rapid-Reset / CONTINUATION-flood load against the gateway does not exhaust
+CPU/memory (bounded, connection dropped); client `Upgrade: h2c`/`Connection` headers are not
+forwarded upstream; an h2->h1 path re-derives framing.
+
+[#gw-09]
+=== GW-09 -- WebSocket cross-site hijacking (CSWSH) / missing Origin check on upgrade
+
+The WS handshake is an HTTP Upgrade the browser sends with ambient cookies, and the
+Same-Origin Policy does *not* restrict cross-origin WebSocket connections -- only server-side
+`Origin` validation does. Accept-any-origin upgraders let an attacker page open an
+authenticated socket in the victim's context (CWE-1385).
+
+*Evidence.* Nginx-UI CVE-2026-34403, Mailpit CVE-2026-22689, Dozzle CVE-2026-44985 *(2026,
+GHSA-sourced; CVSS enrichment pending)* -- all `CheckOrigin -> true` on cookie-authenticated
+WS endpoints.
+
+*Control.* Validate `Origin` server-side on the upgrade handshake against an allowlist
+(reject unknown origins) *before* the relay is established; the handshake already runs the
+full pipeline incl. auth (Plan 05 D1), and Origin validation joins it for session-authed WS
+routes. Require `SameSite` on the session cookie and do not rely on ambient cookies alone to
+authenticate a socket.
+
+*Status:* GAP. Plan 05 D1 runs auth on the handshake but does not name `Origin` validation.
+Recommend adding it (see Gaps). Especially load-bearing once `require: session` WS routes
+exist (Plan 07).
+
+*Assertion.* A WebSocket upgrade with a foreign `Origin` on a session-authenticated route is
+rejected before any upstream dial; only allowlisted origins complete the handshake.
+
+[#gw-10]
+=== GW-10 -- Control-plane exposure / default credentials / config-driven code execution
+
+An exposed admin API, a functional default credential, or config-driven scripting turns any
+control-plane reachability into full compromise.
+
+*Evidence.* APISIX CVE-2020-13945 (built-in default admin token
+`edd1c9f0...`), CVE-2022-24112 (Admin-API IP bypass -> Lua `script` RCE), CVE-2021-45232
+(Dashboard: two web frameworks, one lacked the auth interceptor -> unauthenticated admin).
+Kong CVE-2020-11710 (sample compose bound Admin API to `0.0.0.0` -> `pre-function` Lua RCE).
+Trend Micro: unsandboxed Lua is the RCE amplifier behind every one.
+
+*Control.* API Sheriff has *no runtime configuration/mutation API and no config-driven
+scripting* -- configuration is immutable, loaded once, frozen (fail-closed boot). The only
+operational surface is health/metrics on the management port (B7), which carries no mutation
+capability and is not on the public data-plane port. There is *no shipped credential of any
+kind*. This eliminates the entire class -- an audit's job is to confirm it stays eliminated
+(no admin endpoint, no `script`/`eval` route field, no default secret creeps in).
+
+*Status:* ELIMINATED (by design -- immutability, no admin API, no scripting). Management-port
+separation is in `application.properties`; a single auth choke-point (the pipeline) avoids
+the APISIX dual-framework trap.
+
+*Assertion.* There is no route or endpoint that mutates configuration at runtime; the
+management port exposes no mutation; no default/functional credential ships; every
+authenticated route is unreachable without a positive auth result (fail-closed, single
+enforcement point).
+
+[#gw-11]
+=== GW-11 -- Pre-auth / config input handling (injection, path-from-ID, XML round-trip)
+
+Management-plane and pre-auth endpoints, and any path/identifier built from input, are the
+softest targets: SQLi, path traversal from a client-supplied ID, template/HTML injection,
+SAML XML round-trip.
+
+*Evidence.* Tyk CVE-2023-42283 / CVE-2023-42284 (two blind SQLi from one missing
+parameterization on analytics `api_id`/`api_version`), CVE-2021-23357 (APIID -> filesystem
+path traversal), CVE-2021-23365 (SAML XML round-trip auth bypass in the identity broker).
+Gravitee CVE-2019-25075 then CVE-2022-38723 (the *same* registration path-traversal, patched
+twice -- incomplete first fix).
+
+*Control.* API Sheriff has *no datastore* (no SQL surface -- ELIMINATED), *no registration/
+management endpoints*, and does *not do SAML* (OIDC only, via the validated token-sheriff
+stack). The residual surface is config-load input: never build a filesystem path from an
+unvalidated value, canonicalize-then-confine config file references to the config root, and
+enforce the secrets rule on the *pre-substitution* scalar (Plan 03 D5). The Gravitee
+double-patch is the lesson for the validator: close the whole *class* (canonicalize-then-
+contain + a full traversal/encoding regression corpus), not one spelling.
+
+*Status:* COVERED/ELIMINATED. No SQL, no SAML, no management endpoints; config-path handling
+and secrets-on-raw-value are Plan 03 D5.
+
+*Assertion.* No SQL or SAML code path exists; config file resolution cannot escape the config
+directory via `..`/encoding; a full traversal corpus is rejected; the secrets rule is
+evaluated on the raw scalar (a literal secret is rejected even if it would substitute to a
+valid value).
+
+[#gw-12]
+=== GW-12 -- Error-path secret leakage / information disclosure
+
+Secrets or internals leak through error messages, verbose responses, or health/info
+endpoints.
+
+*Evidence.* APISIX CVE-2022-29266 (`jwt-auth` surfaced the user's HMAC *secret key* in an
+error body from `lua-resty-jwt` -> forge tokens). The code review's own findings: binding
+errors can echo resolved secret values into the boot log; the interim `/api/info` leaks a
+version string.
+
+*Control.* Every gateway-generated rejection is `application/problem+json` naming the
+category only, no internal detail (link:architecture.adoc#_error_contract[error contract]).
+Sanitize/truncate config binding-error messages so no resolved scalar (secret) is ever logged
+(Plan 03 D5). `OidcConfig`/`Session` `toString()` redaction already holds; the binding path
+must not bypass it. Remove `/api/info`/`/api/health` from the public port (Plan 04 deletes
+the placeholder resources).
+
+*Status:* PARTIAL. Error contract is Plan 04; binding redaction is Plan 03 D5; placeholder
+removal is Plan 04.
+
+*Assertion.* No error response or log line contains a resolved secret value or a stack
+trace/internal detail; a bind failure adjacent to a resolved secret never surfaces the
+secret; problem+json bodies carry category only.
+
+== OAuth / OIDC / BFF failure catalogue
+
+These bite the BFF variants (Plans 07-08). The confidential-client *engine*
+(`token-sheriff-client`) and the *validation* library (`token-sheriff-validation`) own most
+of the cryptographic and flow legs; API Sheriff owns the browser-facing side. Each entry
+notes which side owns the control. Normative anchors: *RFC 9700* (OAuth 2.0 Security BCP,
+Jan 2025), *OAuth 2.0 for Browser-Based Apps BCP*, *RFC 9207* (`iss`), *RFC 9449* (DPoP),
+*OIDC Core*, *OIDC Back-Channel Logout 1.0*.
+
+[#bff-01]
+=== BFF-01 -- `redirect_uri` validation (exact match)
+
+Lax redirect-URI matching (wildcard, subdomain, path-prefix, traversal, parser discrepancy)
+delivers the authorization `code` to an attacker endpoint -> account takeover.
+
+*Evidence.* Keycloak CVE-2023-6927 (wildcard bypass), CVE-2024-8883 (`localhost` valid-URI ->
+arbitrary redirect), CVE-2026-3872 (`..;/` traversal past the allowed path). pixiv HackerOne
+#1861974 (path traversal leaked codes). RFC 9700 §2.1/§4.1: *exact string match*, no
+wildcards.
+
+*Control.* The BFF redirect URI is a single fixed server endpoint -- trivially exact-matchable.
+Register it statically, never templatize/wildcard it, canonicalize-and-reject
+`..`/`..;`/encoded traversal before matching. Engine constructs the authorization request;
+gateway config supplies the exact URI.
+
+*Status:* COVERED. Reserved-path exact-match registration (Plan 07 D2); one fixed
+`oidc.redirect_uri`.
+
+*Assertion.* Wildcard/subdomain/path-prefix/`..;/` variants of the redirect URI are all
+rejected; only the exact registered URI is accepted.
+
+[#bff-02]
+=== BFF-02 -- `state` / CSRF on the callback
+
+Without an unguessable, session-bound, single-use `state`, the callback can't prove it
+matches a flow this browser started -> login CSRF / code injection.
+
+*Evidence.* HedgeDoc GHSA-6wm6-3vpq-6qvv, PolarLearn GHSA-fhhm-574m-7rpw (missing `state` ->
+login CSRF). RFC 9700 §4.1.
+
+*Control.* The engine's `FlowContext` generates the `state` (32-byte SecureRandom) and
+verifies it constant-time on callback, fail-closed -- but it is an *in-memory DTO the gateway
+must persist and discard*: single-use is a *caller contract*, not enforced by the type. So the
+Plan 07 D2b *pending-authorization record* is the gateway's job precisely here: persist the
+`FlowContext` bound to the browser, short TTL, add the return-URL (the engine's DTO has none),
+and *discard after callback* (the one-time-use the engine does not enforce). Cookie-mode
+carries it in a sealed short-lived `__Host-` login cookie (Plan 08). PKCE does not replace
+login-CSRF protection -- keep both.
+
+*Status:* COVERED. Engine `FlowContext` (gen + constant-time verify) + Plan 07 D2b
+(persistence, return-URL, single-use discard -- the residual the engine leaves open).
+
+*Assertion.* A callback with a missing/foreign/re-used `state` is rejected; the record is
+single-use (a replayed callback fails); return-URL is same-origin validated (no open
+redirect).
+
+[#bff-03]
+=== BFF-03 -- PKCE downgrade / authorization-code injection
+
+Code injected into a victim session, or PKCE stripped/downgraded to `plain`, lets the client
+redeem an attacker-influenced code.
+
+*Evidence.* RFC 9700 §4.5 (prevent code injection; PKCE `S256`). Documented code-injection
+technique writeups.
+
+*Control.* Always PKCE `S256` (reject `plain`); fail closed if a token response arrives for a
+flow whose verifier the gateway did not store (the pending-authorization record binds it);
+single-use codes, revoke-on-reuse. Engine performs the exchange; the record provides the
+verifier binding.
+
+*Status:* COVERED (engine + Plan 07 D2b binding). Verify the engine enforces `S256` and
+single-use on 0.9.2 (Plan 07 D1 verification step).
+
+*Assertion.* A token response with no matching stored verifier is rejected; `plain` PKCE is
+refused; a code redeemed twice fails and revokes issued tokens.
+
+[#bff-04]
+=== BFF-04 -- Missing / unvalidated `nonce` -> ID-token replay
+
+A `nonce` sent but never checked (or never sent) lets a captured ID token from another
+session be replayed -- it verifies cryptographically.
+
+*Evidence.* roadiz GHSA-3gx8-q682-38mx (nonce generated, never validated). OIDC Core
+§3.1.3.7.
+
+*Control.* Random `nonce` stored in the pending-authorization record; on ID-token validation
+require present-and-equal, then discard (single use). `token-sheriff-validation` performs the
+check; the record supplies the expected value.
+
+*Status:* COVERED (validation lib + Plan 07 D2b). Confirm the lib enforces it (Plan 07 D1).
+
+*Assertion.* An ID token whose `nonce` is absent or unequal to the stored value is rejected;
+replay of an ID token from another flow fails.
+
+[#bff-05]
+=== BFF-05 -- IdP mix-up (multi-issuer) and the `iss` defence
+
+A client federating multiple IdPs can be confused about which AS a response came from and
+send a code to the wrong (attacker) endpoint.
+
+*Evidence.* RFC 9207 (`iss` response param; reject mismatched/missing `iss`). RFC 9700 §4.4.
+
+*Control.* API Sheriff is *single-IdP by design* (one global `oidc` block -- Plan 07 Out of
+Scope), which structurally removes mix-up. Still verify `iss` on the callback if the engine
+supports RFC 9207 (defence-in-depth). If multi-IdP is ever added, per-IdP distinct redirect
+URIs + `iss` verification become mandatory.
+
+*Status:* ELIMINATED (single-IdP) + engine `iss` check where available.
+
+*Assertion.* Only one issuer is configurable; a callback carrying a mismatched `iss` is
+rejected.
+
+[#bff-06]
+=== BFF-06 -- JWT / ID-token validation (alg confusion, `alg:none`, `kid`, aud/iss/exp)
+
+The verifier honors the token's own `alg`/`kid` (RS256->HS256 key confusion, `alg:none`,
+`kid` path/SQL injection) or skips audience/issuer/expiry.
+
+*Evidence.* `jsonwebtoken` CVE-2015-9235 (`alg:none`) / CVE-2016-10555 (RS256->HS256)
+*(IDs unverified; the class is canonical)*, CVE-2022-23539 (unrestricted key type). Java
+CVE-2022-21449 "Psychic Signatures" (ECDSA `(0,0)` accepted -- forge any ES256 JWT/ID
+token/SAML). pac4j CVE-2026-29000 *(dependency relationship unverified)* (PlainJWT-in-JWE
+accepted via public key). Original: Auth0 "Critical vulnerabilities in JWT libraries".
+
+*Control.* `token-sheriff-validation` owns this fail-closed: `SignatureAlgorithmPreferences`
+is an *allow-list* (RS/PS/ES/EdDSA), with `none` and *all* HMAC algorithms globally rejected
+-- so RS256->HS256 key-confusion is structurally impossible, not merely checked. It also
+rejects an embedded-`jwk` header (CVE-2018-0114), enforces a <2048-bit RSA floor, and carries
+an *in-library* guard for the CVE-2022-21449 ECDSA "psychic signature" (`r|s == 0` rejected
+before the JDK verifier) -- defence-in-depth on top of the patched Java 25 runtime. `iss`/
+`aud`/`azp`/`exp`/`nbf`/`iat`(+skew)/`sub` are validated by the pipeline. Keys come only from
+configured/discovered JWKS (BFF-07). The gateway's residual is to *configure* the expected
+audience/issuer and, if desired, a narrower per-issuer `alg` list.
+
+*Status:* COVERED (validation lib, fail-closed, incl. in-library psychic-signature guard;
+patched JVM is belt-and-braces). Verify the wired issuer config sets `expectedAudience` (Plan
+04/07 D1).
+
+*Assertion.* Tokens with `alg:none`, RS256->HS256 confusion, a `kid` that resolves outside
+the configured JWKS, wrong `aud`/`iss`, or expired -> all rejected; the running JVM is a
+Psychic-Signatures-patched release.
+
+[#bff-07]
+=== BFF-07 -- JWKS handling (`jku`/`x5u` SSRF, rotation races, unbounded fetch)
+
+Trusting a per-token key URL fetches attacker keys (and is an SSRF primitive); naive
+"refresh on unknown `kid`" is a DoS/amplifier; no cache caps.
+
+*Evidence.* `jku`/`x5u` header-injection auth-bypass writeups (PortSwigger JWT). Rotation-race
+and unbounded-fetch discussions.
+
+*Control.* `token-sheriff-validation` owns this and is strong: token-header `jku`/`x5u`/`jwk`
+are ignored (they appear nowhere in its key resolution; embedded `jwk` is actively rejected);
+`HttpJwksLoader` fetches only from the configured/discovered endpoint behind an `EgressPolicy`
+that blocks internal/metadata ranges on the initial fetch *and every background refresh*
+(DNS-rebinding-safe, GW-05 tie-in); it caches with a TTL, keeps a bounded rotation grace
+window, and `getKeyInfo(kid)` never triggers an on-demand fetch -- so a flood of unknown
+`kid`s cannot drive a fetch storm. Its Quarkus JWKS-readiness health check already gates the
+ITs. Gateway residual: keep the secure egress defaults; widen only via `allowedEgressHost` for
+a trusted IdP.
+
+*Status:* COVERED (validation lib, fail-closed, SSRF-guarded). Nothing for the gateway to
+build.
+
+*Assertion.* A token-supplied `jku`/`x5u` is ignored; JWKS is fetched only from the
+configured endpoint; a flood of unknown-`kid` tokens does not cause unbounded outbound
+fetches; rotation across overlapping keys keeps validation working.
+
+[#bff-08]
+=== BFF-08 -- Refresh-token rotation / reuse-detection under concurrency
+
+A stolen refresh token is a long-lived bearer credential. Rotation without correct reuse
+detection either fails to revoke the family or forks it so attacker and victim both persist.
+
+*Evidence.* better-auth GHSA-392p-2q2v-4372 (concurrent redemption *forks the token family*).
+RFC 9700 §4.14 (rotate with reuse detection -> revoke the whole family on reuse).
+
+*Control.* The engine owns this fail-closed: `RefreshTokenFamily` + `TokenLifecycleManager`
+rotate on every refresh, single-flight *per session* (a `ConcurrentMap<sessionId, future>`
+spanning redeem+apply so a benign concurrent refresh does not self-classify as reuse), and on
+a superseded RT revoke the whole family (RFC 7009) and clear the store. *Caveat the gateway
+must respect:* the family map is *in-memory per instance* (bounded LRU) -- the stateless
+cookie variant (Plan 08), which runs multiple instances with no shared state, cannot share
+reuse detection across instances; that is the documented Plan 08 trade-off (single-flight per
+instance; IdP-side reuse tolerance is an operator decision, never a gateway default). Server
+mode keeps RTs in the store; cookie mode keeps them only inside the AES-GCM cookie.
+
+*Status:* COVERED (engine) with the multi-instance caveat documented in Plan 08 D3. If a
+shared refresh-family store is ever wanted for cookie mode, the engine's `TokenStore` SPI is
+the seam (no shared implementation ships today).
+
+*Assertion.* A replayed rotated RT revokes the family and forces re-auth; concurrent
+refreshes on one session do not fork the family; cookie-mode never exposes the RT to the
+browser.
+
+[#bff-09]
+=== BFF-09 -- Logout (back-channel token validation, RP-initiated open redirect, fixation)
+
+Under-validated back-channel logout tokens allow forged logout (DoS) or accepting an ID token
+as a logout token; a lax `post_logout_redirect_uri` is an open redirect; incomplete session
+destruction leaves a fixated session.
+
+*Evidence.* OIDC Back-Channel Logout 1.0: logout token MUST carry `events` (with the
+back-channel member) and `sub`/`sid`, and MUST NOT carry `nonce`; validate sig/`iss`/`aud`/
+`iat`. Keycloak redirect CVEs (CVE-2023-6927/8883/2026-3872) apply to the post-logout URI.
+
+*Control.* Validate logout tokens strictly: signature+`iss`+`aud`, require `events`, require
+`sub`/`sid`, *reject any token containing `nonce`*, short `iat` window; destroy via the
+`sid`/`sub` secondary index (Plan 07 D6). Exact-match `post_logout_redirect_uri`. Destroy the
+server session and rotate/clear the cookie on any logout; revoke the RT family. Cookie-mode
+disables the back-channel endpoint (`404`, Plan 08 D4) -- no session to destroy.
+
+*Status:* COVERED. Plan 07 D6 (both channels, logout-token checks, logout-`state` cookie) +
+Plan 08 D4.
+
+*Assertion.* A logout token missing `events`/`sub`/`sid`, or *containing* `nonce`, or an ID
+token replayed as a logout token -> rejected; a non-registered `post_logout_redirect_uri` ->
+rejected; post-logout the session is gone and the cookie cleared; cookie-mode back-channel ->
+`404`.
+
+[#bff-10]
+=== BFF-10 -- Cookie hardening & token-leakage-to-browser
+
+Tokens reaching JS, or a weakly-flagged session cookie, defeat the BFF rationale; session
+fixation on login lets a pre-seeded session be adopted.
+
+*Evidence.* Browser-Based Apps BCP (BFF keeps tokens server-side). BFF cookie guidance
+(`__Host-`+`HttpOnly`+`Secure`+`SameSite`). Session-fixation guidance.
+
+*Control.* No token ever reaches the browser: server-mode holds them in the store; cookie-mode
+seals them in an `HttpOnly` AES-GCM cookie decrypted per request. Session cookie:
+`__Host-` + `HttpOnly` + `Secure` + `SameSite=Lax`, opaque id only (Plan 07 D3 / variant
+docs). Regenerate the session id on login and privilege change; destroy on logout.
+
+*Status:* COVERED. Plan 07 D3 + variant docs.
+
+*Assertion.* No response ever carries a token to the browser; the session cookie has
+`__Host-`+`HttpOnly`+`Secure`+`SameSite`; the session id is regenerated at login (fixation
+test).
+
+[#bff-11]
+=== BFF-11 -- CSRF on the cookie-authenticated BFF API (the classic BFF gap)
+
+Once auth is a cookie, every cross-site request carries it; `SameSite` alone is insufficient
+(Lax GET gaps, same-site subdomain attackers, browser inconsistencies). *Highest-probability
+real BFF bug.*
+
+*Evidence.* BFF security writeups repeatedly name this as the pattern's #1 gap.
+
+*Control.* Fixed CSRF defence on unsafe methods (Plan 07 D5): `Origin` exact-match against
+`session.csrf.trusted_origins`; `Sec-Fetch-Site: same-origin` accepted when `Origin` absent;
+else `403` + `CSRF_REJECTED`. Lock CORS to the SPA origin. This composes with the WebSocket
+Origin check (GW-09).
+
+*Status:* COVERED. Plan 07 D5 (fixed behaviour, no knob).
+
+*Assertion.* An unsafe-method request with a foreign `Origin` -> `403`; `Sec-Fetch-Site`
+variants behave per spec; CORS is limited to the configured origin.
+
+[#bff-12]
+=== BFF-12 -- Encrypted-cookie AES-GCM nonce / key rotation (stateless variant)
+
+AES-256-GCM nonce reuse under one key is catastrophic (leaks the GHASH subkey -> tag forgery;
+keystream reuse -> plaintext recovery); a key-rollover bug drops or forges sessions.
+
+*Evidence.* "Nonce-Disrespecting Adversaries" (practical GCM nonce-reuse attacks). RFC 9700 /
+crypto guidance.
+
+*Control.* Fresh random 96-bit nonce per seal from a CSPRNG (never counter/derived); cookie
+= `version‖key-id‖nonce‖ciphertext‖tag` with version+key-id+cookie-name in the GCM AAD
+(deterministic key selection, replay-across-format prevention); tamper -> treated as no
+session; `previous_key` decrypt-only with re-seal on next write; ~4 KB size budget enforced
+at seal (fail login loudly, no silent truncation). Plan 08 D2 (strengthened for this class).
+
+*Status:* COVERED. Plan 08 D2.
+
+*Assertion.* Each seal uses a unique random nonce; a flipped byte in ciphertext/nonce/tag ->
+unauthenticated (never `500`); a `previous_key`-sealed cookie decrypts and re-seals under the
+current key; an oversized token set fails login with a clear error; key material never logged.
+
+[#bff-13]
+=== BFF-13 -- Callback response hygiene (HPP duplicate params, code reuse, error reflection)
+
+Duplicate `code`/`state`/`iss` (HTTP parameter pollution) exploit parser disagreement; a
+reused code; a reflected `error_description`.
+
+*Evidence.* Keycloak CVE-2026-9689 (HPP in the OIDC redirect URI). OAuth parameter-pollution
+research. RFC 9700 §4.5.3 (single-use codes, revoke on reuse).
+
+*Control.* The engine's `CallbackParameters.parse(rawQuery)` already *rejects* duplicate
+security-relevant params (`code`/`state`, RFC 9700 §4.7.3 defence) rather than last-wins,
+`IssValidator` checks `iss` (incl. absent-`iss` rejection) and `CallbackHandler` verifies
+`state` *before* code redemption, and `InboundErrorNormalizer` sanitizes `error`/
+`error_description` (never reflected). The single load-bearing *gateway* obligation: feed the
+*raw* query string to `parse(rawQuery)` -- the `of(Map)` overload cannot re-detect duplicates
+because the map already collapsed them. Single-use codes/revoke-on-reuse are the AS's.
+
+*Status:* COVERED (engine), with a mandatory usage rule. Recommend Plan 07 state explicitly
+that the callback endpoint calls `CallbackParameters.parse(rawQuery)`, never `of(Map)`, and
+test a duplicate-`code` callback is rejected.
+
+*Assertion.* A callback with duplicate `code`/`state` reaches `parse(rawQuery)` and is
+rejected; `state`/`iss` are verified before `code`; `error_description` is never reflected.
+
+[#bff-14]
+=== BFF-14 -- Sender-constraining (DPoP / mTLS)
+
+Plain bearer tokens are replayable if stolen (logs, proxies, XSS, MITM). Sender-constraining
+binds a token to a client key.
+
+*Evidence.* RFC 9449 (DPoP: `cnf` binding, `jti` replay cache, `htu`/`htm`/`iat` checks),
+RFC 8705 (mTLS-bound). Misuse = not validating `cnf`, no `jti` cache, accepting bound and
+bearer interchangeably (downgrade).
+
+*Control.* Optional hardening, not a required control for the base threat model. The
+architecture already carries the hook: the 4-arg `AccessTokenRequest(token, headers, uri,
+method)` supplies the URI+method DPoP needs. Where the threat model warrants, issue DPoP/mTLS
+-bound access *and refresh* tokens, enforce the `cnf` binding and `jti` replay cache, and do
+not accept the same token as a plain bearer (no downgrade). Neutralizes RT theft (BFF-08)
+even with imperfect rotation.
+
+*Status:* PARTIAL (hook present; full enforcement post-1.0 unless prioritized). Record as a
+deliberate future hardening in Plan 09's audit, not a base requirement.
+
+*Assertion.* If enabled: a bound token presented without its key -> rejected; a replayed DPoP
+`jti` -> rejected; the same token is not accepted as a plain bearer.
+
+== Validation matrix
+
+Every catalogue entry, its owning plan, and its status. This is the release-gate checklist:
+each COVERED/PARTIAL row must have a passing test before 1.0; each GAP row is a recommended
+plan amendment (next section).
+
+[cols="1,3,1,1"]
+|===
+| ID | Control (short) | Owner | Status
+
+| <<gw-01>> | One canonical path for routing+auth+forward (+ matrix/encoded-slash) | cui-http (canonical path) + Plan 04 invariant / 03 D5 | PARTIAL
+| <<gw-02>> | Reject ambiguous HTTP framing | Gateway/web-server (cui-http out of scope) -- Plan 04 | GAP
+| <<gw-03>> | Header CR/LF reject; hop-by-hop cannot strip framing/trust | cui-http (CR/LF) + Plan 04 (hop-by-hop) | PARTIAL
+| <<gw-04>> | TCP-peer forwarded gate; regenerate; CIDR validation | cui-http resolver + ADR-0003 / Plan 04 (peer gate) / 03 D5 (trust-all) | COVERED
+| <<gw-05>> | Fixed topology upstream; scheme allowlist; egress-policy (control plane) | ADR-0004 / Plan 03 D5 / token-sheriff `EgressPolicy` | COVERED
+| <<gw-06>> | Fail-closed SNI/mTLS; test behaviour not flag | Plan 06 | PARTIAL
+| <<gw-07>> | Streaming + body cap; idle timeout; admission cap; YAML limits | Gateway (cui-http no streaming body) -- ADR-0006 / Plan 04 / 03 D5 | PARTIAL
+| <<gw-08>> | h2 stream-reset/CONTINUATION bounds; no h2c forward | Plan 04 / 05 | GAP
+| <<gw-09>> | WebSocket Origin validation on upgrade | Plan 05 | GAP
+| <<gw-10>> | No admin API / no scripting / no default creds | Design / Plan 04 | ELIMINATED
+| <<gw-11>> | No SQL/SAML/mgmt endpoints; safe config-path handling | Design / Plan 03 D5 | COVERED
+| <<gw-12>> | problem+json category-only; no secret in logs | cui-http + token-sheriff mappers / Plan 04 / 03 D5 | PARTIAL
+| <<bff-01>> | Exact-match redirect URI | Engine (logout) + AS (auth) / Plan 07 D2 | COVERED
+| <<bff-02>> | Session-bound single-use `state` | Engine `FlowContext` + Plan 07 D2b (persist/discard) | COVERED
+| <<bff-03>> | PKCE `S256`; verifier binding; single-use code | Engine `PkceChallenge` (S256-only) | COVERED
+| <<bff-04>> | `nonce` validated + single-use | Engine `IdTokenValidationBridge` + Plan 07 D2b (persist) | COVERED
+| <<bff-05>> | Single-IdP; `iss` verification | Design + engine `IssValidator` | ELIMINATED
+| <<bff-06>> | Alg pinning; aud/iss/exp; psychic-sig guard | Validation lib (fail-closed, in-library) + ADR-0001 | COVERED
+| <<bff-07>> | Ignore `jku`/`x5u`; egress-guarded bounded JWKS fetch | Validation lib (`EgressPolicy`) | COVERED
+| <<bff-08>> | RT rotation + family revoke; single-flight | Engine `RefreshTokenFamily` + Plan 08 D3 (multi-instance caveat) | COVERED
+| <<bff-09>> | Logout: exact post-logout URI + state (engine); back-channel token checks (gateway) | Engine (RP-initiated) + Plan 07 D6 (back-channel) / 08 D4 | COVERED
+| <<bff-10>> | Tokens never in browser; `__Host-` cookie; fixation | Engine `TokenStore` SPI + Plan 07 D3 | COVERED
+| <<bff-11>> | CSRF on cookie-authed API (Origin/Sec-Fetch-Site) | Plan 07 D5 | COVERED
+| <<bff-12>> | AES-GCM random nonce; key-id AAD; rotation; size budget | Plan 08 D2 (gateway `TokenStore` impl) | COVERED
+| <<bff-13>> | Reject duplicate callback params (HPP) | Engine `CallbackParameters.parse(rawQuery)` -- Plan 07 usage rule | COVERED
+| <<bff-14>> | DPoP/mTLS sender-constraining (optional) | Engine + validation lib (4-arg `AccessTokenRequest`) / Plan 09 | PARTIAL
+|===
+
+== Gaps to bake in (recommended plan amendments)
+
+The GAP/PARTIAL rows are where a *documented, real-world* failure class is not yet nailed by
+a plan. Baking these in now is the whole point of this exercise. Recommended (each is a
+small, additive change; a follow-up plan-edit pass can land them):
+
+. *GW-01 (Plan 04) -- make the single-canonical-path invariant explicit and tested.* cui-http
+  already hands back a canonical path; the gateway's job is to route, verb-gate, auth-select,
+  `allowed_paths`-match, and forward on *that same* value (never the raw URI), plus decide the
+  encoded-slash policy and handle matrix `;` params (both left open by cui-http). Assertion: an
+  encoded-traversal/encoded-slash/matrix-param corpus proves no authorize-as-public /
+  dispatch-to-protected divergence (upstream count = 0). Dominant gateway CVE class; the
+  direct fix for the code-review raw-vs-normalized finding.
+. *GW-02 (Plan 04) -- add explicit HTTP-framing rejection.* cui-http is explicitly out of
+  scope here, so this is entirely gateway/web-server: CL+TE both present, body on a bodyless
+  method, and `Connection`-list framing-strip attempts are rejected; a smuggling corpus
+  produces zero desyncs. Justified because API Sheriff runs behind other proxies by design.
+. *GW-08 (Plans 04/05) -- pin HTTP/2 abuse bounds.* Verify and assert stream-creation/reset
+  rate limiting (Rapid Reset), CONTINUATION frame count/size bounds, and non-forwarding of
+  client `Upgrade: h2c`/`Connection` to the upstream.
+. *GW-09 (Plan 05) -- WebSocket `Origin` validation on the upgrade handshake* against an
+  allowlist, before the relay is established (CSWSH). Load-bearing once `require: session` WS
+  routes exist.
+. *GW-06 (Plan 06) -- fail-closed SNI + behaviour tests.* Make explicit: empty/fragmented SNI
+  takes the strict policy or rejects (never a permissive default); the full ClientHello is
+  reassembled before SNI routing; every security-gating boolean (mTLS require, upstream
+  verify) has a *behaviour* test (a real handshake fails when it must), not just a flag-read.
+. *BFF-13 (Plan 07) -- pin the callback parsing *usage rule*.* The engine already rejects
+  HPP; the gateway must call `CallbackParameters.parse(rawQuery)` on the raw query (never the
+  duplicate-blind `of(Map)`) and test a duplicate-`code` callback is rejected. Also state
+  (Plan 07) that scope enforcement is the gateway's -- the validation lib exposes
+  `providesScopes()` but enforces nothing.
+. *Cross-cutting -- adopt this document as a release gate (Plan 09).* The security-audit
+  sweep validates every COVERED/PARTIAL assertion has a passing test and every GAP is closed
+  or explicitly risk-accepted; consider a short ADR recording "CVE-derived validation
+  baseline is a 1.0 release gate".
+
+None of these change the architecture; they are hardening assertions on features already
+planned (mostly *wiring* audited library controls correctly), sourced from failures other
+gateways and OAuth stacks actually shipped.
+
+== References
+
+*Normative*
+
+* RFC 9700 -- OAuth 2.0 Security Best Current Practice (Jan 2025)
+* OAuth 2.0 for Browser-Based Apps BCP (`draft-ietf-oauth-browser-based-apps`)
+* RFC 9207 -- Authorization Server Issuer Identification (`iss`)
+* RFC 9449 -- OAuth 2.0 Demonstrating Proof of Possession (DPoP); RFC 8705 -- mTLS-bound tokens
+* RFC 9470 -- OAuth 2.0 Step-up Authentication Challenge
+* RFC 7239 -- Forwarded HTTP Extension; RFC 9110/9112 -- HTTP semantics/1.1
+* OpenID Connect Core 1.0; OpenID Connect Back-Channel Logout 1.0
+* RFC 6265 -- HTTP State Management (`__Host-` prefix, cookie limits)
+
+*Research anchors*
+
+* Orange Tsai, "Breaking Parser Logic: Take Your Path Normalization Off and Pop 0days Out"
+  (Black Hat USA 2018)
+* James Kettle / PortSwigger, "HTTP Desync Attacks" (2019) and "HTTP/1.1 Must Die" (2025)
+* Tim McLean / Auth0, "Critical vulnerabilities in JSON Web Token libraries"
+* Neil Madden, "Psychic Signatures in Java" (CVE-2022-21449)
+* "Nonce-Disrespecting Adversaries" (practical AES-GCM nonce-reuse attacks)
+
+*Advisory indexes used*
+
+* Traefik security advisories (github.com/traefik/traefik/security/advisories)
+* KrakenD security advisories (krakend.io/security-advisories)
+* Apache APISIX advisories (apisix.apache.org/blog) and Kong changelog
+* NVD / GitHub Security Advisories / GitLab Advisory DB for the CVE IDs cited inline
+
+CVE IDs marked *(unverified)* in the catalogue were sourced from advisory aggregators and not
+confirmed on an NVD/GHSA primary page; cite the failure *class* until the number is confirmed.
+The catalogue is a living baseline -- new CVEs in comparable systems should be triaged into a
+new `GW-`/`BFF-` row with its assertion.

--- a/doc/security-threat-model.adoc
+++ b/doc/security-threat-model.adoc
@@ -642,15 +642,25 @@ login CSRF). RFC 9700 §4.1.
 
 *Control.* The engine's `FlowContext` generates the `state` (32-byte SecureRandom) and
 verifies it constant-time on callback, fail-closed -- but it is an *in-memory DTO the gateway
-must persist and discard*: single-use is a *caller contract*, not enforced by the type. So the
-Plan 07 D2b *pending-authorization record* is the gateway's job precisely here: persist the
-`FlowContext` bound to the browser, short TTL, add the return-URL (the engine's DTO has none),
-and *discard after callback* (the one-time-use the engine does not enforce). Cookie-mode
-carries it in a sealed short-lived `__Host-` login cookie (Plan 08). PKCE does not replace
-login-CSRF protection -- keep both.
+must persist and discard*: single-use is a *caller contract*, not enforced by the type. The
+Plan 07 D2b *pending-authorization record* is the gateway's job: persist the `FlowContext`,
+short TTL, add the return-URL (the engine's DTO has none), and *bind it to the initiating
+browser* with a short-lived `HttpOnly` `__Host-` binding cookie (a record retrievable by
+`state` alone can be delivered to a *different* browser -- the callback must require the
+matching binding cookie, not just a valid `state`). PKCE does not replace login-CSRF
+protection -- keep both.
 
-*Status:* COVERED. Engine `FlowContext` (gen + constant-time verify) + Plan 07 D2b
-(persistence, return-URL, single-use discard -- the residual the engine leaves open).
+*Status (mode-split -- the single-use guarantee differs):*
+
+* *Server mode:* COVERED. The record is server-side; the gateway *discards it on first
+  callback* (true single-use) and the binding cookie ties it to the browser.
+* *Cookie mode:* PARTIAL (accepted risk). The record travels only in the sealed short-lived
+  `__Host-` login cookie (Plan 08 -- no server store to mark consumed), so within the cookie's
+  short TTL a captured login cookie *could* be replayed. Mitigation and accepted risk: the TTL
+  is minutes, the cookie is `HttpOnly`+`Secure`+`__Host-` (not JS-readable, HTTPS-only,
+  origin-locked), the browser binding still holds, and the exposure window is the login round
+  trip only. Documented as an explicit risk acceptance in Plan 08 (choose server mode if
+  strict single-use of the login step is required).
 
 *Assertion.* A callback with a missing/foreign/re-used `state` is rejected; the record is
 single-use (a replayed callback fails); return-URL is same-origin validated (no open
@@ -787,9 +797,19 @@ reuse detection across instances; that is the documented Plan 08 trade-off (sing
 instance; IdP-side reuse tolerance is an operator decision, never a gateway default). Server
 mode keeps RTs in the store; cookie mode keeps them only inside the AES-GCM cookie.
 
-*Status:* COVERED (engine) with the multi-instance caveat documented in Plan 08 D3. If a
-shared refresh-family store is ever wanted for cookie mode, the engine's `TokenStore` SPI is
-the seam (no shared implementation ships today).
+*Status (mode-split -- the guarantee is not universal):*
+
+* *Server mode:* COVERED. Single node / sticky session, one in-memory family map -> full
+  rotation + reuse -> family-revocation as the engine implements it.
+* *Cookie mode:* PARTIAL (accepted risk). Multiple instances, no shared state by design, so a
+  family cannot be tracked across instances -- an RT rotated on instance A and replayed against
+  instance B is *not* seen as reuse by B. This is inherent to the stateless variant, not a
+  defect. Documented as an explicit Plan 08 risk acceptance: mitigations are short
+  `ttl_seconds` / short access-token lifetimes and IdP-side reuse tolerance (an operator
+  availability-vs-detection choice); choose *Variant 2* for instant, node-spanning revocation.
+  If cross-instance detection is ever required, the engine's `TokenStore` SPI is the seam for a
+  shared family store -- but that reintroduces the external dependency the variant exists to
+  avoid.
 
 *Assertion.* A replayed rotated RT revokes the family and forces re-auth; concurrent
 refreshes on one session do not fork the family; cookie-mode never exposes the RT to the
@@ -950,13 +970,13 @@ plan amendment (next section).
 | <<gw-11>> | No SQL/SAML/mgmt endpoints; safe config-path handling | Design / Plan 03 D5 | COVERED
 | <<gw-12>> | problem+json category-only; no secret in logs | cui-http + token-sheriff mappers / Plan 04 / 03 D5 | PARTIAL
 | <<bff-01>> | Exact-match redirect URI | Engine (logout) + AS (auth) / Plan 07 D2 | COVERED
-| <<bff-02>> | Session-bound single-use `state` | Engine `FlowContext` + Plan 07 D2b (persist/discard) | COVERED
+| <<bff-02>> | Browser-bound `state`; single-use | Engine `FlowContext` + Plan 07 D2b (binding cookie) | COVERED (server) / PARTIAL-accepted (cookie: TTL replay window)
 | <<bff-03>> | PKCE `S256`; verifier binding; single-use code | Engine `PkceChallenge` (S256-only) | COVERED
 | <<bff-04>> | `nonce` validated + single-use | Engine `IdTokenValidationBridge` + Plan 07 D2b (persist) | COVERED
 | <<bff-05>> | Single-IdP; `iss` verification | Design + engine `IssValidator` | ELIMINATED
 | <<bff-06>> | Alg pinning; aud/iss/exp; psychic-sig guard | Validation lib (fail-closed, in-library) + ADR-0001 | COVERED
 | <<bff-07>> | Ignore `jku`/`x5u`; egress-guarded bounded JWKS fetch | Validation lib (`EgressPolicy`) | COVERED
-| <<bff-08>> | RT rotation + family revoke; single-flight | Engine `RefreshTokenFamily` + Plan 08 D3 (multi-instance caveat) | COVERED
+| <<bff-08>> | RT rotation + family revoke; single-flight | Engine `RefreshTokenFamily` + Plan 08 D3 | COVERED (server) / PARTIAL-accepted (cookie: per-instance)
 | <<bff-09>> | Logout: exact post-logout URI + state (engine); back-channel token checks (gateway) | Engine (RP-initiated) + Plan 07 D6 (back-channel) / 08 D4 | COVERED
 | <<bff-10>> | Tokens never in browser; `__Host-` cookie; fixation | Engine `TokenStore` SPI + Plan 07 D3 | COVERED
 | <<bff-11>> | CSRF on cookie-authed API (Origin/Sec-Fetch-Site) | Plan 07 D5 | COVERED

--- a/integration-tests/scripts/lib-docker-compose.sh
+++ b/integration-tests/scripts/lib-docker-compose.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Shared helpers for resolving the Docker Compose command and probing the daemon.
+# Source this file: `source "$(dirname "$0")/lib-docker-compose.sh"`
+#
+# Rationale: not every host wires the Compose v2 plugin into the docker CLI
+# (`docker compose`). Rancher Desktop, for example, ships the standalone
+# `docker-compose` binary instead. Hardcoding `docker compose` makes it fail
+# with "unknown shorthand flag: 'f'" because docker parses `-f` as a top-level
+# option. Resolve whichever form is actually available.
+
+# Prints the working compose invocation (either "docker compose" or
+# "docker-compose"), or nothing if neither is available. Returns non-zero when
+# no compose command exists.
+resolve_compose_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+        return 0
+    fi
+    if command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+        return 0
+    fi
+    return 1
+}
+
+# Returns 0 when the Docker daemon is reachable, non-zero otherwise.
+docker_daemon_up() {
+    docker info >/dev/null 2>&1
+}

--- a/integration-tests/scripts/start-integration-container.sh
+++ b/integration-tests/scripts/start-integration-container.sh
@@ -90,7 +90,7 @@ for i in {1..60}; do
     fi
     if [ $i -eq 60 ]; then
         echo "❌ Keycloak failed to start within 60 seconds"
-        echo "Check logs with: docker compose logs keycloak"
+        echo "Check logs with: ${COMPOSE_BASE} logs keycloak"
         exit 1
     fi
     echo "⏳ Waiting for Keycloak... (attempt $i/60)"
@@ -106,7 +106,7 @@ for i in {1..30}; do
     fi
     if [ $i -eq 30 ]; then
         echo "❌ go-httpbin upstream failed to start within 30 seconds"
-        echo "Check logs with: docker compose logs go-httpbin"
+        echo "Check logs with: ${COMPOSE_BASE} logs go-httpbin"
         exit 1
     fi
     echo "⏳ Waiting for go-httpbin... (attempt $i/30)"
@@ -123,7 +123,7 @@ if [[ "${BENCHMARK_MODE:-false}" == "true" ]]; then
         fi
         if [ $i -eq 30 ]; then
             echo "❌ nginx-static backend failed to start within 30 seconds"
-            echo "Check logs with: docker compose logs nginx-static"
+            echo "Check logs with: ${COMPOSE_BASE} logs nginx-static"
             exit 1
         fi
         echo "⏳ Waiting for nginx-static... (attempt $i/30)"
@@ -184,4 +184,4 @@ echo "  curl -sf http://localhost:19000/q/health/live"
 echo "  curl -k https://localhost:1090/health/ready"
 echo ""
 echo "🛑 To stop: ./scripts/stop-integration-container.sh"
-echo "📋 To view logs: docker compose logs -f"
+echo "📋 To view logs: ${COMPOSE_BASE} logs -f"

--- a/integration-tests/scripts/start-integration-container.sh
+++ b/integration-tests/scripts/start-integration-container.sh
@@ -8,9 +8,23 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ROOT_DIR="$(dirname "$PROJECT_DIR")"
 APP_TARGET_DIR="${ROOT_DIR}/api-sheriff/target"
 
+# shellcheck source=lib-docker-compose.sh
+source "${SCRIPT_DIR}/lib-docker-compose.sh"
+
 echo "🚀 Starting API Sheriff Integration Tests with Docker Compose"
 echo "Project directory: ${PROJECT_DIR}"
 echo "Root directory: ${ROOT_DIR}"
+
+# Resolve the compose command (docker compose plugin vs standalone docker-compose)
+COMPOSE_BASE="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_BASE" ]]; then
+    echo "❌ Docker Compose not available (neither 'docker compose' nor 'docker-compose')"
+    exit 1
+fi
+if ! docker_daemon_up; then
+    echo "❌ Docker daemon not running — start Docker/Rancher Desktop first"
+    exit 1
+fi
 
 cd "${PROJECT_DIR}"
 
@@ -23,11 +37,11 @@ DISTROLESS_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^ap
 if [[ -n "$JFR_IMAGE" ]]; then
     AVAILABLE_IMAGE="$JFR_IMAGE"
     IMAGE_TYPE="jfr"
-    COMPOSE_CMD="docker compose -f docker-compose.yml -f docker-compose.jfr.yml"
+    COMPOSE_CMD="$COMPOSE_BASE -f docker-compose.yml -f docker-compose.jfr.yml"
 elif [[ -n "$DISTROLESS_IMAGE" ]]; then
     AVAILABLE_IMAGE="$DISTROLESS_IMAGE"
     IMAGE_TYPE="distroless"
-    COMPOSE_CMD="docker compose -f docker-compose.yml"
+    COMPOSE_CMD="$COMPOSE_BASE -f docker-compose.yml"
 else
     AVAILABLE_IMAGE=""
     IMAGE_TYPE="none"
@@ -134,8 +148,8 @@ for i in {1..30}; do
         # diagnosable from CI artifacts (uploaded via the failsafe-reports folder).
         DIAG_DIR="target/failsafe-reports"
         mkdir -p "$DIAG_DIR"
-        echo "----- docker compose logs api-sheriff -----"
-        docker compose logs --no-color api-sheriff 2>&1 | tee "$DIAG_DIR/api-sheriff-app.log"
+        echo "----- $COMPOSE_BASE logs api-sheriff -----"
+        $COMPOSE_BASE logs --no-color api-sheriff 2>&1 | tee "$DIAG_DIR/api-sheriff-app.log"
         echo "----- /q/health -----"
         curl -s http://localhost:19000/q/health 2>&1 | tee "$DIAG_DIR/api-sheriff-health.json"
         echo ""
@@ -146,7 +160,7 @@ for i in {1..30}; do
 done
 
 # Extract native startup time from logs
-NATIVE_STARTUP=$(docker compose logs api-sheriff 2>/dev/null | grep "started in" | sed -n 's/.*started in \([0-9.]*\)s.*/\1/p' | tail -1)
+NATIVE_STARTUP=$($COMPOSE_BASE logs api-sheriff 2>/dev/null | grep "started in" | sed -n 's/.*started in \([0-9.]*\)s.*/\1/p' | tail -1)
 if [ ! -z "$NATIVE_STARTUP" ]; then
     echo "⚡ Native app startup: ${NATIVE_STARTUP}s (application only)"
 fi

--- a/integration-tests/scripts/stop-integration-container.sh
+++ b/integration-tests/scripts/stop-integration-container.sh
@@ -6,18 +6,34 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# shellcheck source=lib-docker-compose.sh
+source "${SCRIPT_DIR}/lib-docker-compose.sh"
+
 echo "🛑 Stopping API Sheriff Integration Tests Docker containers"
 
 cd "${PROJECT_DIR}"
+
+# This runs at Maven's pre-clean phase as a best-effort cleanup. If Docker isn't
+# available or the daemon isn't running there is nothing to stop, so exit
+# cleanly rather than failing `clean install`.
+COMPOSE_BASE="$(resolve_compose_cmd || true)"
+if [[ -z "$COMPOSE_BASE" ]]; then
+    echo "ℹ️  Docker Compose not available — nothing to stop, skipping cleanup."
+    exit 0
+fi
+if ! docker_daemon_up; then
+    echo "ℹ️  Docker daemon not running — nothing to stop, skipping cleanup."
+    exit 0
+fi
 
 # Detect if JFR image is running to use matching compose files
 JFR_RUNNING=$(docker ps --format "{{.Image}}" | grep "^api-sheriff:jfr$" || true)
 
 if [[ -n "$JFR_RUNNING" ]]; then
-    COMPOSE_CMD="docker compose -f docker-compose.yml -f docker-compose.jfr.yml"
+    COMPOSE_CMD="$COMPOSE_BASE -f docker-compose.yml -f docker-compose.jfr.yml"
     MODE="jfr"
 else
-    COMPOSE_CMD="docker compose -f docker-compose.yml"
+    COMPOSE_CMD="$COMPOSE_BASE -f docker-compose.yml"
     MODE="distroless"
 fi
 

--- a/integration-tests/scripts/stop-integration-container.sh
+++ b/integration-tests/scripts/stop-integration-container.sh
@@ -37,14 +37,17 @@ else
     MODE="distroless"
 fi
 
-# Stop and remove containers
+# Stop and remove containers. --remove-orphans also tears down containers from
+# optional compose profiles (e.g. the benchmark nginx-static) that this base
+# COMPOSE_CMD does not list; without it those orphans linger and block network
+# removal, breaking the teardown.
 echo "📦 Stopping Docker containers ($MODE mode)..."
-$COMPOSE_CMD down
+$COMPOSE_CMD down --remove-orphans
 
 # Optional: Clean up images and volumes
 if [ "$1" = "--clean" ]; then
     echo "🧹 Cleaning up Docker images and volumes..."
-    $COMPOSE_CMD down --volumes --rmi all
+    $COMPOSE_CMD down --remove-orphans --volumes --rmi all
 fi
 
 echo "✅ API Sheriff Integration Tests stopped successfully"


### PR DESCRIPTION
## Summary

Three related bodies of work from the 2026-07-17 adversarial review + deep CVE research, plus a parallel IT-scripts fix.

### 1. New: `doc/security-threat-model.adoc` — CVE-derived validation baseline
Trust boundaries (B1–B7) + STRIDE, then a failure catalogue where **every class is anchored to a real, cited CVE** from a comparable gateway/proxy (APISIX, Kong, Traefik, KrakenD, Tyk, Gravitee + canonical nginx/Envoy/HAProxy/JOSE CVEs) or OAuth/OIDC stack. Each entry maps to an API Sheriff control, a status (COVERED/PARTIAL/GAP/ELIMINATED), and a **testable assertion**. A validation matrix ties each control to its owning plan and doubles as the 1.0 release gate (wired into Plan 09's audit).

Attribution reflects a **source review of the foundation libraries** `cui-http` 2.1.0 and `TokenSheriff` 0.9.2 — what they own fail-closed (e.g. in-library CVE-2022-21449 psychic-signature guard, `jku`/`x5u` ignored behind an SSRF egress policy, refresh-family reuse-revoke, callback HPP rejection) vs. the genuine gateway residual.

### 2. New: `doc/plan/02b-reconciliation.adoc` — doc/code reconciliation + quality debt
A no-feature sweep closing the contradictions found in the review: the whole-second-timeout rule ADR-0008 says was removed (still enforced), ADR-0009 status, README `/q/*` ports, dead `jwks:inline`, Hamcrest vs the forbidden-frameworks rule, the unwired invalid-config negative script, and the wrk error-counter aggregation that lets an error-only run benchmark as *faster*.

### 3. Plan hardening — six gap-controls threaded in with correct library-vs-gateway ownership
- **Plan 04 D3b** — GW-01 single-canonical-path invariant, GW-02 framing/anti-smuggling gate, GW-08 HTTP/2 abuse bounds
- **Plan 05** — GW-09 WebSocket `Origin` validation on the upgrade
- **Plan 06** — GW-06 fail-closed SNI (reassemble ClientHello, test behaviour-not-flag)
- **Plan 07 D2b/D2c** — pending-auth record wrapping the engine `FlowContext`; BFF-13 `CallbackParameters.parse(rawQuery)`; scope enforcement
- **Plan 08** — BFF-08 in-memory-per-instance refresh-family caveat

Plus 0.9.2/2.1.0 dependency corrections and a centralized Execution Workflow in `plan/README.adoc`.

### 4. Parallel: IT scripts resolve `docker compose` vs `docker-compose`
`lib-docker-compose.sh` picks the Compose v2 plugin or the standalone binary and probes the daemon; `start-` fails fast with a clear message, `stop-` (pre-clean) skips cleanly so `clean install` isn't broken on a host without Docker.

## Scope
Documentation (`.adoc`) and integration-test shell scripts only — **no production code changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive security threat-model and CVE-derived validation baseline.
  * Expanded documentation indexes, reading order, implementation sequencing, and release-readiness guidance.
  * Clarified endpoint routing, environment substitution, TLS, WebSocket, gRPC, BFF session, cookie, and request-pipeline requirements.
  * Added detailed security controls, validation matrices, acceptance criteria, and operational guidance.

* **Developer Experience**
  * Integration scripts now support both Docker Compose command variants and provide clearer Docker availability checks.
  * Improved container startup, shutdown, and diagnostic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->