### PR TITLE
chore(config): raise verification-feedback effort to level-5

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -154,7 +154,7 @@
       },
       "effort": {
         "default": "level-3",
-        "verification-feedback": "level-3",
+        "verification-feedback": "level-5",
         "post-run-review": "level-4"
       }
     }


### PR DESCRIPTION
Bump the `plan.effort.verification-feedback` role from `level-3` to `level-5` in `.plan/marshal.json`, so feedback-triage dispatches run at a higher reasoning tier.

Single-line configuration change; no source or plan state touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)