### PR TITLE
chore(steward): land plan-marshall artifacts for 0.1.1144

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -277,7 +277,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1137",
+    "provisioned_version": "0.1.1144",
     "config_seed_fingerprint": "37df1a33"
   }
 }

--- a/.plan/project-architecture/api-sheriff/enriched.json
+++ b/.plan/project-architecture/api-sheriff/enriched.json
@@ -1,5 +1,7 @@
 {
-  "best_practices": [],
+  "best_practices": [
+    "Placeholder-substitution coercion in ConfigLoader.coerce() is schema-agnostic (accepted limitation, recurring review finding): a whole-value placeholder resolving to an all-digit or true/false string is coerced regardless of the target field's schema type. When touching the substitution path, prefer threading the expected schema type through substitute()/coerce() (destination-type-aware coercion) rather than adding value-shape heuristics."
+  ],
   "insights": [],
   "internal_dependencies": [],
   "key_dependencies": [


### PR DESCRIPTION
Lands the steward-maintained plan-marshall artifacts:

- `.plan/marshal.json`: provisioned_version bump 0.1.1137 -> 0.1.1144
- `.plan/project-architecture/api-sheriff/enriched.json`: architecture artifact refresh

No source or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)