### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -168,12 +168,32 @@
     "map": {
       "java": [
         {
+          "glob": "*.sh",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
           "glob": "*/src/main/*.java",
           "role": "production",
           "build_class": "compile"
         },
         {
+          "glob": "*/src/main/resources/*",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
           "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "*/src/test/*IT.java",
+          "role": "test",
+          "build_class": "verify"
+        },
+        {
+          "glob": "*/src/test/resources/*",
           "role": "test",
           "build_class": "module-tests"
         },
@@ -257,7 +277,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1116",
+    "provisioned_version": "0.1.1137",
     "config_seed_fingerprint": "37df1a33"
   }
 }


### PR DESCRIPTION
## Summary

Steward-maintained artifact landing from `/marshall-steward upgrade and land`, run after updating the plan-marshall plugin set from `0.1.1131` to `0.1.1137`.

Two changes to `.plan/marshal.json`:

### 1. `build.map` re-seed (java domain)

Re-derived from the live tree, adding four globs (nothing removed, so no hand-edits were clobbered):

| Glob | Role | Build class |
|------|------|-------------|
| `*.sh` | config | verify |
| `*/src/main/resources/*` | production | compile |
| `*/src/test/*IT.java` | test | verify |
| `*/src/test/resources/*` | test | module-tests |

Effect: the `pre-push-quality-gate` finalize step now activates when a change touches shell scripts, main/test resources, or `*IT.java` integration tests — paths that previously fell outside the registered footprint.

### 2. Provisioning stamp refresh

`system.provisioned_version` advances `0.1.1116` → `0.1.1137`.

This required fixing an upstream defect first. `generate_executor` could not locate `dist-manifest.json`: on a Claude Code marketplace install the manifest is published to `~/.claude/plugins/marketplaces/<marketplace>/`, but `_find_installed_manifest()` only searches the plugin **cache** root and its parent. With no manifest it stamped `MARSHALL_VERSION = ''` into the executor, and `sync-defaults` then overwrote the existing `provisioned_version` with an empty string.

Beyond the blanked field, this left version-based staleness detection **failing open** — `installed_version` resolved to `unknown`, so `marshal_status` was always vacuously `fresh` and neither executor nor config-seed staleness could ever fire.

Resolved locally by making the manifest visible to the resolver, after which preflight reports real versions (`installed`/`executor`/`marshal` all `0.1.1137`). A durable upstream fix belongs in plan-marshall — see the notes below.

## Upstream follow-up (plan-marshall, not this repo)

- Add the marketplace clone root to the candidate list in `_find_installed_manifest()`, mapping `.../plugins/cache/<marketplace>` → `.../plugins/marketplaces/<marketplace>`.
- Make `stamp_provisioning_fields()` non-destructive: when `read_provisioned_version()` returns `''`, preserve any existing value rather than overwriting a known-good stamp with an empty sentinel.
- Consider surfacing an unresolvable manifest as an explicit warning so the staleness check fails closed rather than silently reporting `fresh`.

## Verification

- `generate_executor preflight` → `status: success`, `marshal_status: fresh`, all three versions `0.1.1137`
- `manage-config steps-sort` → `reordered: false` (finalize-step order already canonical)
- `manage-config sync-defaults` → `added_count: 0` (no missing default keys)

No production code, tests, or build configuration are touched — this changes plan-marshall tooling configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
