### PR TITLE
feat(gateway): add anchor type/access axes and asset-serving action

### DIFF
--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelope.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * The gateway-owned response envelope for the asset terminal action (decision:
+ * ADR-0014).
+ * <p>
+ * The gateway — never the backing source — governs the response headers of every
+ * served asset, so a compromised or misconfigured directory/upstream cannot dictate
+ * caching, content sniffing, or cookie behaviour. The governance is uniform across
+ * both {@link AssetSource} implementations:
+ * <ul>
+ *   <li><strong>Fixed content type.</strong> The {@code Content-Type} is derived
+ *       from the {@linkplain #contentTypeFor(String) gateway's own extension map},
+ *       overriding whatever the source claimed; an unknown extension falls back to
+ *       {@value #DEFAULT_CONTENT_TYPE}.</li>
+ *   <li><strong>No MIME sniffing.</strong> {@code X-Content-Type-Options: nosniff}
+ *       is always set.</li>
+ *   <li><strong>Governed caching.</strong> An {@link AccessLevel#AUTHENTICATED}
+ *       asset is forced to {@code Cache-Control: no-store} regardless of source, so
+ *       authenticated content is never written to a shared cache.</li>
+ *   <li><strong>No cookies.</strong> Any {@code Set-Cookie} the source emitted is
+ *       stripped — an asset action never establishes a session.</li>
+ *   <li><strong>Read-only verbs.</strong> Only {@code GET} and {@code HEAD} are
+ *       served ({@link #isAllowedMethod(HttpMethod)}).</li>
+ * </ul>
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@UtilityClass
+public class AssetResponseEnvelope {
+
+    /** The content type served for an extension the gateway does not recognise. */
+    public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+    /** The {@code Content-Type} response header name. */
+    public static final String CONTENT_TYPE = "Content-Type";
+    /** The {@code X-Content-Type-Options} response header name. */
+    public static final String CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+    /** The {@code Cache-Control} response header name. */
+    public static final String CACHE_CONTROL = "Cache-Control";
+    /** The {@code Set-Cookie} response header name (always stripped). */
+    public static final String SET_COOKIE = "Set-Cookie";
+    /** The {@code nosniff} value for {@link #CONTENT_TYPE_OPTIONS}. */
+    public static final String NOSNIFF = "nosniff";
+    /** The {@code no-store} value forced for authenticated assets. */
+    public static final String NO_STORE = "no-store";
+
+    private static final Map<String, String> CONTENT_TYPES = Map.ofEntries(
+            Map.entry("html", "text/html; charset=utf-8"),
+            Map.entry("htm", "text/html; charset=utf-8"),
+            Map.entry("css", "text/css; charset=utf-8"),
+            Map.entry("js", "text/javascript; charset=utf-8"),
+            Map.entry("mjs", "text/javascript; charset=utf-8"),
+            Map.entry("json", "application/json"),
+            Map.entry("map", "application/json"),
+            Map.entry("xml", "application/xml"),
+            Map.entry("txt", "text/plain; charset=utf-8"),
+            Map.entry("svg", "image/svg+xml"),
+            Map.entry("png", "image/png"),
+            Map.entry("jpg", "image/jpeg"),
+            Map.entry("jpeg", "image/jpeg"),
+            Map.entry("gif", "image/gif"),
+            Map.entry("webp", "image/webp"),
+            Map.entry("ico", "image/x-icon"),
+            Map.entry("woff", "font/woff"),
+            Map.entry("woff2", "font/woff2"),
+            Map.entry("ttf", "font/ttf"),
+            Map.entry("pdf", "application/pdf"),
+            Map.entry("wasm", "application/wasm"));
+
+    /**
+     * Resolves the gateway-governed content type for a filename by its extension.
+     *
+     * @param filename the served filename (may contain a path); never {@code null}
+     * @return the mapped content type, or {@value #DEFAULT_CONTENT_TYPE} for an
+     *         unknown or absent extension
+     */
+    public static String contentTypeFor(String filename) {
+        Objects.requireNonNull(filename, "filename");
+        int lastSlash = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+        String name = filename.substring(lastSlash + 1);
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return DEFAULT_CONTENT_TYPE;
+        }
+        String extension = name.substring(dot + 1).toLowerCase(Locale.ROOT);
+        return CONTENT_TYPES.getOrDefault(extension, DEFAULT_CONTENT_TYPE);
+    }
+
+    /**
+     * Whether the request verb is servable by an asset action — {@code GET} and
+     * {@code HEAD} only.
+     *
+     * @param method the request method; never {@code null}
+     * @return {@code true} for {@link HttpMethod#GET} or {@link HttpMethod#HEAD}
+     */
+    public static boolean isAllowedMethod(HttpMethod method) {
+        Objects.requireNonNull(method, "method");
+        return method == HttpMethod.GET || method == HttpMethod.HEAD;
+    }
+
+    /**
+     * Builds the final, gateway-governed response header set for a served asset.
+     * <p>
+     * The source headers are copied verbatim except for the four the gateway owns:
+     * {@code Content-Type} is overridden from the extension map, {@code Set-Cookie}
+     * is dropped, {@code X-Content-Type-Options: nosniff} is added, and — for
+     * {@link AccessLevel#AUTHENTICATED} — {@code Cache-Control: no-store} overrides
+     * whatever the source declared. Header-name matching is case-insensitive.
+     *
+     * @param filename      the served filename, used to resolve the content type
+     * @param access        the effective access level of the serving route
+     * @param sourceHeaders the raw headers the backing source proposed; never
+     *                      {@code null}
+     * @return an ordered, mutable copy of the governed headers
+     */
+    public static Map<String, String> governedHeaders(String filename, AccessLevel access,
+            Map<String, String> sourceHeaders) {
+        Objects.requireNonNull(filename, "filename");
+        Objects.requireNonNull(access, "access");
+        Objects.requireNonNull(sourceHeaders, "sourceHeaders");
+        boolean authenticated = access == AccessLevel.AUTHENTICATED;
+        Map<String, String> governed = new LinkedHashMap<>();
+        for (Map.Entry<String, String> header : sourceHeaders.entrySet()) {
+            if (isGatewayOwned(header.getKey(), authenticated)) {
+                continue;
+            }
+            governed.put(header.getKey(), header.getValue());
+        }
+        governed.put(CONTENT_TYPE, contentTypeFor(filename));
+        governed.put(CONTENT_TYPE_OPTIONS, NOSNIFF);
+        if (authenticated) {
+            governed.put(CACHE_CONTROL, NO_STORE);
+        }
+        return governed;
+    }
+
+    private static boolean isGatewayOwned(String headerName, boolean authenticated) {
+        return headerName.equalsIgnoreCase(CONTENT_TYPE)
+                || headerName.equalsIgnoreCase(CONTENT_TYPE_OPTIONS)
+                || headerName.equalsIgnoreCase(SET_COOKIE)
+                || (authenticated && headerName.equalsIgnoreCase(CACHE_CONTROL));
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelope.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 
@@ -162,9 +163,9 @@ public class AssetResponseEnvelope {
     }
 
     private static boolean isGatewayOwned(String headerName, boolean authenticated) {
-        return headerName.equalsIgnoreCase(CONTENT_TYPE)
-                || headerName.equalsIgnoreCase(CONTENT_TYPE_OPTIONS)
-                || headerName.equalsIgnoreCase(SET_COOKIE)
-                || (authenticated && headerName.equalsIgnoreCase(CACHE_CONTROL));
+        return CONTENT_TYPE.equalsIgnoreCase(headerName)
+                || CONTENT_TYPE_OPTIONS.equalsIgnoreCase(headerName)
+                || SET_COOKIE.equalsIgnoreCase(headerName)
+                || (authenticated && CACHE_CONTROL.equalsIgnoreCase(headerName));
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.api.asset;
 
 import java.util.Map;
 
+
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import java.util.Map;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+
+/**
+ * The sealed source seam for the asset terminal action (decision: ADR-0014).
+ * <p>
+ * An asset route resolves its bytes through exactly one {@code AssetSource}: a
+ * {@link DirectoryAssetSource local directory} or an {@link UpstreamAssetSource
+ * secondary origin}. Sealing the hierarchy lets the terminal-action dispatcher match
+ * the two cases exhaustively while keeping every other module closed to new source
+ * kinds.
+ * <p>
+ * <strong>Auth-before-source-resolution ordering contract.</strong> Every
+ * implementation MUST be invoked only after the request pipeline has (1) authenticated
+ * and authorized the request against the route's effective auth posture and (2)
+ * confined the request sub-path through {@link PathConfinement}. An implementation
+ * MUST NOT touch its backing store — open a file, issue an upstream call — until a
+ * confined target has been produced; the confinement result is the only path an
+ * implementation may act on. This ordering is what makes an {@code access:
+ * authenticated} asset fail closed: no byte is read before authorization succeeds.
+ * <p>
+ * The gateway — not the source — governs the response headers: every implementation
+ * routes its proposed headers through
+ * {@link AssetResponseEnvelope#governedHeaders(String, AccessLevel, Map)} and honours
+ * {@link AssetResponseEnvelope#isAllowedMethod(HttpMethod)} before serving.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public sealed interface AssetSource permits DirectoryAssetSource, UpstreamAssetSource {
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.api.asset;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -87,6 +88,49 @@ public sealed interface AssetSource permits DirectoryAssetSource, UpstreamAssetS
         @Override
         public byte[] body() {
             return body.clone();
+        }
+
+        /**
+         * Value equality over the status, headers, and body <em>content</em> — the
+         * generated accessor would compare the {@code body} array by identity, so it is
+         * overridden to use {@link Arrays#equals(byte[], byte[])}.
+         *
+         * @param other the object to compare against
+         * @return {@code true} when {@code other} is a {@code Served} with the same status,
+         *         headers, and body bytes
+         */
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            return other instanceof Served served
+                    && status == served.status
+                    && headers.equals(served.headers)
+                    && Arrays.equals(body, served.body);
+        }
+
+        /**
+         * Content-based hash consistent with {@link #equals(Object)} — the {@code body}
+         * array contributes via {@link Arrays#hashCode(byte[])} rather than identity.
+         *
+         * @return the content hash
+         */
+        @Override
+        public int hashCode() {
+            return Objects.hash(status, headers, Arrays.hashCode(body));
+        }
+
+        /**
+         * Renders the status and headers with only the body <em>length</em> — the body
+         * bytes are never dumped, since an asset response may carry sensitive content on
+         * this security-focused gateway.
+         *
+         * @return a body-content-free description of this response
+         */
+        @Override
+        public String toString() {
+            return "Served[status=%d, headers=%s, body.length=%d]".formatted(status, headers, body.length);
         }
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.api.asset;
 
 import java.util.Map;
+import java.util.Objects;
 
 
 import de.cuioss.sheriff.api.config.model.AccessLevel;
@@ -48,4 +49,44 @@ import de.cuioss.sheriff.api.config.model.HttpMethod;
  * @since 1.0
  */
 public sealed interface AssetSource permits DirectoryAssetSource, UpstreamAssetSource {
+
+    /**
+     * Serves the confined asset addressed by {@code subPath}.
+     *
+     * @param method  the request verb; only {@code GET} and {@code HEAD} are served
+     * @param subPath the untrusted request sub-path relative to the source's root
+     * @return the governed {@link Served} response
+     */
+    Served serve(HttpMethod method, String subPath);
+
+    /**
+     * A gateway-governed asset response — the shared shape both {@link AssetSource}
+     * implementations and the edge dispatcher use, from the raw source read through
+     * the buffered write-back.
+     *
+     * @param status  the HTTP status code
+     * @param headers the governed response headers (never source-dictated)
+     * @param body    the response body; empty for {@code HEAD} and every non-200
+     *                outcome
+     * @author API Sheriff Team
+     * @since 1.0
+     */
+    record Served(int status, Map<String, String> headers, byte[] body) {
+
+        /**
+         * Canonical constructor defensively copying the headers and body.
+         */
+        public Served {
+            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+            body = Objects.requireNonNull(body, "body").clone();
+        }
+
+        /**
+         * @return a defensive copy of the response body
+         */
+        @Override
+        public byte[] body() {
+            return body.clone();
+        }
+    }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -32,8 +32,11 @@ import de.cuioss.sheriff.api.config.model.HttpMethod;
  * Serves regular files from a configured directory root — no classpath-embedded
  * resources — through the two shared, gateway-owned primitives:
  * {@link PathConfinement} maps the untrusted request sub-path to a target proven to
- * lie inside the root (any escape or malformed encoding is a 404), and
- * {@link AssetResponseEnvelope} governs every served response (fixed content type,
+ * lie inside the root lexically (any encoding-based escape or malformed encoding is a
+ * 404), and this class additionally verifies the resolved target's <em>real</em> path
+ * (symlinks followed) still lies inside the root's real path before it is touched — so
+ * a symlink planted under root cannot serve content that lives outside it. Every
+ * response is then governed by {@link AssetResponseEnvelope} (fixed content type,
  * {@code nosniff}, forced {@code no-store} for authenticated access, stripped
  * {@code Set-Cookie}). Only {@code GET} and {@code HEAD} are served; a {@code HEAD}
  * carries the governed headers with an empty body. Files larger than the configured
@@ -96,8 +99,9 @@ public final class DirectoryAssetSource implements AssetSource {
      * @param method  the request verb; only {@code GET} and {@code HEAD} are served
      * @param subPath the untrusted request sub-path relative to the root
      * @return the governed {@link Served} response — {@code 405} for a non-read verb,
-     *         {@code 404} for a confinement rejection or a missing file, {@code 413}
-     *         for an oversized file, {@code 500} on a read error, otherwise {@code 200}
+     *         {@code 404} for a confinement rejection, a symlink escape, or a missing
+     *         file, {@code 413} for an oversized file, {@code 500} on a read error,
+     *         otherwise {@code 200}
      */
     @Override
     public Served serve(HttpMethod method, String subPath) {
@@ -113,6 +117,9 @@ public final class DirectoryAssetSource implements AssetSource {
         if (!Files.isRegularFile(file)) {
             return new Served(NOT_FOUND, Map.of(), EMPTY_BODY);
         }
+        if (!realPathWithinRoot(file)) {
+            return new Served(NOT_FOUND, Map.of(), EMPTY_BODY);
+        }
         try {
             if (Files.size(file) > maxBytes) {
                 return new Served(PAYLOAD_TOO_LARGE, Map.of(), EMPTY_BODY);
@@ -123,6 +130,28 @@ public final class DirectoryAssetSource implements AssetSource {
             return new Served(OK, headers, body);
         } catch (IOException readFailure) {
             return new Served(SERVER_ERROR, Map.of(), EMPTY_BODY);
+        }
+    }
+
+    /**
+     * Verifies the confined {@code file}'s symlink-resolved real path still lies inside the
+     * configured root's real path.
+     * <p>
+     * {@link PathConfinement} closes the encoding/traversal class <em>lexically</em>: it proves
+     * the requested path's normalized string starts with the root's normalized string. A symlink
+     * entry living under {@code root} — planted by a compromised deploy step, a hostile archive
+     * extraction, or any other write access to the mounted volume — can lexically resolve inside
+     * root while its followed target lives outside it; that is a different spelling of the same
+     * escape class the confinement javadoc claims closes entirely. Resolving both sides through
+     * {@link Path#toRealPath(java.nio.file.LinkOption...)} (default: follow symlinks) and
+     * comparing the real paths closes that spelling too. Fails closed: any I/O failure resolving
+     * either real path (a TOCTOU removal, an unresolvable symlink cycle) is treated as an escape.
+     */
+    private boolean realPathWithinRoot(Path file) {
+        try {
+            return file.toRealPath().startsWith(root.toRealPath());
+        } catch (IOException unresolvable) {
+            return false;
         }
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+/**
+ * The local-directory / volume-mount {@link AssetSource} (decision: ADR-0014).
+ * <p>
+ * Serves confined files from a configured directory root through the shared
+ * {@link PathConfinement} and {@link AssetResponseEnvelope}. This is the sealed-seam
+ * member of the asset-source hierarchy; its directory-serving behaviour is
+ * implemented in the local-directory asset-source deliverable.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public final class DirectoryAssetSource implements AssetSource {
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -99,6 +99,7 @@ public final class DirectoryAssetSource implements AssetSource {
      *         {@code 404} for a confinement rejection or a missing file, {@code 413}
      *         for an oversized file, {@code 500} on a read error, otherwise {@code 200}
      */
+    @Override
     public Served serve(HttpMethod method, String subPath) {
         Objects.requireNonNull(method, "method");
         if (!AssetResponseEnvelope.isAllowedMethod(method)) {
@@ -122,35 +123,6 @@ public final class DirectoryAssetSource implements AssetSource {
             return new Served(OK, headers, body);
         } catch (IOException readFailure) {
             return new Served(SERVER_ERROR, Map.of(), EMPTY_BODY);
-        }
-    }
-
-    /**
-     * A gateway-governed directory-asset response.
-     *
-     * @param status  the HTTP status code
-     * @param headers the governed response headers (never source-dictated)
-     * @param body    the response body; empty for {@code HEAD} and every non-200
-     *                outcome
-     * @author API Sheriff Team
-     * @since 1.0
-     */
-    public record Served(int status, Map<String, String> headers, byte[] body) {
-
-        /**
-         * Canonical constructor defensively copying the headers and body.
-         */
-        public Served {
-            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
-            body = Objects.requireNonNull(body, "body").clone();
-        }
-
-        /**
-         * @return a defensive copy of the response body
-         */
-        @Override
-        public byte[] body() {
-            return body.clone();
         }
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -15,16 +15,141 @@
  */
 package de.cuioss.sheriff.api.asset;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+
 /**
  * The local-directory / volume-mount {@link AssetSource} (decision: ADR-0014).
  * <p>
- * Serves confined files from a configured directory root through the shared
- * {@link PathConfinement} and {@link AssetResponseEnvelope}. This is the sealed-seam
- * member of the asset-source hierarchy; its directory-serving behaviour is
- * implemented in the local-directory asset-source deliverable.
+ * Serves regular files from a configured directory root — no classpath-embedded
+ * resources — through the two shared, gateway-owned primitives:
+ * {@link PathConfinement} maps the untrusted request sub-path to a target proven to
+ * lie inside the root (any escape or malformed encoding is a 404), and
+ * {@link AssetResponseEnvelope} governs every served response (fixed content type,
+ * {@code nosniff}, forced {@code no-store} for authenticated access, stripped
+ * {@code Set-Cookie}). Only {@code GET} and {@code HEAD} are served; a {@code HEAD}
+ * carries the governed headers with an empty body. Files larger than the configured
+ * cap are refused rather than streamed.
+ * <p>
+ * Honouring the {@link AssetSource} ordering contract, the backing filesystem is
+ * touched only after confinement has produced an in-root target — no byte is read for
+ * a rejected path.
  *
  * @author API Sheriff Team
  * @since 1.0
  */
 public final class DirectoryAssetSource implements AssetSource {
+
+    /** The default served-file size cap (10 MiB). */
+    public static final long DEFAULT_MAX_BYTES = 10L * 1024 * 1024;
+
+    private static final int OK = 200;
+    private static final int NOT_FOUND = 404;
+    private static final int METHOD_NOT_ALLOWED = 405;
+    private static final int PAYLOAD_TOO_LARGE = 413;
+    private static final int SERVER_ERROR = 500;
+    private static final byte[] EMPTY_BODY = new byte[0];
+
+    private final Path root;
+    private final AccessLevel access;
+    private final PathConfinement confinement;
+    private final long maxBytes;
+
+    /**
+     * Creates a source rooted at {@code root} for a route of the given access level,
+     * using the default {@link PathConfinement} and {@value #DEFAULT_MAX_BYTES}-byte
+     * size cap.
+     *
+     * @param root   the configured directory root (mandatory)
+     * @param access the serving route's effective access level (mandatory)
+     */
+    public DirectoryAssetSource(Path root, AccessLevel access) {
+        this(root, access, new PathConfinement(), DEFAULT_MAX_BYTES);
+    }
+
+    /**
+     * Creates a source with an explicit confinement and size cap.
+     *
+     * @param root        the configured directory root (mandatory)
+     * @param access      the serving route's effective access level (mandatory)
+     * @param confinement the shared path confinement (mandatory)
+     * @param maxBytes    the maximum served-file size in bytes
+     */
+    public DirectoryAssetSource(Path root, AccessLevel access, PathConfinement confinement, long maxBytes) {
+        this.root = Objects.requireNonNull(root, "root").toAbsolutePath().normalize();
+        this.access = Objects.requireNonNull(access, "access");
+        this.confinement = Objects.requireNonNull(confinement, "confinement");
+        this.maxBytes = maxBytes;
+    }
+
+    /**
+     * Serves the confined asset addressed by {@code subPath}.
+     *
+     * @param method  the request verb; only {@code GET} and {@code HEAD} are served
+     * @param subPath the untrusted request sub-path relative to the root
+     * @return the governed {@link Served} response — {@code 405} for a non-read verb,
+     *         {@code 404} for a confinement rejection or a missing file, {@code 413}
+     *         for an oversized file, {@code 500} on a read error, otherwise {@code 200}
+     */
+    public Served serve(HttpMethod method, String subPath) {
+        Objects.requireNonNull(method, "method");
+        if (!AssetResponseEnvelope.isAllowedMethod(method)) {
+            return new Served(METHOD_NOT_ALLOWED, Map.of(), EMPTY_BODY);
+        }
+        Optional<Path> confined = confinement.confine(root, subPath);
+        if (confined.isEmpty()) {
+            return new Served(NOT_FOUND, Map.of(), EMPTY_BODY);
+        }
+        Path file = confined.get();
+        if (!Files.isRegularFile(file)) {
+            return new Served(NOT_FOUND, Map.of(), EMPTY_BODY);
+        }
+        try {
+            if (Files.size(file) > maxBytes) {
+                return new Served(PAYLOAD_TOO_LARGE, Map.of(), EMPTY_BODY);
+            }
+            Map<String, String> headers = AssetResponseEnvelope.governedHeaders(
+                    file.getFileName().toString(), access, Map.of());
+            byte[] body = method == HttpMethod.HEAD ? EMPTY_BODY : Files.readAllBytes(file);
+            return new Served(OK, headers, body);
+        } catch (IOException readFailure) {
+            return new Served(SERVER_ERROR, Map.of(), EMPTY_BODY);
+        }
+    }
+
+    /**
+     * A gateway-governed directory-asset response.
+     *
+     * @param status  the HTTP status code
+     * @param headers the governed response headers (never source-dictated)
+     * @param body    the response body; empty for {@code HEAD} and every non-200
+     *                outcome
+     * @author API Sheriff Team
+     * @since 1.0
+     */
+    public record Served(int status, Map<String, String> headers, byte[] body) {
+
+        /**
+         * Canonical constructor defensively copying the headers and body.
+         */
+        public Served {
+            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+            body = Objects.requireNonNull(body, "body").clone();
+        }
+
+        /**
+         * @return a defensive copy of the response body
+         */
+        @Override
+        public byte[] body() {
+            return body.clone();
+        }
+    }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
 
+
 import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.core.HttpSecurityValidator;
 import de.cuioss.http.security.exceptions.UrlSecurityException;

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.PipelineFactory;
+
+/**
+ * Canonicalize-and-confine for asset paths — the single boundary that turns an
+ * untrusted request sub-path into a filesystem target proven to lie inside a
+ * configured root (decision: ADR-0014, threat GW-asset-traversal).
+ * <p>
+ * Confinement is applied <strong>before any source is touched</strong> and is shared
+ * by every {@link AssetSource}. It runs in two stages, both fail-closed:
+ * <ol>
+ *   <li><strong>Canonicalize</strong> the raw sub-path through the {@code cui-http}
+ *       {@code URL_PATH} validation pipeline ({@code strict} policy). The pipeline
+ *       rejects the whole class of encoding attacks — percent-encoded traversal and
+ *       slashes, double/mixed encoding, {@code %00} null bytes, overlong sequences,
+ *       backslash and {@code ..;/} tricks — throwing {@link UrlSecurityException},
+ *       which this class maps to a rejection rather than a leaked exception.</li>
+ *   <li><strong>Confine</strong> the normalized path under the root: resolve it
+ *       against the absolute, normalized root and confirm the result still starts
+ *       with the root. Any {@code ..} segment that survives canonicalization and
+ *       would escape the root is rejected here.</li>
+ * </ol>
+ * Rejecting the whole class — not one spelling — is deliberate: the confinement is
+ * the sole gate, so a single missed encoding is a traversal. The adversarial test
+ * corpus proves no member of the class escapes.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public final class PathConfinement {
+
+    private final HttpSecurityValidator pathValidator;
+
+    /**
+     * Creates a confinement backed by the supplied inbound-validation policy and the
+     * application's shared security event counter.
+     *
+     * @param configuration the {@code cui-http} inbound validation policy
+     * @param eventCounter  the shared security event counter (never a local instance
+     *                      in production wiring)
+     */
+    public PathConfinement(SecurityConfiguration configuration, SecurityEventCounter eventCounter) {
+        this.pathValidator = PipelineFactory.createUrlPathPipeline(
+                Objects.requireNonNull(configuration, "configuration"),
+                Objects.requireNonNull(eventCounter, "eventCounter"));
+    }
+
+    /**
+     * Creates a confinement with the {@code strict} inbound-validation policy and a
+     * fresh event counter — the convenience wiring for tests and single-root use.
+     */
+    public PathConfinement() {
+        this(SecurityConfiguration.strict(), new SecurityEventCounter());
+    }
+
+    /**
+     * Canonicalizes {@code requestSubPath} and confines it under {@code root}.
+     *
+     * @param root           the configured directory root; confinement guarantees the
+     *                       returned path is inside it
+     * @param requestSubPath the untrusted request sub-path (relative to the asset
+     *                       mount); may be {@code null}
+     * @return the confined, absolute, normalized path, or {@link Optional#empty()}
+     *         when the input is rejected by the canonicalization pipeline or would
+     *         escape {@code root}
+     */
+    public Optional<Path> confine(Path root, String requestSubPath) {
+        Objects.requireNonNull(root, "root");
+        if (requestSubPath == null) {
+            return Optional.empty();
+        }
+        String canonical;
+        try {
+            String asAbsolute = "/" + stripLeadingSlashes(requestSubPath);
+            canonical = pathValidator.validate(asAbsolute).orElse("/");
+        } catch (UrlSecurityException rejected) {
+            return Optional.empty();
+        }
+        String relative = stripLeadingSlashes(canonical);
+        Path confinedRoot = root.toAbsolutePath().normalize();
+        try {
+            Path resolved = confinedRoot.resolve(relative).normalize();
+            if (!resolved.startsWith(confinedRoot)) {
+                return Optional.empty();
+            }
+            return Optional.of(resolved);
+        } catch (InvalidPathException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private static String stripLeadingSlashes(String value) {
+        int index = 0;
+        while (index < value.length() && value.charAt(index) == '/') {
+            index++;
+        }
+        return value.substring(index);
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+/**
+ * The secondary-origin {@link AssetSource} (decision: ADR-0014).
+ * <p>
+ * Serves assets from a secondary origin reached through the same SSRF-controlled data
+ * plane the proxy action uses, governed by the shared {@link AssetResponseEnvelope}.
+ * This is the sealed-seam member of the asset-source hierarchy; its upstream-serving
+ * behaviour is implemented in the upstream asset-source deliverable.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public final class UpstreamAssetSource implements AssetSource {
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -130,6 +130,7 @@ public final class UpstreamAssetSource implements AssetSource {
      *         scheme or fetch error, {@code 504} on a timeout, {@code 413} for an
      *         oversized body, otherwise the governed upstream status
      */
+    @Override
     public Served serve(HttpMethod method, String remainder) {
         Objects.requireNonNull(method, "method");
         if (!AssetResponseEnvelope.isAllowedMethod(method)) {
@@ -296,35 +297,6 @@ public final class UpstreamAssetSource implements AssetSource {
             public UpstreamTimeoutException(Throwable cause) {
                 super("upstream fetch timed out", cause);
             }
-        }
-    }
-
-    /**
-     * A gateway-governed upstream-asset response.
-     *
-     * @param status  the (governed) HTTP status code
-     * @param headers the governed response headers (never upstream-dictated)
-     * @param body    the response body; empty for {@code HEAD}, a non-2xx upstream
-     *                status, and every rejection
-     * @author API Sheriff Team
-     * @since 1.0
-     */
-    public record Served(int status, Map<String, String> headers, byte[] body) {
-
-        /**
-         * Canonical constructor defensively copying the headers and body.
-         */
-        public Served {
-            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
-            body = Objects.requireNonNull(body, "body").clone();
-        }
-
-        /**
-         * @return a defensive copy of the response body
-         */
-        @Override
-        public byte[] body() {
-            return body.clone();
         }
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -21,13 +21,15 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
 
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
@@ -210,7 +212,7 @@ public final class UpstreamAssetSource implements AssetSource {
             HttpResponse<byte[]> response;
             try {
                 response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
-            } catch (java.net.http.HttpTimeoutException timeout) {
+            } catch (HttpTimeoutException timeout) {
                 throw new UpstreamFetcher.UpstreamTimeoutException(timeout);
             } catch (InterruptedException interrupted) {
                 Thread.currentThread().interrupt();
@@ -218,12 +220,12 @@ public final class UpstreamAssetSource implements AssetSource {
             }
             byte[] body = response.body();
             if (body.length > maxBytes) {
-                body = java.util.Arrays.copyOf(body, (int) Math.min(maxBytes + 1, body.length));
+                body = Arrays.copyOf(body, (int) Math.min(maxBytes + 1, body.length));
             }
             Map<String, String> headers = new LinkedHashMap<>();
             response.headers().map().forEach((name, values) -> {
                 if (!values.isEmpty()) {
-                    headers.put(name, values.get(0));
+                    headers.put(name, values.getFirst());
                 }
             });
             return new UpstreamFetcher.Fetched(response.statusCode(), headers, body);

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -15,16 +15,314 @@
  */
 package de.cuioss.sheriff.api.asset;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
+
 /**
  * The secondary-origin {@link AssetSource} (decision: ADR-0014).
  * <p>
- * Serves assets from a secondary origin reached through the same SSRF-controlled data
- * plane the proxy action uses, governed by the shared {@link AssetResponseEnvelope}.
- * This is the sealed-seam member of the asset-source hierarchy; its upstream-serving
- * behaviour is implemented in the upstream asset-source deliverable.
+ * Serves assets from an upstream reached through the same fixed-topology, SSRF-guarded
+ * egress the proxy action uses — no parallel fetch stack of its own. The target is a
+ * {@link ResolvedUpstream} decomposed at boot from a topology alias, so the host is
+ * never attacker-controlled; the untrusted request remainder is confined by the shared
+ * {@link PathConfinement} (over a synthetic base, rejecting traversal/encoding) BEFORE
+ * the upstream is touched, and only appended to the resolved base path. The single
+ * blocking fetch is delegated to an {@link UpstreamFetcher} seam whose
+ * {@linkplain #httpFetcher(Duration, Duration, long) default} embodies the SSRF
+ * controls: a scheme allowlist ({@code http}/{@code https}), {@code followRedirects}
+ * set to {@code NEVER}, a connect/read timeout, and a bounded response body.
+ * <p>
+ * Every response is passed through {@link AssetResponseEnvelope}, so the gateway — not
+ * the (possibly hostile) upstream — decides the response metadata: the content type is
+ * taken from the fixed extension map (overriding the upstream's claim), {@code nosniff}
+ * is set, an upstream {@code Set-Cookie} is stripped, and an
+ * {@link AccessLevel#AUTHENTICATED} asset is forced to {@code no-store} even when the
+ * upstream sent {@code Cache-Control: public}.
  *
  * @author API Sheriff Team
  * @since 1.0
  */
 public final class UpstreamAssetSource implements AssetSource {
+
+    /** The default served-asset size cap (10 MiB). */
+    public static final long DEFAULT_MAX_BYTES = 10L * 1024 * 1024;
+    /** The default upstream connect timeout. */
+    public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    /** The default upstream read timeout. */
+    public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(10);
+
+    private static final int OK = 200;
+    private static final int NOT_FOUND = 404;
+    private static final int METHOD_NOT_ALLOWED = 405;
+    private static final int PAYLOAD_TOO_LARGE = 413;
+    private static final int BAD_GATEWAY = 502;
+    private static final int GATEWAY_TIMEOUT = 504;
+    private static final int LOWEST_ERROR_STATUS = 400;
+    private static final byte[] EMPTY_BODY = new byte[0];
+    /**
+     * The synthetic confinement base: it never touches the filesystem, but gives the
+     * shared {@link PathConfinement} a non-root anchor so a remainder that traverses
+     * above it is rejected (a {@code "/"} anchor would confine nothing).
+     */
+    private static final Path CONFINEMENT_BASE = Path.of("/__sheriff_asset_base__");
+
+    private final ResolvedUpstream upstream;
+    private final AccessLevel access;
+    private final PathConfinement confinement;
+    private final UpstreamFetcher fetcher;
+    private final long maxBytes;
+
+    /**
+     * Creates a source for a fixed-topology upstream and route access level, using the
+     * default {@link PathConfinement}, the {@linkplain #httpFetcher(Duration, Duration,
+     * long) SSRF-guarded HTTP fetcher}, and the default timeouts and size cap.
+     *
+     * @param upstream the boot-resolved upstream target (mandatory)
+     * @param access   the serving route's effective access level (mandatory)
+     */
+    public UpstreamAssetSource(ResolvedUpstream upstream, AccessLevel access) {
+        this(upstream, access, new PathConfinement(),
+                httpFetcher(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_MAX_BYTES), DEFAULT_MAX_BYTES);
+    }
+
+    /**
+     * Creates a source with an explicit confinement, fetch seam, and size cap.
+     *
+     * @param upstream    the boot-resolved upstream target (mandatory)
+     * @param access      the serving route's effective access level (mandatory)
+     * @param confinement the shared path confinement (mandatory)
+     * @param fetcher     the upstream fetch seam (mandatory)
+     * @param maxBytes    the maximum served-asset size in bytes
+     */
+    public UpstreamAssetSource(ResolvedUpstream upstream, AccessLevel access, PathConfinement confinement,
+            UpstreamFetcher fetcher, long maxBytes) {
+        this.upstream = Objects.requireNonNull(upstream, "upstream");
+        this.access = Objects.requireNonNull(access, "access");
+        this.confinement = Objects.requireNonNull(confinement, "confinement");
+        this.fetcher = Objects.requireNonNull(fetcher, "fetcher");
+        this.maxBytes = maxBytes;
+    }
+
+    /**
+     * Serves the confined upstream asset addressed by {@code remainder}.
+     *
+     * @param method    the request verb; only {@code GET} and {@code HEAD} are served
+     * @param remainder the untrusted request path remainder after the route prefix
+     * @return the governed {@link Served} response — {@code 405} for a non-read verb,
+     *         {@code 404} for a confinement rejection, {@code 502} for a disallowed
+     *         scheme or fetch error, {@code 504} on a timeout, {@code 413} for an
+     *         oversized body, otherwise the governed upstream status
+     */
+    public Served serve(HttpMethod method, String remainder) {
+        Objects.requireNonNull(method, "method");
+        if (!AssetResponseEnvelope.isAllowedMethod(method)) {
+            return new Served(METHOD_NOT_ALLOWED, Map.of(), EMPTY_BODY);
+        }
+        if (!isAllowedScheme(upstream.scheme())) {
+            return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);
+        }
+        Optional<String> confined = confinedRemainder(remainder);
+        if (confined.isEmpty()) {
+            return new Served(NOT_FOUND, Map.of(), EMPTY_BODY);
+        }
+        URI target;
+        try {
+            target = upstreamUri(confined.get());
+        } catch (URISyntaxException malformed) {
+            return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);
+        }
+        UpstreamFetcher.Fetched fetched;
+        try {
+            fetched = fetcher.fetch(target);
+        } catch (UpstreamFetcher.UpstreamTimeoutException timeout) {
+            return new Served(GATEWAY_TIMEOUT, Map.of(), EMPTY_BODY);
+        } catch (IOException fetchFailure) {
+            return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);
+        }
+        if (fetched.body().length > maxBytes) {
+            return new Served(PAYLOAD_TOO_LARGE, Map.of(), EMPTY_BODY);
+        }
+        Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                filenameOf(confined.get()), access, fetched.headers());
+        boolean serveBody = method == HttpMethod.GET && fetched.status() < LOWEST_ERROR_STATUS;
+        byte[] body = serveBody ? fetched.body() : EMPTY_BODY;
+        return new Served(fetched.status(), governed, body);
+    }
+
+    private Optional<String> confinedRemainder(String remainder) {
+        return confinement.confine(CONFINEMENT_BASE, remainder)
+                .map(confined -> "/" + CONFINEMENT_BASE.relativize(confined).toString().replace('\\', '/'));
+    }
+
+    private URI upstreamUri(String urlRemainder) throws URISyntaxException {
+        String base = upstream.basePath();
+        String prefix = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+        String path = "/".equals(urlRemainder) && prefix.isEmpty() ? "/" : prefix + urlRemainder;
+        return new URI(upstream.scheme(), null, upstream.host(), upstream.port(), path, null, null);
+    }
+
+    private static String filenameOf(String urlRemainder) {
+        int lastSlash = urlRemainder.lastIndexOf('/');
+        return lastSlash < 0 ? urlRemainder : urlRemainder.substring(lastSlash + 1);
+    }
+
+    private static boolean isAllowedScheme(String scheme) {
+        return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+    }
+
+    /**
+     * The SSRF-guarded default fetch seam: a blocking JDK HTTP client that never follows
+     * redirects, honours a connect and read timeout, and reads a bounded body.
+     * <p>
+     * The redirect-{@code NEVER} policy is the SSRF control that keeps a hostile upstream
+     * from bouncing the fetch to an internal address; the fixed-topology target supplied
+     * by {@link ResolvedUpstream} keeps the host itself off the attacker's control.
+     *
+     * @param connectTimeout the connect timeout
+     * @param readTimeout    the per-request read timeout
+     * @param maxBytes       the response body cap in bytes
+     * @return the SSRF-guarded fetch seam
+     */
+    public static UpstreamFetcher httpFetcher(Duration connectTimeout, Duration readTimeout, long maxBytes) {
+        Objects.requireNonNull(connectTimeout, "connectTimeout");
+        Objects.requireNonNull(readTimeout, "readTimeout");
+        HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(connectTimeout)
+                .build();
+        return target -> {
+            HttpRequest request = HttpRequest.newBuilder(target).timeout(readTimeout).GET().build();
+            HttpResponse<byte[]> response;
+            try {
+                response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            } catch (java.net.http.HttpTimeoutException timeout) {
+                throw new UpstreamFetcher.UpstreamTimeoutException(timeout);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("upstream fetch interrupted", interrupted);
+            }
+            byte[] body = response.body();
+            if (body.length > maxBytes) {
+                body = java.util.Arrays.copyOf(body, (int) Math.min(maxBytes + 1, body.length));
+            }
+            Map<String, String> headers = new LinkedHashMap<>();
+            response.headers().map().forEach((name, values) -> {
+                if (!values.isEmpty()) {
+                    headers.put(name, values.get(0));
+                }
+            });
+            return new UpstreamFetcher.Fetched(response.statusCode(), headers, body);
+        };
+    }
+
+    /**
+     * The upstream fetch seam — a single blocking GET against a fixed-topology target,
+     * governed for SSRF by its implementation.
+     *
+     * @author API Sheriff Team
+     * @since 1.0
+     */
+    @FunctionalInterface
+    public interface UpstreamFetcher {
+
+        /**
+         * Fetches the target, never following redirects.
+         *
+         * @param target the fully-resolved upstream URI
+         * @return the raw upstream response
+         * @throws IOException on a transport failure; an
+         *                     {@link UpstreamTimeoutException} signals a timeout
+         */
+        Fetched fetch(URI target) throws IOException;
+
+        /**
+         * A raw upstream response, before gateway governance.
+         *
+         * @param status  the upstream HTTP status
+         * @param headers the upstream response headers (first value per name)
+         * @param body    the upstream response body
+         * @author API Sheriff Team
+         * @since 1.0
+         */
+        record Fetched(int status, Map<String, String> headers, byte[] body) {
+
+            /**
+             * Canonical constructor defensively copying the headers and body.
+             */
+            public Fetched {
+                headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+                body = Objects.requireNonNull(body, "body").clone();
+            }
+
+            /**
+             * @return a defensive copy of the upstream body
+             */
+            @Override
+            public byte[] body() {
+                return body.clone();
+            }
+        }
+
+        /**
+         * Signals that the upstream fetch exceeded its read timeout.
+         *
+         * @author API Sheriff Team
+         * @since 1.0
+         */
+        final class UpstreamTimeoutException extends IOException {
+
+            private static final long serialVersionUID = 1L;
+
+            /**
+             * @param cause the underlying timeout
+             */
+            public UpstreamTimeoutException(Throwable cause) {
+                super("upstream fetch timed out", cause);
+            }
+        }
+    }
+
+    /**
+     * A gateway-governed upstream-asset response.
+     *
+     * @param status  the (governed) HTTP status code
+     * @param headers the governed response headers (never upstream-dictated)
+     * @param body    the response body; empty for {@code HEAD}, a non-2xx upstream
+     *                status, and every rejection
+     * @author API Sheriff Team
+     * @since 1.0
+     */
+    public record Served(int status, Map<String, String> headers, byte[] body) {
+
+        /**
+         * Canonical constructor defensively copying the headers and body.
+         */
+        public Served {
+            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+            body = Objects.requireNonNull(body, "body").clone();
+        }
+
+        /**
+         * @return a defensive copy of the response body
+         */
+        @Override
+        public byte[] body() {
+            return body.clone();
+        }
+    }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.api.asset;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,18 +23,25 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * The secondary-origin {@link AssetSource} (decision: ADR-0014).
@@ -190,7 +198,11 @@ public final class UpstreamAssetSource implements AssetSource {
 
     /**
      * The SSRF-guarded default fetch seam: a blocking JDK HTTP client that never follows
-     * redirects, honours a connect and read timeout, and reads a bounded body.
+     * redirects, honours a connect and read timeout, and reads a <strong>streamed</strong>,
+     * mid-flight-abort-capped body — consistent with the proxy data plane's
+     * {@code DispatchStage.ByteCappedBodyStream} (ADR-0006): the fetch never buffers the whole
+     * upstream body before enforcing {@code maxBytes}, it stops pulling further chunks and
+     * completes as soon as the cap is crossed.
      * <p>
      * The redirect-{@code NEVER} policy is the SSRF control that keeps a hostile upstream
      * from bouncing the fetch to an internal address; the fixed-topology target supplied
@@ -212,7 +224,7 @@ public final class UpstreamAssetSource implements AssetSource {
             HttpRequest request = HttpRequest.newBuilder(target).timeout(readTimeout).GET().build();
             HttpResponse<byte[]> response;
             try {
-                response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+                response = client.send(request, info -> new CappedByteArrayBodySubscriber(maxBytes));
             } catch (HttpTimeoutException timeout) {
                 throw new UpstreamFetcher.UpstreamTimeoutException(timeout);
             } catch (InterruptedException interrupted) {
@@ -220,6 +232,9 @@ public final class UpstreamAssetSource implements AssetSource {
                 throw new IOException("upstream fetch interrupted", interrupted);
             }
             byte[] body = response.body();
+            // The subscriber already stopped pulling once the cap was crossed, so body is at most
+            // one in-flight chunk past maxBytes; this backstop trims it to a fixed, small over-cap
+            // size so callers checking body.length > maxBytes see a stable signal either way.
             if (body.length > maxBytes) {
                 body = Arrays.copyOf(body, (int) Math.min(maxBytes + 1, body.length));
             }
@@ -231,6 +246,65 @@ public final class UpstreamAssetSource implements AssetSource {
             });
             return new UpstreamFetcher.Fetched(response.statusCode(), headers, body);
         };
+    }
+
+    /**
+     * A {@link HttpResponse.BodySubscriber} that accumulates the upstream body only up to
+     * {@code maxBytes} and then <strong>cancels its subscription</strong> — the mid-flight abort
+     * that keeps a large or slow (hostile or merely misbehaving) asset upstream from forcing the
+     * gateway to buffer an unbounded response into memory before the size cap has any effect,
+     * mirroring {@code DispatchStage.ByteCappedBodyStream}'s streamed request-body cap.
+     */
+    private static final class CappedByteArrayBodySubscriber implements HttpResponse.BodySubscriber<byte[]> {
+
+        private final long maxBytes;
+        private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        private final CompletableFuture<byte[]> result = new CompletableFuture<>();
+        private Flow.@Nullable Subscription subscription;
+        private long bytesSeen;
+
+        CappedByteArrayBodySubscriber(long maxBytes) {
+            this.maxBytes = maxBytes;
+        }
+
+        @Override
+        public CompletionStage<byte[]> getBody() {
+            return result;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> items) {
+            for (ByteBuffer item : items) {
+                byte[] chunk = new byte[item.remaining()];
+                item.get(chunk);
+                buffer.writeBytes(chunk);
+                bytesSeen += chunk.length;
+            }
+            if (bytesSeen > maxBytes && subscription != null) {
+                // Abort the in-flight fetch: stop pulling further chunks. The over-cap buffer
+                // already accumulated is enough to trip the caller's body.length > maxBytes check
+                // (backstop-trimmed there), without ever reading the remainder of a large body.
+                subscription.cancel();
+                result.complete(buffer.toByteArray());
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            result.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            // A no-op when the cap-crossed branch in onNext already completed result.
+            result.complete(buffer.toByteArray());
+        }
     }
 
     /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -280,6 +280,13 @@ public final class UpstreamAssetSource implements AssetSource {
 
         @Override
         public void onNext(List<ByteBuffer> items) {
+            // Late chunks may still be delivered after the cap-crossed branch below cancels the
+            // subscription and completes the result — cancellation is not instantaneous. Fast-return
+            // once the result is settled so the over-cap buffer is bounded at the first cap crossing
+            // rather than growing by whatever the publisher delivers during cancel propagation.
+            if (result.isDone()) {
+                return;
+            }
             for (ByteBuffer item : items) {
                 byte[] chunk = new byte[item.remaining()];
                 item.get(chunk);

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -360,6 +360,50 @@ public final class UpstreamAssetSource implements AssetSource {
             public byte[] body() {
                 return body.clone();
             }
+
+            /**
+             * Value equality over the status, headers, and body <em>content</em> — the
+             * generated accessor would compare the {@code body} array by identity, so it
+             * is overridden to use {@link Arrays#equals(byte[], byte[])}.
+             *
+             * @param other the object to compare against
+             * @return {@code true} when {@code other} is a {@code Fetched} with the same
+             *         status, headers, and body bytes
+             */
+            @Override
+            public boolean equals(Object other) {
+                if (this == other) {
+                    return true;
+                }
+                return other instanceof Fetched fetched
+                        && status == fetched.status
+                        && headers.equals(fetched.headers)
+                        && Arrays.equals(body, fetched.body);
+            }
+
+            /**
+             * Content-based hash consistent with {@link #equals(Object)} — the
+             * {@code body} array contributes via {@link Arrays#hashCode(byte[])} rather
+             * than identity.
+             *
+             * @return the content hash
+             */
+            @Override
+            public int hashCode() {
+                return Objects.hash(status, headers, Arrays.hashCode(body));
+            }
+
+            /**
+             * Renders the status and headers with only the body <em>length</em> — the raw
+             * upstream body bytes are never dumped, since they may carry sensitive content
+             * on this security-focused gateway.
+             *
+             * @return a body-content-free description of this upstream response
+             */
+            @Override
+            public String toString() {
+                return "Fetched[status=%d, headers=%s, body.length=%d]".formatted(status, headers, body.length);
+            }
         }
 
         /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/package-info.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The asset terminal action (decision: ADR-0014) — serving static content through
+ * the gateway instead of proxying to an upstream.
+ * <p>
+ * The package is organized around three cooperating pieces, all framework-agnostic
+ * (ADR-0005):
+ * <ul>
+ *   <li>{@link de.cuioss.sheriff.api.asset.PathConfinement} — the canonicalize-and-
+ *       confine boundary that turns an untrusted request sub-path into a target proven
+ *       to lie inside a configured root, rejecting the whole traversal/encoding attack
+ *       class before any source is touched.</li>
+ *   <li>{@link de.cuioss.sheriff.api.asset.AssetResponseEnvelope} — the gateway-owned
+ *       response governance: a fixed content-type map, {@code nosniff}, forced
+ *       {@code no-store} for authenticated access, stripped {@code Set-Cookie}, and
+ *       {@code GET}/{@code HEAD}-only serving.</li>
+ *   <li>{@link de.cuioss.sheriff.api.asset.AssetSource} — the sealed source seam
+ *       permitting the local-directory and secondary-origin sources, carrying the
+ *       auth-before-source-resolution ordering contract.</li>
+ * </ul>
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+package de.cuioss.sheriff.api.asset;

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
@@ -24,13 +24,16 @@ import java.util.Objects;
 import java.util.Optional;
 
 
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.Protocol;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
 import de.cuioss.sheriff.api.config.model.ResolvedRoute;
 import de.cuioss.sheriff.api.config.model.ResolvedTopology;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
@@ -99,7 +102,7 @@ public final class RouteTableBuilder {
             UpstreamDefaultsConfig defaults = resolveDefaults(gateway, endpoint);
             for (RouteConfig route : endpoint.routes()) {
                 Optional<AnchorConfig> anchor = resolveAnchor(gateway, endpoint, route);
-                resolved.add(resolveRoute(gateway, route, endpoint, anchor, upstream, defaults));
+                resolved.add(resolveRoute(gateway, route, endpoint, anchor, upstream, defaults, topology));
             }
         }
 
@@ -134,7 +137,8 @@ public final class RouteTableBuilder {
     }
 
     private static ResolvedRoute resolveRoute(GatewayConfig gateway, RouteConfig route, EndpointConfig endpoint,
-            Optional<AnchorConfig> anchor, ResolvedUpstream upstream, UpstreamDefaultsConfig defaults) {
+            Optional<AnchorConfig> anchor, ResolvedUpstream upstream, UpstreamDefaultsConfig defaults,
+            ResolvedTopology topology) {
         AuthConfig auth = route.auth().or(endpoint::auth).or(() -> anchor.flatMap(AnchorConfig::auth))
                 .orElseThrow(() -> new RouteTableException(
                         "route '%s' has no effective auth (no route, endpoint, or anchor auth block)"
@@ -154,7 +158,7 @@ public final class RouteTableBuilder {
                 .flatMap(UpstreamConfig.NotModified::enabled)
                 .orElse(defaults.notModifiedEnabled());
         ForwardConfig effectiveForward = route.forward().orElseGet(() -> ForwardConfig.builder().build());
-        ResolvedRoute resolved = ResolvedRoute.builder()
+        ResolvedRoute.ResolvedRouteBuilder builder = ResolvedRoute.builder()
                 .id(route.id())
                 .protocol(route.protocol().orElse(Protocol.HTTP))
                 .anchor(anchor.map(AnchorConfig::name))
@@ -165,11 +169,45 @@ public final class RouteTableBuilder {
                 .effectiveSecurityHeaders(securityHeaders)
                 .retryEnabled(retryEnabled)
                 .notModifiedEnabled(notModifiedEnabled)
-                .upstream(upstream)
-                .effectiveForward(effectiveForward)
-                .build();
+                .effectiveForward(effectiveForward);
+        // A route resolves to exactly one terminal action: an asset action (when the route
+        // declares an asset block) is materialized here; otherwise the route proxies to its
+        // endpoint upstream. ADR-0014: upstream XOR asset.
+        if (route.asset().isPresent()) {
+            builder.asset(Optional.of(resolveAsset(route, route.asset().get(), anchor, topology)));
+        } else {
+            builder.upstream(Optional.of(upstream));
+        }
+        ResolvedRoute resolved = builder.build();
         logPosture(resolved);
         return resolved;
+    }
+
+    /**
+     * Materializes a route's asset terminal action (ADR-0014). A {@code directory}
+     * source carries its configured root; an {@code upstream} source resolves its
+     * topology alias through the same {@link ResolvedTopology} the proxy action uses —
+     * no parallel resolution. The effective access level is inherited from the route's
+     * resolving anchor (ADR-0013), defaulting to {@link AccessLevel#PUBLIC} for an
+     * unanchored asset route (the configuration validator rejects an asset action on a
+     * non-asset anchor before assembly, so this default is a defensive floor).
+     */
+    private static ResolvedAsset resolveAsset(RouteConfig route, AssetConfig asset, Optional<AnchorConfig> anchor,
+            ResolvedTopology topology) {
+        AccessLevel access = anchor.map(AnchorConfig::access).orElse(AccessLevel.PUBLIC);
+        return switch (asset.source()) {
+            case DIRECTORY -> ResolvedAsset.directory(asset.directory().orElseThrow(() -> new RouteTableException(
+                            "asset route '%s' declares source: directory but no directory root".formatted(route.id()))),
+                    access);
+            case UPSTREAM -> {
+                String alias = asset.upstream().orElseThrow(() -> new RouteTableException(
+                        "asset route '%s' declares source: upstream but no upstream alias".formatted(route.id())));
+                ResolvedUpstream resolvedUpstream = topology.lookup(alias).orElseThrow(() -> new RouteTableException(
+                        "asset route '%s' upstream alias '%s' does not resolve in the topology"
+                                .formatted(route.id(), alias)));
+                yield ResolvedAsset.upstream(resolvedUpstream, access);
+            }
+        };
     }
 
     private static void logPosture(ResolvedRoute route) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
@@ -74,6 +74,8 @@ public final class RouteTableBuilder {
 
     private static final List<HttpMethod> STANDARD_ALLOWED_METHODS = List.copyOf(EnumSet.allOf(HttpMethod.class));
 
+    /** The {@link AuthConfig#require()} value meaning no authentication is required; also the
+     * display fallback for an absent anchor name / security-filter profile in {@link #logPosture}. */
     private static final String NONE = "none";
 
     /**
@@ -174,7 +176,7 @@ public final class RouteTableBuilder {
         // declares an asset block) is materialized here; otherwise the route proxies to its
         // endpoint upstream. ADR-0014: upstream XOR asset.
         if (route.asset().isPresent()) {
-            builder.asset(Optional.of(resolveAsset(route, route.asset().get(), anchor, topology)));
+            builder.asset(Optional.of(resolveAsset(route, route.asset().get(), anchor, auth, topology)));
         } else {
             builder.upstream(Optional.of(upstream));
         }
@@ -187,14 +189,18 @@ public final class RouteTableBuilder {
      * Materializes a route's asset terminal action (ADR-0014). A {@code directory}
      * source carries its configured root; an {@code upstream} source resolves its
      * topology alias through the same {@link ResolvedTopology} the proxy action uses —
-     * no parallel resolution. The effective access level is inherited from the route's
-     * resolving anchor (ADR-0013), defaulting to {@link AccessLevel#PUBLIC} for an
-     * unanchored asset route (the configuration validator rejects an asset action on a
-     * non-asset anchor before assembly, so this default is a defensive floor).
+     * no parallel resolution. The effective access level the gateway-owned response
+     * envelope (asset package) keys its caching on is
+     * {@link #effectiveAccessLevel(Optional, AuthConfig) derived from the route's
+     * effective auth posture}, not the anchor's static {@code access} declaration alone
+     * — a route or endpoint may legally strengthen a {@code public}-access anchor's
+     * floor with its own {@code auth} block (ADR-0007 forbids weakening the floor, not
+     * strengthening it), and such a route must still be governed {@code no-store} even
+     * though its anchor stays {@code access: public}.
      */
     private static ResolvedAsset resolveAsset(RouteConfig route, AssetConfig asset, Optional<AnchorConfig> anchor,
-            ResolvedTopology topology) {
-        AccessLevel access = anchor.map(AnchorConfig::access).orElse(AccessLevel.PUBLIC);
+            AuthConfig effectiveAuth, ResolvedTopology topology) {
+        AccessLevel access = effectiveAccessLevel(anchor, effectiveAuth);
         return switch (asset.source()) {
             case DIRECTORY -> ResolvedAsset.directory(asset.directory().orElseThrow(() -> new RouteTableException(
                             "asset route '%s' declares source: directory but no directory root".formatted(route.id()))),
@@ -208,6 +214,25 @@ public final class RouteTableBuilder {
                 yield ResolvedAsset.upstream(resolvedUpstream, access);
             }
         };
+    }
+
+    /**
+     * The access level the asset response envelope keys its caching governance on: a route whose
+     * effective auth requires authentication ({@code require} not {@code none}) is always treated
+     * as {@link AccessLevel#AUTHENTICATED}, regardless of the anchor's declared {@code access} —
+     * the anchor's {@code access} only supplies the fallback when the route is effectively
+     * unauthenticated. This closes the gap where a route or endpoint strengthens a
+     * {@code public}-access anchor's auth floor: the served asset must still be forced
+     * {@code no-store} even though the anchor itself stays {@code access: public}. Defaults to
+     * {@link AccessLevel#PUBLIC} for an unanchored, effectively-unauthenticated asset route (the
+     * configuration validator rejects an asset action on a non-asset anchor before assembly, so
+     * this default is a defensive floor).
+     */
+    private static AccessLevel effectiveAccessLevel(Optional<AnchorConfig> anchor, AuthConfig effectiveAuth) {
+        if (!NONE.equals(effectiveAuth.require())) {
+            return AccessLevel.AUTHENTICATED;
+        }
+        return anchor.map(AnchorConfig::access).orElse(AccessLevel.PUBLIC);
     }
 
     private static void logPosture(ResolvedRoute route) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AccessLevel.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AccessLevel.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.config.model;
+
+/**
+ * The audience an anchor admits (decision: ADR-0013).
+ * <p>
+ * Every anchor declares a required {@code access} level; it is a classification
+ * axis orthogonal to {@link AnchorType type}, enforced fail-closed at boot by the
+ * access-to-auth matrix: {@link #AUTHENTICATED} requires a fully-backed auth
+ * posture, and {@link #PUBLIC} combined with an auth block is a boot failure.
+ * <p>
+ * The constant name {@code PUBLIC} is the Java-safe rendering of the {@code public}
+ * configuration value (Java reserves the lowercase word); the case-insensitive YAML
+ * binding maps {@code public} / {@code authenticated} onto these constants.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public enum AccessLevel {
+
+    /** An anonymous surface: no authentication required. */
+    PUBLIC,
+    /** An authenticated surface: requires a fully-backed auth posture. */
+    AUTHENTICATED
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AnchorConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AnchorConfig.java
@@ -35,11 +35,21 @@ import lombok.Builder;
  * allowed. Anchors vanish at runtime: the route-table builder materializes each
  * route's effective values and the request pipeline never consults an anchor.
  * <p>
+ * Every anchor additionally declares two required classification axes (decision:
+ * ADR-0013): {@link AnchorType type} ({@code proxy} / {@code bff} / {@code asset} —
+ * the former {@code passthrough} value renamed to {@code proxy}) and
+ * {@link AccessLevel access} ({@code public} / {@code authenticated}). Both are
+ * mandatory on every anchor and drive the fail-closed access-to-auth boot matrix.
+ * <p>
  * {@code name} is the anchor's map key from {@code gateway.yaml}, injected during
  * loading; it is not a property of the anchor block itself.
  *
  * @param name             the anchor name (its map key, mandatory)
  * @param pathPrefix       the owned path namespace (mandatory)
+ * @param type             the anchor kind (mandatory) — {@code proxy} /
+ *                         {@code bff} / {@code asset}
+ * @param access           the anchor audience (mandatory) — {@code public} /
+ *                         {@code authenticated}
  * @param auth             the anchor-level auth floor, empty when the anchor
  *                         declares none
  * @param securityFilter   the anchor-level security filter, empty when the anchor
@@ -52,18 +62,21 @@ import lombok.Builder;
  * @since 1.0
  */
 @Builder
-public record AnchorConfig(String name, String pathPrefix, Optional<AuthConfig> auth,
+public record AnchorConfig(String name, String pathPrefix, AnchorType type, AccessLevel access,
+Optional<AuthConfig> auth,
 Optional<SecurityFilterConfig> securityFilter, Optional<SecurityHeadersConfig> securityHeaders,
 List<HttpMethod> allowedMethods) {
 
     /**
-     * Canonical constructor requiring {@code name} and {@code pathPrefix},
-     * defensively copying {@code allowedMethods}, and normalizing absent optional
-     * blocks to {@link Optional#empty()}.
+     * Canonical constructor requiring {@code name}, {@code pathPrefix},
+     * {@code type} and {@code access}, defensively copying {@code allowedMethods},
+     * and normalizing absent optional blocks to {@link Optional#empty()}.
      */
     public AnchorConfig {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(pathPrefix, "pathPrefix");
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(access, "access");
         auth = Objects.requireNonNullElse(auth, Optional.empty());
         securityFilter = Objects.requireNonNullElse(securityFilter, Optional.empty());
         securityHeaders = Objects.requireNonNullElse(securityHeaders, Optional.empty());

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AnchorType.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AnchorType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.config.model;
+
+/**
+ * The kind of surface an anchor classifies (decision: ADR-0013).
+ * <p>
+ * Every anchor declares a required {@code type}; it is a classification axis
+ * orthogonal to {@link AccessLevel access}, and selects what terminal behaviour
+ * the anchor's routes expose. The former {@code passthrough} value is renamed to
+ * {@link #PROXY} — an anchor-{@code type} value rename only; the unrelated TLS-L4
+ * {@code tls.passthrough_sni} surface keeps its name and is untouched.
+ * <p>
+ * The configuration values ({@code proxy} / {@code bff} / {@code asset}) are
+ * lowercase; the case-insensitive YAML binding maps them onto these constants.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+public enum AnchorType {
+
+    /** A plain reverse-proxy surface (formerly {@code passthrough}). */
+    PROXY,
+    /** A Backend-For-Frontend surface. */
+    BFF,
+    /** A static-asset surface (decision: ADR-0014). */
+    ASSET
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AssetConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/AssetConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.config.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.Builder;
+
+/**
+ * The per-route {@code asset} terminal-action block (decision: ADR-0014).
+ * <p>
+ * An asset action serves static content through the gateway-owned
+ * {@code AssetResponseEnvelope} instead of proxying to an upstream. A route
+ * carries at most one terminal action: either {@code upstream} or {@code asset},
+ * never both. The {@link Source source} discriminator selects where the bytes come
+ * from:
+ * <ul>
+ *   <li>{@link Source#DIRECTORY} — a local directory / volume mount, served through
+ *       path confinement ({@code directory} names the root; no classpath-embedded
+ *       resources).</li>
+ *   <li>{@link Source#UPSTREAM} — a secondary origin reached through the same
+ *       SSRF-controlled data plane the proxy action uses ({@code upstream} names the
+ *       topology alias).</li>
+ * </ul>
+ * The configuration values ({@code directory} / {@code upstream}) are lowercase; the
+ * case-insensitive YAML binding maps them onto the {@link Source} constants.
+ *
+ * @param source    the source discriminator (mandatory)
+ * @param directory the local directory root, present for {@link Source#DIRECTORY}
+ * @param upstream  the topology alias of the secondary origin, present for
+ *                  {@link Source#UPSTREAM}
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@Builder
+public record AssetConfig(Source source, Optional<String> directory, Optional<String> upstream) {
+
+    /**
+     * The asset content source (decision: ADR-0014).
+     */
+    public enum Source {
+
+        /** A local directory / volume mount. */
+        DIRECTORY,
+        /** A secondary origin reached through the SSRF-controlled data plane. */
+        UPSTREAM
+    }
+
+    /**
+     * Canonical constructor requiring {@code source} and normalizing absent
+     * source-specific fields to {@link Optional#empty()}.
+     */
+    public AssetConfig {
+        Objects.requireNonNull(source, "source");
+        directory = Objects.requireNonNullElse(directory, Optional.empty());
+        upstream = Objects.requireNonNullElse(upstream, Optional.empty());
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedAsset.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedAsset.java
@@ -35,9 +35,13 @@ import lombok.Builder;
  * carried: {@link AssetConfig.Source#DIRECTORY} carries a {@code directory} root and
  * no upstream; {@link AssetConfig.Source#UPSTREAM} carries a boot-{@code resolved}
  * upstream (a topology alias decomposed exactly like the proxy action's upstream) and
- * no directory. The {@link AccessLevel access} level — inherited from the route's
- * resolving anchor (ADR-0013) — is the axis the gateway-owned response envelope keys
- * its caching on ({@link AccessLevel#AUTHENTICATED} forces {@code no-store}).
+ * no directory. The {@link AccessLevel access} level is the axis the gateway-owned
+ * response envelope keys its caching on ({@link AccessLevel#AUTHENTICATED} forces
+ * {@code no-store}); it is derived from the route's <em>effective</em> auth posture
+ * (ADR-0013), falling back to the resolving anchor's declared {@code access} only when
+ * the route is effectively unauthenticated — a route or endpoint that strengthens a
+ * {@code public}-access anchor's auth floor with its own {@code auth} block still
+ * resolves to {@link AccessLevel#AUTHENTICATED} here.
  *
  * @param source    the asset content source discriminator (mandatory)
  * @param access    the effective access level of the serving route (mandatory), the

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedAsset.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedAsset.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.config.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.Builder;
+
+/**
+ * The asset terminal action of a route, materialized once at boot (decision:
+ * ADR-0014).
+ * <p>
+ * A route resolves to exactly one terminal action — either an
+ * {@link ResolvedRoute#upstream() upstream} proxy target or this asset action,
+ * never both. This record is the boot-time <em>description</em> of an asset action;
+ * the live, framework-coupled source (a directory reader or an SSRF-guarded upstream
+ * fetcher) is built from it by the route-runtime assembler, so the agnostic
+ * {@code config.model} layer stays free of the {@code asset} runtime package.
+ * <p>
+ * The {@link AssetConfig.Source source} discriminator selects which resolved field is
+ * carried: {@link AssetConfig.Source#DIRECTORY} carries a {@code directory} root and
+ * no upstream; {@link AssetConfig.Source#UPSTREAM} carries a boot-{@code resolved}
+ * upstream (a topology alias decomposed exactly like the proxy action's upstream) and
+ * no directory. The {@link AccessLevel access} level — inherited from the route's
+ * resolving anchor (ADR-0013) — is the axis the gateway-owned response envelope keys
+ * its caching on ({@link AccessLevel#AUTHENTICATED} forces {@code no-store}).
+ *
+ * @param source    the asset content source discriminator (mandatory)
+ * @param access    the effective access level of the serving route (mandatory), the
+ *                  axis the response envelope keys governed caching on
+ * @param directory the configured directory root, present for
+ *                  {@link AssetConfig.Source#DIRECTORY} and empty otherwise
+ * @param upstream  the boot-resolved secondary origin, present for
+ *                  {@link AssetConfig.Source#UPSTREAM} and empty otherwise
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@Builder
+public record ResolvedAsset(AssetConfig.Source source, AccessLevel access, Optional<String> directory,
+Optional<ResolvedUpstream> upstream) {
+
+    /**
+     * Canonical constructor requiring {@code source} and {@code access}, normalizing
+     * absent optionals, and enforcing the source-to-field invariant — a
+     * {@link AssetConfig.Source#DIRECTORY} action carries a directory root and no
+     * upstream, an {@link AssetConfig.Source#UPSTREAM} action carries a resolved
+     * upstream and no directory.
+     */
+    public ResolvedAsset {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(access, "access");
+        directory = Objects.requireNonNullElse(directory, Optional.empty());
+        upstream = Objects.requireNonNullElse(upstream, Optional.empty());
+        switch (source) {
+            case DIRECTORY -> {
+                if (directory.isEmpty() || upstream.isPresent()) {
+                    throw new IllegalArgumentException(
+                            "DIRECTORY asset requires a directory root and no upstream target");
+                }
+            }
+            case UPSTREAM -> {
+                if (upstream.isEmpty() || directory.isPresent()) {
+                    throw new IllegalArgumentException(
+                            "UPSTREAM asset requires a resolved upstream and no directory root");
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a {@link AssetConfig.Source#DIRECTORY} asset action.
+     *
+     * @param root   the configured directory root (mandatory)
+     * @param access the serving route's effective access level (mandatory)
+     * @return the resolved directory asset action
+     */
+    public static ResolvedAsset directory(String root, AccessLevel access) {
+        return new ResolvedAsset(AssetConfig.Source.DIRECTORY, access, Optional.of(root), Optional.empty());
+    }
+
+    /**
+     * Creates a {@link AssetConfig.Source#UPSTREAM} asset action.
+     *
+     * @param upstream the boot-resolved secondary origin (mandatory)
+     * @param access   the serving route's effective access level (mandatory)
+     * @return the resolved upstream asset action
+     */
+    public static ResolvedAsset upstream(ResolvedUpstream upstream, AccessLevel access) {
+        return new ResolvedAsset(AssetConfig.Source.UPSTREAM, access, Optional.empty(), Optional.of(upstream));
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/ResolvedRoute.java
@@ -49,10 +49,18 @@ import lombok.Builder;
  *                               consumed), empty when none resolves
  * @param effectiveSecurityHeaders the materialized response-header posture carried
  *                               (not yet consumed), empty when none resolves
- * @param retryEnabled           the materialized upstream-retry toggle
+ * @param retryEnabled           the materialized upstream-retry toggle (meaningful
+ *                               only for a proxy route)
  * @param notModifiedEnabled     the materialized HTTP-304 not-modified toggle
- * @param upstream               the resolved upstream target for the route's
- *                               endpoint (mandatory)
+ *                               (meaningful only for a proxy route)
+ * @param upstream               the resolved upstream target for a proxy route,
+ *                               present when the route's terminal action is proxy and
+ *                               empty for an asset route
+ * @param asset                  the resolved asset terminal action, present when the
+ *                               route serves assets and empty for a proxy route; a
+ *                               route resolves to exactly one terminal action, so
+ *                               {@code upstream} and {@code asset} are mutually
+ *                               exclusive (ADR-0014)
  * @param effectiveForward       the materialized, deny-by-default {@code forward}
  *                               allowlist consumed by stage 5; an empty
  *                               {@link ForwardConfig} when the route declares none
@@ -63,13 +71,16 @@ import lombok.Builder;
 public record ResolvedRoute(String id, Protocol protocol, Optional<String> anchor, MatchConfig match,
 AuthConfig effectiveAuth, List<HttpMethod> effectiveAllowedMethods,
 Optional<SecurityFilterConfig> effectiveSecurityFilter, Optional<SecurityHeadersConfig> effectiveSecurityHeaders,
-boolean retryEnabled, boolean notModifiedEnabled, ResolvedUpstream upstream, ForwardConfig effectiveForward) {
+boolean retryEnabled, boolean notModifiedEnabled, Optional<ResolvedUpstream> upstream, Optional<ResolvedAsset> asset,
+ForwardConfig effectiveForward) {
 
     /**
      * Canonical constructor requiring the mandatory components, defensively copying
      * {@code effectiveAllowedMethods}, normalizing absent optionals, defaulting an
-     * absent {@code protocol} to {@link Protocol#HTTP}, and defaulting an absent
-     * {@code effectiveForward} to a deny-by-default empty {@link ForwardConfig}.
+     * absent {@code protocol} to {@link Protocol#HTTP}, defaulting an absent
+     * {@code effectiveForward} to a deny-by-default empty {@link ForwardConfig}, and
+     * enforcing the terminal-action invariant: exactly one of {@code upstream}
+     * (proxy) or {@code asset} resolves.
      */
     public ResolvedRoute {
         Objects.requireNonNull(id, "id");
@@ -80,7 +91,12 @@ boolean retryEnabled, boolean notModifiedEnabled, ResolvedUpstream upstream, For
         effectiveAllowedMethods = effectiveAllowedMethods == null ? List.of() : List.copyOf(effectiveAllowedMethods);
         effectiveSecurityFilter = Objects.requireNonNullElse(effectiveSecurityFilter, Optional.empty());
         effectiveSecurityHeaders = Objects.requireNonNullElse(effectiveSecurityHeaders, Optional.empty());
-        Objects.requireNonNull(upstream, "upstream");
+        upstream = Objects.requireNonNullElse(upstream, Optional.empty());
+        asset = Objects.requireNonNullElse(asset, Optional.empty());
+        if (upstream.isPresent() == asset.isPresent()) {
+            throw new IllegalArgumentException(
+                    "route '" + id + "' must resolve exactly one terminal action (upstream XOR asset)");
+        }
         effectiveForward = effectiveForward == null ? ForwardConfig.builder().build() : effectiveForward;
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/RouteConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/model/RouteConfig.java
@@ -40,6 +40,9 @@ import lombok.Builder;
  *                       global default applies
  * @param forward        the forwarding allowlist, empty when nothing is forwarded
  * @param upstream       the upstream target settings, empty when omitted
+ * @param asset          the asset terminal-action settings, empty when omitted; a
+ *                       route carries at most one terminal action, so {@code asset}
+ *                       and {@code upstream} are mutually exclusive (ADR-0014)
  * @param rateLimit      the reserved rate-limit block, empty when omitted
  * @author API Sheriff Team
  * @since 1.0
@@ -47,7 +50,7 @@ import lombok.Builder;
 @Builder
 public record RouteConfig(String id, Optional<Protocol> protocol, Optional<String> anchor, MatchConfig match,
 Optional<AuthConfig> auth, Optional<SecurityFilterConfig> securityFilter, Optional<ForwardConfig> forward,
-Optional<UpstreamConfig> upstream, Optional<RateLimitConfig> rateLimit) {
+Optional<UpstreamConfig> upstream, Optional<AssetConfig> asset, Optional<RateLimitConfig> rateLimit) {
 
     /**
      * Canonical constructor requiring {@code id} and {@code match} and normalizing
@@ -62,6 +65,7 @@ Optional<UpstreamConfig> upstream, Optional<RateLimitConfig> rateLimit) {
         securityFilter = Objects.requireNonNullElse(securityFilter, Optional.empty());
         forward = Objects.requireNonNullElse(forward, Optional.empty());
         upstream = Objects.requireNonNullElse(upstream, Optional.empty());
+        asset = Objects.requireNonNullElse(asset, Optional.empty());
         rateLimit = Objects.requireNonNullElse(rateLimit, Optional.empty());
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -32,7 +32,9 @@ import java.util.Set;
 import de.cuioss.sheriff.api.config.ConfigLogMessages;
 import de.cuioss.sheriff.api.config.RouteTableBuilder;
 import de.cuioss.sheriff.api.config.load.ConfigError;
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AnchorType;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
@@ -70,6 +72,12 @@ import de.cuioss.tools.logging.CuiLogger;
  * effective-auth completeness check — all collect into the same shared
  * {@code errors} list with file/pointer context and never fail fast.
  * <p>
+ * The fail-closed access→auth matrix (ADR-0013) adds per-anchor checks: a
+ * {@code type: bff} anchor requires {@code access: authenticated}; an
+ * {@code access: authenticated} anchor requires a non-{@code none} auth floor whose
+ * backing block is present; and an {@code access: public} anchor must not declare an
+ * auth block. These collect into the same shared list and never fail fast.
+ * <p>
  * Framework-agnostic (ADR-0005): the rule set is supplied at construction and the
  * validator carries no framework imports.
  *
@@ -93,6 +101,8 @@ public final class ConfigValidator {
     private static final int BROAD_PREFIX_IPV6 = 32;
     private static final String WILDCARD_ORIGIN = "*";
     private static final String REQUIRE_NONE = "none";
+    private static final String REQUIRE_BEARER = "bearer";
+    private static final String REQUIRE_SESSION = "session";
 
     private static final List<ValidationRule> DEFAULT_RULES = List.of(
             (gateway, endpoints, topology, errors) -> validateVersion(gateway, errors),
@@ -106,6 +116,7 @@ public final class ConfigValidator {
             (gateway, endpoints, topology, errors) -> validateRouteAuthResolvable(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateAnchorAuthFloor(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateEffectiveAuth(gateway, endpoints, errors),
+            (gateway, endpoints, topology, errors) -> validateAccessAuthMatrix(gateway, errors),
             (gateway, endpoints, topology, errors) -> validateMethodMembership(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateForwardedTrust(gateway, errors),
             (gateway, endpoints, topology, errors) -> validateCors(gateway, errors),
@@ -400,6 +411,61 @@ public final class ConfigValidator {
         }
         if (requires.contains("session") && gateway.oidc().isEmpty()) {
             errors.add(new ConfigError(GATEWAY_FILE, "/oidc", "effective auth 'session' requires an oidc block"));
+        }
+    }
+
+    /**
+     * Rule: the fail-closed access→auth matrix on every anchor (ADR-0013). A
+     * {@code type: bff} anchor must declare {@code access: authenticated}; an
+     * {@code access: authenticated} anchor must declare a non-{@code none} auth floor
+     * whose backing block is present (a {@code bearer} floor needs
+     * {@code token_validation} issuers, a {@code session} floor needs an {@code oidc}
+     * block); and an {@code access: public} anchor must not declare an auth block.
+     * Every violation collects into the shared list; the rule never fails fast.
+     */
+    private static void validateAccessAuthMatrix(GatewayConfig gateway, List<ConfigError> errors) {
+        for (AnchorConfig anchor : gateway.anchors().values()) {
+            String pointer = ANCHORS_POINTER + "/" + anchor.name();
+            if (anchor.type() == AnchorType.BFF && anchor.access() != AccessLevel.AUTHENTICATED) {
+                errors.add(new ConfigError(GATEWAY_FILE, pointer,
+                        "anchor '%s' is type 'bff' and must declare access: authenticated".formatted(anchor.name())));
+            }
+            if (anchor.access() == AccessLevel.PUBLIC) {
+                if (anchor.auth().isPresent()) {
+                    errors.add(new ConfigError(GATEWAY_FILE, pointer,
+                            "anchor '%s' is access: public and must not declare an auth block"
+                                    .formatted(anchor.name())));
+                }
+            } else {
+                validateAuthenticatedAnchorBacking(gateway, anchor, pointer, errors);
+            }
+        }
+    }
+
+    /**
+     * The {@code access: authenticated} half of the matrix (ADR-0013): the anchor must
+     * declare a non-{@code none} auth floor, and that floor's backing block must be
+     * present — a {@code bearer} floor needs {@code token_validation} issuers, a
+     * {@code session} floor needs an {@code oidc} block.
+     */
+    private static void validateAuthenticatedAnchorBacking(GatewayConfig gateway, AnchorConfig anchor, String pointer,
+            List<ConfigError> errors) {
+        String require = anchor.auth().map(AuthConfig::require).orElse(REQUIRE_NONE);
+        if (REQUIRE_NONE.equals(require)) {
+            errors.add(new ConfigError(GATEWAY_FILE, pointer,
+                    "anchor '%s' is access: authenticated but declares no non-'none' auth floor"
+                            .formatted(anchor.name())));
+            return;
+        }
+        if (REQUIRE_BEARER.equals(require)
+                && gateway.tokenValidation().map(tv -> tv.issuers().isEmpty()).orElse(true)) {
+            errors.add(new ConfigError(GATEWAY_FILE, pointer,
+                    "anchor '%s' access: authenticated bearer floor requires token_validation with at least one issuer"
+                            .formatted(anchor.name())));
+        }
+        if (REQUIRE_SESSION.equals(require) && gateway.oidc().isEmpty()) {
+            errors.add(new ConfigError(GATEWAY_FILE, pointer,
+                    "anchor '%s' access: authenticated session floor requires an oidc block".formatted(anchor.name())));
         }
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -488,9 +488,13 @@ public final class ConfigValidator {
                 boolean assetAnchor = anchor.map(a -> a.type() == AnchorType.ASSET).orElse(false);
                 boolean hasAsset = route.asset().isPresent();
                 if (assetAnchor && !hasAsset) {
-                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                    // assetAnchor is derived from anchor.map(...).orElse(false), so it can only be
+                    // true when the anchor is present; ifPresent makes that guarantee provable
+                    // rather than dereferencing the Optional with a bare get().
+                    anchor.ifPresent(resolvedAnchor -> errors.add(new ConfigError(endpointFile(endpoint),
+                            ENDPOINT_ROUTES_POINTER,
                             "route '%s' resolves to asset anchor '%s' but declares no asset terminal action"
-                                    .formatted(route.id(), anchor.get().name())));
+                                    .formatted(route.id(), resolvedAnchor.name()))));
                 } else if (!assetAnchor && hasAsset) {
                     String context = anchor
                             .map(a -> "its anchor '%s' is type '%s'".formatted(a.name(),

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -35,6 +35,7 @@ import de.cuioss.sheriff.api.config.load.ConfigError;
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
 import de.cuioss.sheriff.api.config.model.AnchorType;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
@@ -117,6 +118,7 @@ public final class ConfigValidator {
             (gateway, endpoints, topology, errors) -> validateAnchorAuthFloor(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateEffectiveAuth(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateAccessAuthMatrix(gateway, errors),
+            (gateway, endpoints, topology, errors) -> validateTerminalAction(gateway, endpoints, topology, errors),
             (gateway, endpoints, topology, errors) -> validateMethodMembership(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateForwardedTrust(gateway, errors),
             (gateway, endpoints, topology, errors) -> validateCors(gateway, errors),
@@ -466,6 +468,68 @@ public final class ConfigValidator {
         if (REQUIRE_SESSION.equals(require) && gateway.oidc().isEmpty()) {
             errors.add(new ConfigError(GATEWAY_FILE, pointer,
                     "anchor '%s' access: authenticated session floor requires an oidc block".formatted(anchor.name())));
+        }
+    }
+
+    /**
+     * Rule: the terminal-action / anchor-type consistency matrix (ADR-0014). A route whose
+     * resolving anchor is {@code type: asset} must declare an {@code asset} terminal action; a
+     * route under a {@code proxy} / {@code bff} anchor (or with no anchor) must not — its terminal
+     * action is the endpoint upstream. An {@code asset} block on a non-asset route is a boot
+     * failure. For a declared asset action, the source-specific field must be present and, for a
+     * {@code source: upstream} action, its topology alias must resolve. Every violation collects
+     * into the shared list; the rule never fails fast.
+     */
+    private static void validateTerminalAction(GatewayConfig gateway, List<EndpointConfig> endpoints,
+            ResolvedTopology topology, List<ConfigError> errors) {
+        for (EndpointConfig endpoint : endpoints) {
+            for (RouteConfig route : endpoint.routes()) {
+                Optional<AnchorConfig> anchor = resolveAnchor(gateway, endpoint, route);
+                boolean assetAnchor = anchor.map(a -> a.type() == AnchorType.ASSET).orElse(false);
+                boolean hasAsset = route.asset().isPresent();
+                if (assetAnchor && !hasAsset) {
+                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                            "route '%s' resolves to asset anchor '%s' but declares no asset terminal action"
+                                    .formatted(route.id(), anchor.get().name())));
+                } else if (!assetAnchor && hasAsset) {
+                    String context = anchor
+                            .map(a -> "its anchor '%s' is type '%s'".formatted(a.name(),
+                                    a.type().name().toLowerCase(Locale.ROOT)))
+                            .orElse("the route is unanchored");
+                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                            "route '%s' declares an asset terminal action but %s; an asset action requires an asset-type anchor"
+                                    .formatted(route.id(), context)));
+                }
+                route.asset().ifPresent(asset -> validateAssetSource(endpoint, route, asset, topology, errors));
+            }
+        }
+    }
+
+    /**
+     * The source-field half of the terminal-action rule (ADR-0014): a {@code source: directory}
+     * action requires a {@code directory} root; a {@code source: upstream} action requires an
+     * {@code upstream} topology alias that resolves.
+     */
+    private static void validateAssetSource(EndpointConfig endpoint, RouteConfig route, AssetConfig asset,
+            ResolvedTopology topology, List<ConfigError> errors) {
+        switch (asset.source()) {
+            case DIRECTORY -> {
+                if (asset.directory().isEmpty()) {
+                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                            "asset route '%s' declares source: directory but no directory root".formatted(route.id())));
+                }
+            }
+            case UPSTREAM -> {
+                Optional<String> alias = asset.upstream();
+                if (alias.isEmpty()) {
+                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                            "asset route '%s' declares source: upstream but no upstream alias".formatted(route.id())));
+                } else if (topology.lookup(alias.get()).isEmpty()) {
+                    errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                            "asset route '%s' upstream alias '%s' does not resolve in the topology"
+                                    .formatted(route.id(), alias.get())));
+                }
+            }
         }
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
@@ -28,6 +28,9 @@ import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 
 
+import de.cuioss.sheriff.api.asset.AssetSource;
+import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
+import de.cuioss.sheriff.api.asset.UpstreamAssetSource;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.events.EventType;
@@ -38,6 +41,7 @@ import io.smallrye.faulttolerance.api.Guard;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.streams.ReadStream;
@@ -132,10 +136,73 @@ public final class DispatchStage {
         AtomicBoolean bodyStreamSubscribed = new AtomicBoolean();
         StreamAwareRetryGate retryGate = new StreamAwareRetryGate(route.isRetryEnabled());
         io.vertx.core.http.HttpMethod upstreamMethod = io.vertx.core.http.HttpMethod.valueOf(method.name());
-        return guardedDispatch(route.getResilienceGuard(), retryGate, method, bytesSent::get,
+        Guard guard = route.getResilienceGuard()
+                .orElseThrow(() -> new IllegalStateException("proxy dispatch requires a resilience guard"));
+        return guardedDispatch(guard, retryGate, method, bytesSent::get,
                 bodyStreamSubscribed::get,
                 () -> awaitDispatch(route, upstreamMethod, requestUri, forwardHeaders, requestBody, bytesSent,
                         bodyStreamSubscribed));
+    }
+
+    /**
+     * Serves an asset route's terminal action, adapting the source-specific served response
+     * to the gateway-uniform {@link AssetDispatch}.
+     * <p>
+     * The two sealed {@link AssetSource} kinds each apply their own gateway-owned
+     * {@code PathConfinement} and {@code AssetResponseEnvelope} governance before returning,
+     * so this method only routes to the matching source and normalizes the buffered result.
+     * The auth-before-source-resolution ordering is guaranteed by the caller: the edge
+     * pipeline authenticates and authorizes the request (stage 4) before this method is
+     * reached, so an unauthorized request never triggers a directory read or an upstream fetch.
+     *
+     * @param source  the route's live asset source (directory or upstream)
+     * @param method  the request verb; only {@code GET} and {@code HEAD} are served
+     * @param subPath the request path remainder after the route prefix is stripped
+     * @return the gateway-governed, buffered asset response
+     */
+    public static AssetDispatch serveAsset(AssetSource source, HttpMethod method, String subPath) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(subPath, "subPath");
+        return switch (source) {
+            case DirectoryAssetSource directory -> {
+                DirectoryAssetSource.Served served = directory.serve(method, subPath);
+                yield new AssetDispatch(served.status(), served.headers(), served.body());
+            }
+            case UpstreamAssetSource upstream -> {
+                UpstreamAssetSource.Served served = upstream.serve(method, subPath);
+                yield new AssetDispatch(served.status(), served.headers(), served.body());
+            }
+        };
+    }
+
+    /**
+     * A gateway-governed, fully-buffered asset response — the source-agnostic result of the
+     * asset terminal action, ready for the edge to write back verbatim.
+     *
+     * @param status  the HTTP status code
+     * @param headers the gateway-governed response headers
+     * @param body    the response body; empty for {@code HEAD} and every non-200 outcome
+     * @author API Sheriff Team
+     * @since 1.0
+     */
+    public record AssetDispatch(int status, Map<String, String> headers, byte[] body) {
+
+        /**
+         * Canonical constructor defensively copying the headers and body.
+         */
+        public AssetDispatch {
+            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+            body = Objects.requireNonNull(body, "body").clone();
+        }
+
+        /**
+         * @return a defensive copy of the response body
+         */
+        @Override
+        public byte[] body() {
+            return body.clone();
+        }
     }
 
     /**
@@ -200,14 +267,17 @@ public final class DispatchStage {
     private HttpClientResponse awaitDispatch(RouteRuntime route, io.vertx.core.http.HttpMethod method,
             String requestUri, Map<String, String> forwardHeaders, ReadStream<Buffer> requestBody,
             AtomicLong bytesSent, AtomicBoolean bodyStreamSubscribed) throws Exception {
-        ResolvedUpstream upstream = route.getUpstream();
+        ResolvedUpstream upstream = route.getUpstream()
+                .orElseThrow(() -> new IllegalStateException("proxy dispatch requires a resolved upstream"));
+        HttpClient httpClient = route.getHttpClient()
+                .orElseThrow(() -> new IllegalStateException("proxy dispatch requires an upstream client"));
         RequestOptions options = new RequestOptions()
                 .setMethod(method)
                 .setHost(upstream.host())
                 .setPort(upstream.port())
                 .setSsl("https".equalsIgnoreCase(upstream.scheme()))
                 .setURI(requestUri);
-        Future<HttpClientResponse> response = route.getHttpClient().request(options)
+        Future<HttpClientResponse> response = httpClient.request(options)
                 .compose(request -> {
                     forwardHeaders.forEach(request::putHeader);
                     // The one-shot inbound body stream is subscribed the instant it is handed to

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
@@ -29,8 +29,6 @@ import java.util.function.LongSupplier;
 
 
 import de.cuioss.sheriff.api.asset.AssetSource;
-import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
-import de.cuioss.sheriff.api.asset.UpstreamAssetSource;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.events.EventType;
@@ -145,64 +143,25 @@ public final class DispatchStage {
     }
 
     /**
-     * Serves an asset route's terminal action, adapting the source-specific served response
-     * to the gateway-uniform {@link AssetDispatch}.
+     * Serves an asset route's terminal action.
      * <p>
-     * The two sealed {@link AssetSource} kinds each apply their own gateway-owned
-     * {@code PathConfinement} and {@code AssetResponseEnvelope} governance before returning,
-     * so this method only routes to the matching source and normalizes the buffered result.
-     * The auth-before-source-resolution ordering is guaranteed by the caller: the edge
-     * pipeline authenticates and authorizes the request (stage 4) before this method is
-     * reached, so an unauthorized request never triggers a directory read or an upstream fetch.
+     * The {@link AssetSource} implementation applies its own gateway-owned
+     * {@code PathConfinement} and {@code AssetResponseEnvelope} governance before returning, so
+     * this method only forwards to the source. The auth-before-source-resolution ordering is
+     * guaranteed by the caller: the edge pipeline authenticates and authorizes the request
+     * (stage 4) before this method is reached, so an unauthorized request never triggers a
+     * directory read or an upstream fetch.
      *
      * @param source  the route's live asset source (directory or upstream)
      * @param method  the request verb; only {@code GET} and {@code HEAD} are served
      * @param subPath the request path remainder after the route prefix is stripped
      * @return the gateway-governed, buffered asset response
      */
-    public static AssetDispatch serveAsset(AssetSource source, HttpMethod method, String subPath) {
+    public static AssetSource.Served serveAsset(AssetSource source, HttpMethod method, String subPath) {
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(method, "method");
         Objects.requireNonNull(subPath, "subPath");
-        return switch (source) {
-            case DirectoryAssetSource directory -> {
-                DirectoryAssetSource.Served served = directory.serve(method, subPath);
-                yield new AssetDispatch(served.status(), served.headers(), served.body());
-            }
-            case UpstreamAssetSource upstream -> {
-                UpstreamAssetSource.Served served = upstream.serve(method, subPath);
-                yield new AssetDispatch(served.status(), served.headers(), served.body());
-            }
-        };
-    }
-
-    /**
-     * A gateway-governed, fully-buffered asset response — the source-agnostic result of the
-     * asset terminal action, ready for the edge to write back verbatim.
-     *
-     * @param status  the HTTP status code
-     * @param headers the gateway-governed response headers
-     * @param body    the response body; empty for {@code HEAD} and every non-200 outcome
-     * @author API Sheriff Team
-     * @since 1.0
-     */
-    public record AssetDispatch(int status, Map<String, String> headers, byte[] body) {
-
-        /**
-         * Canonical constructor defensively copying the headers and body.
-         */
-        public AssetDispatch {
-            headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
-            body = Objects.requireNonNull(body, "body").clone();
-        }
-
-        /**
-         * @return a defensive copy of the response body
-         */
-        @Override
-        public byte[] body() {
-            return body.clone();
-        }
+        return source.serve(method, subPath);
     }
 
     /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
@@ -442,11 +442,11 @@ public class GatewayEdgeRoute {
     private void serveAsset(RoutingContext ctx, PipelineRequest request, RouteRuntime route, String remainder) {
         AssetSource source = route.getAssetSource()
                 .orElseThrow(() -> new IllegalStateException("asset dispatch requires an asset source"));
-        DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, request.method(), remainder);
+        AssetSource.Served served = DispatchStage.serveAsset(source, request.method(), remainder);
         writeBufferedAsset(ctx, request, served);
     }
 
-    private void writeBufferedAsset(RoutingContext ctx, PipelineRequest request, DispatchStage.AssetDispatch served) {
+    private void writeBufferedAsset(RoutingContext ctx, PipelineRequest request, AssetSource.Served served) {
         Map<String, String> stageHeaders = Map.copyOf(request.responseHeaders());
         ctx.vertx().runOnContext(v -> {
             HttpServerResponse response = ctx.response();

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.api.edge;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
@@ -38,11 +39,16 @@ import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.config.SecurityConfigurationBuilder;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.sheriff.api.ApiSheriffLogMessages;
+import de.cuioss.sheriff.api.asset.AssetSource;
+import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
+import de.cuioss.sheriff.api.asset.UpstreamAssetSource;
 import de.cuioss.sheriff.api.auth.AuthenticationStage;
 import de.cuioss.sheriff.api.auth.GatewayValidator;
 import de.cuioss.sheriff.api.config.model.ForwardedConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
+import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteTable;
 import de.cuioss.sheriff.api.config.model.SecurityFilterConfig;
 import de.cuioss.sheriff.api.events.EventCategory;
@@ -70,6 +76,7 @@ import io.quarkus.virtual.threads.VirtualThreads;
 import io.smallrye.faulttolerance.api.Guard;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -207,7 +214,8 @@ public class GatewayEdgeRoute {
         this.routes = assembler.assemble(routeTable,
                 GatewayEdgeRoute::securityConfigurationFor,
                 target -> vertx.createHttpClient(),
-                this::guardFor);
+                this::guardFor,
+                GatewayEdgeRoute::assetSourceFor);
         LOGGER.info(ApiSheriffLogMessages.INFO.ROUTE_TABLE_COMPILED, routes.size());
 
         this.securityHeadersStage = new SecurityHeadersStage(gatewayConfig.securityHeaders());
@@ -395,8 +403,17 @@ public class GatewayEdgeRoute {
         String prefix = stripTrailingSlash(route.getMatcher().pathPrefix());
         String canonical = requireCanonicalPath(request);
         String remainder = canonical.length() >= prefix.length() ? canonical.substring(prefix.length()) : "";
+        // An asset route serves its terminal action directly — the buffered, gateway-governed
+        // asset response — instead of streaming to an upstream. Auth (stage 4) has already run,
+        // so an unauthorized request never reaches the source (auth-before-source, ADR-0014).
+        if (route.getAssetSource().isPresent()) {
+            serveAsset(ctx, request, route, remainder);
+            return;
+        }
         String query = renderQuery(forward.query());
-        String uri = DispatchStage.upstreamRequestUri(route.getUpstream(), remainder, query);
+        ResolvedUpstream upstreamTarget = route.getUpstream()
+                .orElseThrow(() -> new IllegalStateException("proxy dispatch requires a resolved upstream"));
+        String uri = DispatchStage.upstreamRequestUri(upstreamTarget, remainder, query);
         long cap = route.getSecurityConfiguration().map(SecurityConfiguration::maxBodySize).orElse(defaultMaxBodySize);
 
         DispatchStage dispatchStage = new DispatchStage(cap, upstreamFailureMapper);
@@ -413,6 +430,37 @@ public class GatewayEdgeRoute {
         ctx.vertx().runOnContext(v ->
                 responseStage.relay(upstream, ctx.response(), route.isNotModifiedEnabled(), request.responseHeaders())
                         .onFailure(failure -> failRelay(ctx, failure)));
+    }
+
+    /**
+     * Serves an asset route's terminal action: resolves the confined asset through the route's
+     * {@link AssetSource} (behind the shared {@code PathConfinement} and gateway-owned
+     * {@code AssetResponseEnvelope}) and writes the buffered, governed response back to the
+     * client. GET/HEAD-only enforcement and header governance live in the source and envelope;
+     * this method only routes and writes.
+     */
+    private void serveAsset(RoutingContext ctx, PipelineRequest request, RouteRuntime route, String remainder) {
+        AssetSource source = route.getAssetSource()
+                .orElseThrow(() -> new IllegalStateException("asset dispatch requires an asset source"));
+        DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, request.method(), remainder);
+        writeBufferedAsset(ctx, request, served);
+    }
+
+    private void writeBufferedAsset(RoutingContext ctx, PipelineRequest request, DispatchStage.AssetDispatch served) {
+        Map<String, String> stageHeaders = Map.copyOf(request.responseHeaders());
+        ctx.vertx().runOnContext(v -> {
+            HttpServerResponse response = ctx.response();
+            if (response.ended()) {
+                return;
+            }
+            response.setStatusCode(served.status());
+            // The stage-0 security headers (HSTS, frame options, …) apply to every response; the
+            // envelope's governed headers (fixed Content-Type, nosniff, no-store) are written last
+            // so they win any name collision.
+            stageHeaders.forEach(response::putHeader);
+            served.headers().forEach(response::putHeader);
+            response.end(Buffer.buffer(served.body()));
+        });
     }
 
     private void failRelay(RoutingContext ctx, Throwable failure) {
@@ -568,6 +616,26 @@ public class GatewayEdgeRoute {
 
     private static String stripTrailingSlash(String value) {
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    /**
+     * Builds the live {@link AssetSource} for an asset route's resolved terminal action: a
+     * {@link DirectoryAssetSource} rooted at the configured directory for a {@code directory}
+     * source, or an {@link UpstreamAssetSource} over the boot-resolved secondary origin for an
+     * {@code upstream} source. Both apply the gateway's confinement and response envelope; the
+     * upstream source rides its own SSRF-guarded fetch seam (ADR-0014), not the proxy data plane.
+     */
+    private static AssetSource assetSourceFor(ResolvedAsset asset) {
+        return switch (asset.source()) {
+            case DIRECTORY -> new DirectoryAssetSource(
+                    Path.of(asset.directory().orElseThrow(
+                            () -> new IllegalStateException("directory asset source requires a directory root"))),
+                    asset.access());
+            case UPSTREAM -> new UpstreamAssetSource(
+                    asset.upstream().orElseThrow(
+                            () -> new IllegalStateException("upstream asset source requires a resolved upstream")),
+                    asset.access());
+        };
     }
 
     /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssembler.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssembler.java
@@ -26,7 +26,9 @@ import java.util.Set;
 
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.sheriff.api.asset.AssetSource;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
 import de.cuioss.sheriff.api.config.model.ResolvedRoute;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteTable;
@@ -82,15 +84,19 @@ public final class RouteRuntimeAssembler {
      * @param securityConfigFactory builds one {@link SecurityConfiguration} per security-filter shape
      * @param clientFactory         builds one {@link HttpClient} per upstream target tuple
      * @param guardFactory          builds one {@link Guard} per resilience shape
+     * @param assetSourceFactory    builds the live {@link AssetSource} for an asset route's
+     *                              terminal action
      * @return the assembled runtimes, in the table's longest-prefix-first order
      * @throws GatewayException when a route requests {@code session} auth or an unsupported protocol
      */
     public List<RouteRuntime> assemble(RouteTable table, SecurityConfigurationFactory securityConfigFactory,
-            UpstreamClientFactory clientFactory, ResilienceGuardFactory guardFactory) {
+            UpstreamClientFactory clientFactory, ResilienceGuardFactory guardFactory,
+            AssetSourceFactory assetSourceFactory) {
         Objects.requireNonNull(table, "table");
         Objects.requireNonNull(securityConfigFactory, "securityConfigFactory");
         Objects.requireNonNull(clientFactory, "clientFactory");
         Objects.requireNonNull(guardFactory, "guardFactory");
+        Objects.requireNonNull(assetSourceFactory, "assetSourceFactory");
 
         Map<SecurityFilterConfig, SecurityConfiguration> securityCache = new HashMap<>();
         Map<UpstreamTarget, HttpClient> clientCache = new HashMap<>();
@@ -104,13 +110,7 @@ public final class RouteRuntimeAssembler {
             Optional<SecurityConfiguration> securityConfiguration = route.effectiveSecurityFilter()
                     .map(filter -> securityCache.computeIfAbsent(filter, securityConfigFactory::create));
 
-            UpstreamTarget target = UpstreamTarget.of(route.upstream());
-            HttpClient client = clientCache.computeIfAbsent(target, clientFactory::create);
-
-            ResilienceShape shape = new ResilienceShape(target, route.retryEnabled());
-            Guard guard = guardCache.computeIfAbsent(shape, guardFactory::create);
-
-            runtimes.add(RouteRuntime.builder()
+            RouteRuntime.RouteRuntimeBuilder runtime = RouteRuntime.builder()
                     .id(route.id())
                     .protocol(route.protocol())
                     .matcher(RouteMatcher.from(route.match()))
@@ -124,11 +124,27 @@ public final class RouteRuntimeAssembler {
                     .effectiveAllowedPaths(route.effectiveSecurityFilter()
                             .map(SecurityFilterConfig::allowedPaths).orElse(List.of()))
                     .retryEnabled(route.retryEnabled())
-                    .notModifiedEnabled(route.notModifiedEnabled())
-                    .upstream(route.upstream())
-                    .httpClient(client)
-                    .resilienceGuard(guard)
-                    .build());
+                    .notModifiedEnabled(route.notModifiedEnabled());
+
+            // A route resolves exactly one terminal action (ADR-0014). An asset route builds its
+            // live source and skips the Vert.x client / resilience-guard dedup entirely — its
+            // egress rides the source's own SSRF-controlled fetch seam, not the proxy data plane.
+            if (route.asset().isPresent()) {
+                runtime.assetSource(Optional.of(assetSourceFactory.create(route.asset().get())));
+            } else {
+                ResolvedUpstream resolvedUpstream = route.upstream().orElseThrow(() -> new GatewayException(
+                        EventType.CONFIG_INVALID,
+                        "Route '" + route.id() + "' resolves no terminal action (neither upstream nor asset)"));
+                UpstreamTarget target = UpstreamTarget.of(resolvedUpstream);
+                HttpClient client = clientCache.computeIfAbsent(target, clientFactory::create);
+                ResilienceShape shape = new ResilienceShape(target, route.retryEnabled());
+                Guard guard = guardCache.computeIfAbsent(shape, guardFactory::create);
+                runtime.upstream(Optional.of(resolvedUpstream))
+                        .httpClient(Optional.of(client))
+                        .resilienceGuard(Optional.of(guard));
+            }
+
+            runtimes.add(runtime.build());
         }
         return List.copyOf(runtimes);
     }
@@ -210,5 +226,20 @@ public final class RouteRuntimeAssembler {
          * @return the built guard
          */
         Guard create(ResilienceShape shape);
+    }
+
+    /**
+     * Factory building the live {@link AssetSource} for an asset route's resolved terminal
+     * action — a directory reader for a {@code directory} source, an SSRF-guarded upstream
+     * fetcher for an {@code upstream} source.
+     */
+    @FunctionalInterface
+    public interface AssetSourceFactory {
+
+        /**
+         * @param asset the resolved asset terminal action
+         * @return the built asset source
+         */
+        AssetSource create(ResolvedAsset asset);
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigModelReflection.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigModelReflection.java
@@ -18,6 +18,7 @@ package de.cuioss.sheriff.api.quarkus;
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
 import de.cuioss.sheriff.api.config.model.AnchorType;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
@@ -87,6 +88,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
         UpstreamConfig.Retry.class,
         UpstreamConfig.NotModified.class,
         UpstreamConfig.CircuitBreaker.class,
+        AssetConfig.class,
+        AssetConfig.Source.class,
         RateLimitConfig.class,
         HttpMethod.class,
         Protocol.class,

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigModelReflection.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigModelReflection.java
@@ -15,7 +15,9 @@
  */
 package de.cuioss.sheriff.api.quarkus;
 
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AnchorType;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
@@ -87,7 +89,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
         UpstreamConfig.CircuitBreaker.class,
         RateLimitConfig.class,
         HttpMethod.class,
-        Protocol.class
+        Protocol.class,
+        AnchorType.class,
+        AccessLevel.class
 })
 public final class ConfigModelReflection {
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/quarkus/ConfigProducer.java
@@ -16,8 +16,10 @@
 package de.cuioss.sheriff.api.quarkus;
 
 import java.nio.file.Path;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 import de.cuioss.sheriff.api.config.ConfigLogMessages;
@@ -26,10 +28,12 @@ import de.cuioss.sheriff.api.config.load.ConfigError;
 import de.cuioss.sheriff.api.config.load.ConfigLoadException;
 import de.cuioss.sheriff.api.config.load.ConfigLoader;
 import de.cuioss.sheriff.api.config.load.EnvSecretResolver;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.Metadata;
 import de.cuioss.sheriff.api.config.model.ResolvedTopology;
+import de.cuioss.sheriff.api.config.model.RouteConfig;
 import de.cuioss.sheriff.api.config.model.RouteTable;
 import de.cuioss.sheriff.api.config.model.TlsConfig;
 import de.cuioss.sheriff.api.config.topology.TopologyResolver;
@@ -127,8 +131,8 @@ public class ConfigProducer {
             EnvSecretResolver resolver = new EnvSecretResolver();
             ConfigLoader.LoadedConfig loaded = new ConfigLoader(directory, resolver).load();
             List<EndpointConfig> enabled = loaded.endpoints().stream().filter(EndpointConfig::enabled).toList();
-            ResolvedTopology topology = new TopologyResolver(resolver).resolve(directory.resolve(TOPOLOGY_FILE), enabled,
-                    loaded.gateway().tls().map(TlsConfig::passthroughSni).map(Map::values).orElse(List.of()));
+            ResolvedTopology topology = new TopologyResolver(resolver)
+                    .resolve(directory.resolve(TOPOLOGY_FILE), enabled, additionalTopologyAliases(loaded, enabled));
             List<ConfigError> violations = new ConfigValidator().validate(loaded.gateway(), enabled, topology);
             if (!violations.isEmpty()) {
                 abort(violations);
@@ -143,6 +147,35 @@ public class ConfigProducer {
             LOGGER.error(e, ConfigLogMessages.ERROR.CONFIG_STARTUP_ABORTED, e.getMessage());
             throw new IllegalStateException("Refusing to start — configuration is invalid", e);
         }
+    }
+
+    /**
+     * The topology aliases that must resolve independently of any enabled endpoint's
+     * {@code base_url}: the {@code tls.passthrough_sni} relay targets and every
+     * {@code source: upstream} asset route's upstream alias (ADR-0014). An asset route's
+     * upstream is a per-route topology reference that the proxy-oriented {@code base_url}
+     * collection in {@link TopologyResolver} does not see, so it is gathered here and
+     * passed alongside the passthrough targets, otherwise the {@link ConfigValidator} and
+     * {@link RouteTableBuilder} asset-source lookup would reject a well-formed
+     * {@code /assets/cdn}-style upstream asset route as unresolved.
+     *
+     * @param loaded  the loaded gateway configuration (source of the passthrough targets)
+     * @param enabled the enabled endpoints whose asset routes are scanned for upstream aliases
+     * @return the deduplicated, insertion-ordered set of additional aliases to resolve
+     */
+    private static Set<String> additionalTopologyAliases(ConfigLoader.LoadedConfig loaded,
+            List<EndpointConfig> enabled) {
+        Set<String> aliases = new LinkedHashSet<>(
+                loaded.gateway().tls().map(TlsConfig::passthroughSni).map(Map::values).orElse(List.of()));
+        for (EndpointConfig endpoint : enabled) {
+            for (RouteConfig route : endpoint.routes()) {
+                route.asset()
+                        .filter(asset -> asset.source() == AssetConfig.Source.UPSTREAM)
+                        .flatMap(AssetConfig::upstream)
+                        .ifPresent(aliases::add);
+            }
+        }
+        return aliases;
     }
 
     private static void abort(List<ConfigError> violations) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/routing/RouteRuntime.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/routing/RouteRuntime.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.sheriff.api.asset.AssetSource;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
@@ -96,18 +97,38 @@ public final class RouteRuntime {
     @Builder.Default
     private final List<String> effectiveAllowedPaths = List.of();
 
-    /** The materialized upstream-retry toggle. */
+    /** The materialized upstream-retry toggle (meaningful only for a proxy route). */
     private final boolean retryEnabled;
 
-    /** The materialized HTTP-304 not-modified toggle. */
+    /** The materialized HTTP-304 not-modified toggle (meaningful only for a proxy route). */
     private final boolean notModifiedEnabled;
 
-    /** The resolved upstream target. */
-    private final ResolvedUpstream upstream;
+    /**
+     * The resolved upstream target for a proxy route; empty for an asset route. A route
+     * carries exactly one terminal action — a proxy {@link #upstream} or an
+     * {@link #assetSource} — never both (ADR-0014).
+     */
+    @Builder.Default
+    private final Optional<ResolvedUpstream> upstream = Optional.empty();
 
-    /** The shared Vert.x client for this route's upstream tuple (one instance per tuple). */
-    private final HttpClient httpClient;
+    /**
+     * The shared Vert.x client for a proxy route's upstream tuple (one instance per
+     * tuple); empty for an asset route.
+     */
+    @Builder.Default
+    private final Optional<HttpClient> httpClient = Optional.empty();
 
-    /** The shared SmallRye Fault-Tolerance guard for this route's resilience shape. */
-    private final Guard resilienceGuard;
+    /**
+     * The shared SmallRye Fault-Tolerance guard for a proxy route's resilience shape;
+     * empty for an asset route.
+     */
+    @Builder.Default
+    private final Optional<Guard> resilienceGuard = Optional.empty();
+
+    /**
+     * The live asset source serving an asset route's terminal action (a directory
+     * reader or an SSRF-guarded upstream fetcher); empty for a proxy route.
+     */
+    @Builder.Default
+    private final Optional<AssetSource> assetSource = Optional.empty();
 }

--- a/api-sheriff/src/main/resources/schema/endpoint.schema.json
+++ b/api-sheriff/src/main/resources/schema/endpoint.schema.json
@@ -174,6 +174,27 @@
                   }
                 }
               },
+              "asset": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source"],
+                "description": "Optional asset terminal action (ADR-0014). Serves static content through the gateway-owned response envelope instead of proxying. A route carries at most one terminal action, so 'asset' and 'upstream' are mutually exclusive (enforced in code).",
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "enum": ["directory", "upstream"],
+                    "description": "The asset content source discriminator: a local directory / volume mount, or a secondary origin reached through the SSRF-controlled data plane."
+                  },
+                  "directory": {
+                    "type": "string",
+                    "description": "The local directory root for source: directory. Served through path confinement; no classpath-embedded resources."
+                  },
+                  "upstream": {
+                    "type": "string",
+                    "description": "The topology alias of the secondary origin for source: upstream."
+                  }
+                }
+              },
               "rate_limit": {
                 "type": "object",
                 "additionalProperties": false,

--- a/api-sheriff/src/main/resources/schema/gateway.schema.json
+++ b/api-sheriff/src/main/resources/schema/gateway.schema.json
@@ -137,15 +137,17 @@
     },
     "anchors": {
       "type": "object",
-      "description": "Optional named, namespace-scoped policy anchors. Each anchor OWNS a disjoint path namespace (path_prefix) and carries the policy floor for every route inside it. Anchor prefixes must be pairwise disjoint (enforced in code).",
+      "description": "Optional named, namespace-scoped policy anchors. Each anchor OWNS a disjoint path namespace (path_prefix) and carries the policy floor for every route inside it. Every anchor declares two required classification axes: 'type' (proxy/bff/asset; the former 'passthrough' value renamed to 'proxy') and 'access' (public/authenticated). Anchor prefixes must be pairwise disjoint (enforced in code).",
       "additionalProperties": false,
       "patternProperties": {
         "^[a-z][a-z0-9_-]*$": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["path_prefix"],
+          "required": ["path_prefix", "type", "access"],
           "properties": {
             "path_prefix": { "type": "string" },
+            "type": { "type": "string", "enum": ["proxy", "bff", "asset"] },
+            "access": { "type": "string", "enum": ["public", "authenticated"] },
             "auth": { "$ref": "#/$defs/auth" },
             "security_filter": { "$ref": "#/$defs/securityFilter" },
             "security_headers": { "$ref": "#/$defs/securityHeaders" },

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelopeTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 
@@ -148,7 +149,7 @@ class AssetResponseEnvelopeTest {
                     "app.js", AccessLevel.PUBLIC, sourceHeaders);
 
             assertAll(
-                    () -> assertFalse(governed.keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Set-Cookie")),
+                    () -> assertFalse(governed.keySet().stream().anyMatch(k -> "Set-Cookie".equalsIgnoreCase(k)),
                             "an asset action must never establish a session"),
                     () -> assertEquals("kept", governed.get("X-Custom"),
                             "unrelated source headers pass through"));

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetResponseEnvelopeTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link AssetResponseEnvelope}: the gateway-owned response governance that
+ * a backing source can never override — the fixed content-type map, {@code nosniff},
+ * forced {@code no-store} for authenticated access, {@code Set-Cookie} stripping, and
+ * {@code GET}/{@code HEAD}-only serving — plus the sealed {@link AssetSource} seam
+ * that carries the auth-before-source-resolution ordering contract.
+ */
+class AssetResponseEnvelopeTest {
+
+    @Nested
+    @DisplayName("The fixed content-type map")
+    class ContentTypeMap {
+
+        static Stream<Arguments> knownExtensions() {
+            return Stream.of(
+                    Arguments.of("index.html", "text/html; charset=utf-8"),
+                    Arguments.of("app.css", "text/css; charset=utf-8"),
+                    Arguments.of("bundle.js", "text/javascript; charset=utf-8"),
+                    Arguments.of("data.json", "application/json"),
+                    Arguments.of("logo.svg", "image/svg+xml"),
+                    Arguments.of("photo.png", "image/png"),
+                    Arguments.of("photo.JPG", "image/jpeg"),
+                    Arguments.of("font.woff2", "font/woff2"),
+                    Arguments.of("module.wasm", "application/wasm"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("knownExtensions")
+        @DisplayName("Should resolve the gateway content type from the extension, case-insensitively")
+        void shouldResolveKnownExtension(String filename, String expected) {
+            assertEquals(expected, AssetResponseEnvelope.contentTypeFor(filename),
+                    () -> "unexpected content type for " + filename);
+        }
+
+        @Test
+        @DisplayName("Should fall back to application/octet-stream for unknown or absent extensions")
+        void shouldFallBackForUnknownExtension() {
+            assertAll(
+                    () -> assertEquals(AssetResponseEnvelope.DEFAULT_CONTENT_TYPE,
+                            AssetResponseEnvelope.contentTypeFor("archive.xyz")),
+                    () -> assertEquals(AssetResponseEnvelope.DEFAULT_CONTENT_TYPE,
+                            AssetResponseEnvelope.contentTypeFor("README")),
+                    () -> assertEquals(AssetResponseEnvelope.DEFAULT_CONTENT_TYPE,
+                            AssetResponseEnvelope.contentTypeFor("trailingdot.")));
+        }
+
+        @Test
+        @DisplayName("Should resolve the extension from the last path segment, ignoring dots in directories")
+        void shouldResolveFromLastSegment() {
+            assertEquals("text/css; charset=utf-8",
+                    AssetResponseEnvelope.contentTypeFor("v1.2/assets/app.css"));
+        }
+    }
+
+    @Nested
+    @DisplayName("The governed response headers")
+    class GovernedHeaders {
+
+        @Test
+        @DisplayName("Should always set X-Content-Type-Options: nosniff and override the content type")
+        void shouldSetNosniffAndOverrideContentType() {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put("Content-Type", "text/plain");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "index.html", AccessLevel.PUBLIC, sourceHeaders);
+
+            assertAll(
+                    () -> assertEquals(AssetResponseEnvelope.NOSNIFF,
+                            governed.get(AssetResponseEnvelope.CONTENT_TYPE_OPTIONS)),
+                    () -> assertEquals("text/html; charset=utf-8",
+                            governed.get(AssetResponseEnvelope.CONTENT_TYPE),
+                            "the gateway content type must override the source's claimed type"));
+        }
+
+        @Test
+        @DisplayName("Should force Cache-Control: no-store for authenticated access regardless of source")
+        void shouldForceNoStoreForAuthenticatedAccess() {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put("Cache-Control", "public, max-age=31536000");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "secret.json", AccessLevel.AUTHENTICATED, sourceHeaders);
+
+            assertEquals(AssetResponseEnvelope.NO_STORE, governed.get(AssetResponseEnvelope.CACHE_CONTROL),
+                    "an authenticated asset must never be cacheable, overriding the source's Cache-Control");
+        }
+
+        @Test
+        @DisplayName("Should preserve a public asset's source Cache-Control (no forced no-store)")
+        void shouldNotForceNoStoreForPublicAccess() {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put("Cache-Control", "public, max-age=600");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "logo.png", AccessLevel.PUBLIC, sourceHeaders);
+
+            assertEquals("public, max-age=600", governed.get(AssetResponseEnvelope.CACHE_CONTROL),
+                    "a public asset keeps the source's caching");
+        }
+
+        @Test
+        @DisplayName("Should strip Set-Cookie the source proposed, case-insensitively")
+        void shouldStripSetCookie() {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put("set-cookie", "SESSION=abc; HttpOnly");
+            sourceHeaders.put("X-Custom", "kept");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "app.js", AccessLevel.PUBLIC, sourceHeaders);
+
+            assertAll(
+                    () -> assertFalse(governed.keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Set-Cookie")),
+                            "an asset action must never establish a session"),
+                    () -> assertEquals("kept", governed.get("X-Custom"),
+                            "unrelated source headers pass through"));
+        }
+    }
+
+    @Nested
+    @DisplayName("The read-only verb enforcement")
+    class MethodEnforcement {
+
+        @ParameterizedTest
+        @EnumSource(value = HttpMethod.class, names = {"GET", "HEAD"})
+        @DisplayName("Should serve GET and HEAD")
+        void shouldAllowReadVerbs(HttpMethod method) {
+            assertTrue(AssetResponseEnvelope.isAllowedMethod(method),
+                    () -> method + " should be servable by an asset action");
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = HttpMethod.class, names = {"POST", "PUT", "PATCH", "DELETE", "OPTIONS"})
+        @DisplayName("Should reject every write / non-read verb")
+        void shouldRejectNonReadVerbs(HttpMethod method) {
+            assertFalse(AssetResponseEnvelope.isAllowedMethod(method),
+                    () -> method + " must not be servable by an asset action");
+        }
+    }
+
+    @Nested
+    @DisplayName("The sealed asset-source seam (auth-before-source-resolution ordering)")
+    class SourceSeam {
+
+        @Test
+        @DisplayName("Should seal the source hierarchy to exactly the directory and upstream sources")
+        void shouldSealSourceHierarchy() {
+            assertTrue(AssetSource.class.isSealed(), "the asset-source seam must be sealed");
+            List<Class<?>> permitted = List.of(AssetSource.class.getPermittedSubclasses());
+            assertAll(
+                    () -> assertEquals(2, permitted.size(), "exactly two source kinds are permitted"),
+                    () -> assertTrue(permitted.contains(DirectoryAssetSource.class),
+                            "the local-directory source is a permitted seam member"),
+                    () -> assertTrue(permitted.contains(UpstreamAssetSource.class),
+                            "the secondary-origin source is a permitted seam member"));
+        }
+
+        @Test
+        @DisplayName("Should have both sources implement the sealed seam")
+        void shouldHaveSourcesImplementSeam() {
+            assertAll(
+                    () -> assertTrue(AssetSource.class.isAssignableFrom(DirectoryAssetSource.class),
+                            "DirectoryAssetSource must implement AssetSource"),
+                    () -> assertTrue(AssetSource.class.isAssignableFrom(UpstreamAssetSource.class),
+                            "UpstreamAssetSource must implement AssetSource"));
+        }
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetSourceServedTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/AssetSourceServedTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+
+import de.cuioss.sheriff.api.asset.AssetSource.Served;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract of the {@link Served} value object: the generated record accessors would
+ * compare and hash the {@code byte[] body} by array identity and dump its bytes in
+ * {@code toString}. The overrides fix both — equality and hashing are content-based, and
+ * {@code toString} renders only the body length, never the (possibly sensitive) bytes.
+ */
+class AssetSourceServedTest {
+
+    private static final int OK = 200;
+    private static final byte[] BODY = "asset-bytes".getBytes(StandardCharsets.UTF_8);
+    private static final Map<String, String> HEADERS = Map.of("Content-Type", "text/plain");
+
+    @Test
+    @DisplayName("equals/hashCode compare the body by content, not array identity")
+    void equalsIsContentBased() {
+        // Arrange — two Served built from independent byte[] instances carrying the same bytes.
+        Served first = new Served(OK, HEADERS, BODY.clone());
+        Served second = new Served(OK, HEADERS, BODY.clone());
+
+        // Act + Assert
+        assertAll(
+                () -> assertEquals(first, second, "equal body bytes make two Served equal"),
+                () -> assertEquals(first.hashCode(), second.hashCode(), "equal Served share a hashCode"),
+                () -> assertEquals(first, first, "a Served equals itself"));
+    }
+
+    @Test
+    @DisplayName("differing status, headers, or body bytes break equality")
+    void inequalityAcrossComponents() {
+        // Arrange
+        Served base = new Served(OK, HEADERS, BODY);
+
+        // Act + Assert
+        assertAll(
+                () -> assertNotEquals(base, new Served(404, HEADERS, BODY), "status participates in equality"),
+                () -> assertNotEquals(base, new Served(OK, Map.of("X", "y"), BODY),
+                        "headers participate in equality"),
+                () -> assertNotEquals(base,
+                        new Served(OK, HEADERS, "other".getBytes(StandardCharsets.UTF_8)),
+                        "body bytes participate in equality"),
+                () -> assertNotEquals("not-a-served", base, "a Served never equals an unrelated type"));
+    }
+
+    @Test
+    @DisplayName("toString reports only the body length, never the raw bytes")
+    void toStringHidesBody() {
+        // Arrange
+        byte[] secret = "session-cookie-value".getBytes(StandardCharsets.UTF_8);
+        Served served = new Served(OK, HEADERS, secret);
+
+        // Act
+        String rendered = served.toString();
+
+        // Assert
+        assertAll(
+                () -> assertTrue(rendered.contains("status=" + OK), "the status is rendered"),
+                () -> assertTrue(rendered.contains("body.length=" + secret.length),
+                        "the body length is rendered for diagnostics"),
+                () -> assertFalse(rendered.contains("session-cookie-value"),
+                        "the raw response body must never be dumped"));
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
@@ -68,7 +68,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should serve an in-root file with body and the governed envelope")
     void shouldServeInRootFile() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
 
         assertAll(
                 () -> assertEquals(OK, served.status(), "an in-root file should serve 200"),
@@ -84,7 +84,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should resolve the content type from the fixed map for a nested asset")
     void shouldResolveContentTypeFromMap() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "assets/app.css");
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "assets/app.css");
 
         assertAll(
                 () -> assertEquals(OK, served.status()),
@@ -95,7 +95,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should deny an out-of-root traversal with 404 and never read the sentinel")
     void shouldDenyOutOfRootTraversal() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "../secret.txt");
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "../secret.txt");
 
         assertAll(
                 () -> assertEquals(NOT_FOUND, served.status(), "an escape attempt must be denied"),
@@ -105,7 +105,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should return 404 for an in-root file that does not exist")
     void shouldReturnNotFoundForMissingFile() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "missing.js");
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "missing.js");
 
         assertEquals(NOT_FOUND, served.status(), "a missing in-root file is a 404");
     }
@@ -115,7 +115,7 @@ class DirectoryAssetSourceTest {
     void shouldForceNoStoreForAuthenticatedRoute() {
         DirectoryAssetSource authenticated = new DirectoryAssetSource(root, AccessLevel.AUTHENTICATED);
 
-        DirectoryAssetSource.Served served = authenticated.serve(HttpMethod.GET, "index.html");
+        AssetSource.Served served = authenticated.serve(HttpMethod.GET, "index.html");
 
         assertAll(
                 () -> assertEquals(OK, served.status()),
@@ -127,7 +127,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should not force no-store for a public route")
     void shouldNotForceNoStoreForPublicRoute() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
 
         assertNotEquals(AssetResponseEnvelope.NO_STORE,
                 served.headers().get(AssetResponseEnvelope.CACHE_CONTROL),
@@ -137,7 +137,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should serve HEAD with the governed headers and an empty body")
     void shouldServeHeadWithoutBody() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.HEAD, "index.html");
+        AssetSource.Served served = publicSource().serve(HttpMethod.HEAD, "index.html");
 
         assertAll(
                 () -> assertEquals(OK, served.status()),
@@ -150,7 +150,7 @@ class DirectoryAssetSourceTest {
     @Test
     @DisplayName("Should reject a write verb with 405")
     void shouldRejectWriteVerb() {
-        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.POST, "index.html");
+        AssetSource.Served served = publicSource().serve(HttpMethod.POST, "index.html");
 
         assertEquals(METHOD_NOT_ALLOWED, served.status(), "POST must be rejected 405");
     }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,8 +38,10 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Tests for {@link DirectoryAssetSource}: in-root files serve through the shared
  * {@link AssetResponseEnvelope}; the shared {@link PathConfinement} denies every
- * out-of-root escape; the content type resolves from the fixed gateway map; and an
- * {@link AccessLevel#AUTHENTICATED} route forces {@code Cache-Control: no-store}.
+ * out-of-root escape (lexically, via encoding/traversal); a symlink planted under root
+ * that resolves outside it is independently denied by the real-path check; the content
+ * type resolves from the fixed gateway map; and an {@link AccessLevel#AUTHENTICATED}
+ * route forces {@code Cache-Control: no-store}.
  */
 class DirectoryAssetSourceTest {
 
@@ -100,6 +103,27 @@ class DirectoryAssetSourceTest {
         assertAll(
                 () -> assertEquals(NOT_FOUND, served.status(), "an escape attempt must be denied"),
                 () -> assertEquals(0, served.body().length, "no byte of the sentinel is served"));
+    }
+
+    @Test
+    @DisplayName("Should deny a symlink under root that resolves outside it (real-path escape)")
+    void shouldDenySymlinkEscapingRoot() {
+        Path outsideTarget = tempDir.resolve("secret.txt");
+        Path link = root.resolve("linked-secret.txt");
+        try {
+            Files.createSymbolicLink(link, outsideTarget);
+        } catch (IOException | UnsupportedOperationException unsupported) {
+            assumeTrue(false,
+                    "symbolic links are not supported/permitted in this environment: " + unsupported.getMessage());
+        }
+
+        AssetSource.Served served = publicSource().serve(HttpMethod.GET, "linked-secret.txt");
+
+        assertAll(
+                () -> assertEquals(NOT_FOUND, served.status(),
+                        "a symlink resolving outside the root must be denied even though it lexically "
+                                + "sits inside root"),
+                () -> assertEquals(0, served.body().length, "no byte of the symlink target is served"));
     }
 
     @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link DirectoryAssetSource}: in-root files serve through the shared
+ * {@link AssetResponseEnvelope}; the shared {@link PathConfinement} denies every
+ * out-of-root escape; the content type resolves from the fixed gateway map; and an
+ * {@link AccessLevel#AUTHENTICATED} route forces {@code Cache-Control: no-store}.
+ */
+class DirectoryAssetSourceTest {
+
+    private static final byte[] INDEX_BODY = "<html><body>home</body></html>".getBytes(StandardCharsets.UTF_8);
+    private static final int OK = 200;
+    private static final int NOT_FOUND = 404;
+    private static final int METHOD_NOT_ALLOWED = 405;
+
+    @TempDir
+    Path tempDir;
+
+    private Path root;
+
+    @BeforeEach
+    void arrangeDirectory() throws IOException {
+        root = Files.createDirectories(tempDir.resolve("public"));
+        Files.write(root.resolve("index.html"), INDEX_BODY);
+        Files.createDirectories(root.resolve("assets"));
+        Files.writeString(root.resolve("assets/app.css"), "body{color:red}");
+        Files.writeString(tempDir.resolve("secret.txt"), "top-secret");
+    }
+
+    private DirectoryAssetSource publicSource() {
+        return new DirectoryAssetSource(root, AccessLevel.PUBLIC);
+    }
+
+    @Test
+    @DisplayName("Should serve an in-root file with body and the governed envelope")
+    void shouldServeInRootFile() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
+
+        assertAll(
+                () -> assertEquals(OK, served.status(), "an in-root file should serve 200"),
+                () -> assertArrayEquals(INDEX_BODY, served.body(), "the file body should be streamed"),
+                () -> assertEquals("text/html; charset=utf-8",
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE),
+                        "the content type resolves from the fixed gateway map"),
+                () -> assertEquals(AssetResponseEnvelope.NOSNIFF,
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE_OPTIONS),
+                        "nosniff is always set"));
+    }
+
+    @Test
+    @DisplayName("Should resolve the content type from the fixed map for a nested asset")
+    void shouldResolveContentTypeFromMap() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "assets/app.css");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertEquals("text/css; charset=utf-8",
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE)));
+    }
+
+    @Test
+    @DisplayName("Should deny an out-of-root traversal with 404 and never read the sentinel")
+    void shouldDenyOutOfRootTraversal() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "../secret.txt");
+
+        assertAll(
+                () -> assertEquals(NOT_FOUND, served.status(), "an escape attempt must be denied"),
+                () -> assertEquals(0, served.body().length, "no byte of the sentinel is served"));
+    }
+
+    @Test
+    @DisplayName("Should return 404 for an in-root file that does not exist")
+    void shouldReturnNotFoundForMissingFile() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "missing.js");
+
+        assertEquals(NOT_FOUND, served.status(), "a missing in-root file is a 404");
+    }
+
+    @Test
+    @DisplayName("Should force Cache-Control: no-store for an authenticated route")
+    void shouldForceNoStoreForAuthenticatedRoute() {
+        DirectoryAssetSource authenticated = new DirectoryAssetSource(root, AccessLevel.AUTHENTICATED);
+
+        DirectoryAssetSource.Served served = authenticated.serve(HttpMethod.GET, "index.html");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertEquals(AssetResponseEnvelope.NO_STORE,
+                        served.headers().get(AssetResponseEnvelope.CACHE_CONTROL),
+                        "an authenticated asset must be no-store"));
+    }
+
+    @Test
+    @DisplayName("Should not force no-store for a public route")
+    void shouldNotForceNoStoreForPublicRoute() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.GET, "index.html");
+
+        assertNotEquals(AssetResponseEnvelope.NO_STORE,
+                served.headers().get(AssetResponseEnvelope.CACHE_CONTROL),
+                "a public asset is not forced to no-store");
+    }
+
+    @Test
+    @DisplayName("Should serve HEAD with the governed headers and an empty body")
+    void shouldServeHeadWithoutBody() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.HEAD, "index.html");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertEquals(0, served.body().length, "HEAD carries no body"),
+                () -> assertEquals("text/html; charset=utf-8",
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE),
+                        "HEAD still carries the governed headers"));
+    }
+
+    @Test
+    @DisplayName("Should reject a write verb with 405")
+    void shouldRejectWriteVerb() {
+        DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.POST, "index.html");
+
+        assertTrue(served.status() == METHOD_NOT_ALLOWED, "POST must be rejected 405");
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/DirectoryAssetSourceTest.java
@@ -19,12 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
@@ -152,6 +152,6 @@ class DirectoryAssetSourceTest {
     void shouldRejectWriteVerb() {
         DirectoryAssetSource.Served served = publicSource().serve(HttpMethod.POST, "index.html");
 
-        assertTrue(served.status() == METHOD_NOT_ALLOWED, "POST must be rejected 405");
+        assertEquals(METHOD_NOT_ALLOWED, served.status(), "POST must be rejected 405");
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/PathConfinementTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/PathConfinementTest.java
@@ -15,7 +15,7 @@
  */
 package de.cuioss.sheriff.api.asset;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -101,7 +101,7 @@ class PathConfinementTest {
     @ParameterizedTest
     @MethodSource("traversalAttackCorpus")
     @DisplayName("No adversarial traversal/encoding vector escapes the confined root")
-    void shouldNeverEscapeConfinedRoot(String attack) throws IOException {
+    void shouldNeverEscapeConfinedRoot(String attack) throws Exception {
         Path confinedRoot = root().toAbsolutePath().normalize();
 
         Optional<Path> confined = confinement.confine(root(), attack);
@@ -109,14 +109,13 @@ class PathConfinementTest {
         confined.ifPresent(resolved -> {
             assertTrue(resolved.startsWith(confinedRoot),
                     () -> "attack '" + attack + "' escaped confinement to: " + resolved);
-            assertFalse(resolved.equals(outsideSentinel.toAbsolutePath().normalize()),
-                    () -> "attack '" + attack + "' reached the out-of-root sentinel");
+            assertNotEquals(resolved, outsideSentinel.toAbsolutePath().normalize(), () -> "attack '" + attack + "' reached the out-of-root sentinel");
         });
     }
 
     @Test
     @DisplayName("A leading traversal that targets a sibling of the root is rejected outright")
-    void shouldRejectLeadingTraversalOutright() throws IOException {
+    void shouldRejectLeadingTraversalOutright() throws Exception {
         Optional<Path> confined = confinement.confine(root(), "../secret.txt");
 
         assertTrue(confined.isEmpty(),
@@ -125,13 +124,13 @@ class PathConfinementTest {
 
     @Test
     @DisplayName("A null sub-path is rejected")
-    void shouldRejectNullSubPath() throws IOException {
+    void shouldRejectNullSubPath() throws Exception {
         assertTrue(confinement.confine(root(), null).isEmpty(), "a null sub-path must be rejected");
     }
 
     @Test
     @DisplayName("An in-root file confines to a path under the root")
-    void shouldConfineInRootFile() throws IOException {
+    void shouldConfineInRootFile() throws Exception {
         Optional<Path> confined = confinement.confine(root(), "index.html");
 
         assertTrue(confined.isPresent(), "a plain in-root file must confine");
@@ -142,7 +141,7 @@ class PathConfinementTest {
 
     @Test
     @DisplayName("An in-root nested sub-path confines under the root")
-    void shouldConfineInRootNestedSubPath() throws IOException {
+    void shouldConfineInRootNestedSubPath() throws Exception {
         Optional<Path> confined = confinement.confine(root(), "assets/css/app.css");
 
         assertTrue(confined.isPresent(), "a nested in-root sub-path must confine");
@@ -152,7 +151,7 @@ class PathConfinementTest {
 
     @Test
     @DisplayName("A leading-slash sub-path is treated as root-relative, not absolute")
-    void shouldTreatLeadingSlashAsRootRelative() throws IOException {
+    void shouldTreatLeadingSlashAsRootRelative() throws Exception {
         Optional<Path> confined = confinement.confine(root(), "/index.html");
 
         assertTrue(confined.isPresent(), "a leading-slash sub-path must confine root-relatively");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/PathConfinementTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/PathConfinementTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link PathConfinement}: the canonicalize-and-confine boundary that must
+ * let no request sub-path escape its configured root.
+ * <p>
+ * The adversarial corpus is an <em>explicit, auditable</em> set of representative
+ * vectors per attack class — encoded traversal, encoded slash, single/double/mixed
+ * percent-encoding, {@code %00} null bytes, overlong UTF-8, backslash separators,
+ * the {@code ..;/} path-parameter trick, and dot/trailing-slash variants. It is
+ * enumerated deterministically rather than sampled from a random generator on
+ * purpose: the security contract is to close the whole <em>class</em>, not one
+ * spelling (the Gravitee double-patch lesson), so every vector must be exercised on
+ * every run. The confinement is the sole gate shared by both asset sources, so a
+ * single escaping spelling is a traversal.
+ */
+class PathConfinementTest {
+
+    private final PathConfinement confinement = new PathConfinement();
+
+    @TempDir
+    Path tempDir;
+
+    private Path root;
+    private Path outsideSentinel;
+
+    private Path root() throws IOException {
+        if (root == null) {
+            root = Files.createDirectories(tempDir.resolve("public"));
+            outsideSentinel = Files.writeString(tempDir.resolve("secret.txt"), "top-secret");
+        }
+        return root;
+    }
+
+    static Stream<String> traversalAttackCorpus() {
+        return Stream.of(
+                // plain multi-level traversal escaping the root
+                "../secret.txt",
+                "../../secret.txt",
+                "../../../../../../etc/passwd",
+                "public/../../secret.txt",
+                // encoded traversal and encoded slash
+                "..%2f..%2fsecret.txt",
+                "%2e%2e%2f%2e%2e%2fsecret.txt",
+                "%2e%2e/%2e%2e/secret.txt",
+                "..%2F..%2Fsecret.txt",
+                // single / double / mixed percent-encoding
+                "%252e%252e%252f%252e%252e%252fsecret.txt",
+                "..%252f..%252fsecret.txt",
+                "%2e%2e%252fsecret.txt",
+                // null-byte injection
+                "../secret.txt%00.html",
+                "%00../secret.txt",
+                "index.html%00",
+                // overlong UTF-8 traversal
+                "%c0%ae%c0%ae%c0%afsecret.txt",
+                "%e0%80%ae%e0%80%ae/secret.txt",
+                // backslash separators (raw and encoded)
+                "..\\..\\secret.txt",
+                "..%5c..%5csecret.txt",
+                // ..;/ path-parameter trick
+                "..;/..;/secret.txt",
+                "public/..;/..;/secret.txt",
+                // dot and trailing-slash variants
+                "....//....//secret.txt",
+                ".../.../secret.txt",
+                "../",
+                "..%2f");
+    }
+
+    @ParameterizedTest
+    @MethodSource("traversalAttackCorpus")
+    @DisplayName("No adversarial traversal/encoding vector escapes the confined root")
+    void shouldNeverEscapeConfinedRoot(String attack) throws IOException {
+        Path confinedRoot = root().toAbsolutePath().normalize();
+
+        Optional<Path> confined = confinement.confine(root(), attack);
+
+        confined.ifPresent(resolved -> {
+            assertTrue(resolved.startsWith(confinedRoot),
+                    () -> "attack '" + attack + "' escaped confinement to: " + resolved);
+            assertFalse(resolved.equals(outsideSentinel.toAbsolutePath().normalize()),
+                    () -> "attack '" + attack + "' reached the out-of-root sentinel");
+        });
+    }
+
+    @Test
+    @DisplayName("A leading traversal that targets a sibling of the root is rejected outright")
+    void shouldRejectLeadingTraversalOutright() throws IOException {
+        Optional<Path> confined = confinement.confine(root(), "../secret.txt");
+
+        assertTrue(confined.isEmpty(),
+                () -> "a leading '../secret.txt' must be rejected, got: " + confined);
+    }
+
+    @Test
+    @DisplayName("A null sub-path is rejected")
+    void shouldRejectNullSubPath() throws IOException {
+        assertTrue(confinement.confine(root(), null).isEmpty(), "a null sub-path must be rejected");
+    }
+
+    @Test
+    @DisplayName("An in-root file confines to a path under the root")
+    void shouldConfineInRootFile() throws IOException {
+        Optional<Path> confined = confinement.confine(root(), "index.html");
+
+        assertTrue(confined.isPresent(), "a plain in-root file must confine");
+        assertTrue(confined.get().startsWith(root().toAbsolutePath().normalize()),
+                () -> "the confined path must stay under the root, got: " + confined.get());
+        assertTrue(confined.get().endsWith("index.html"), "the confined path must resolve the requested file");
+    }
+
+    @Test
+    @DisplayName("An in-root nested sub-path confines under the root")
+    void shouldConfineInRootNestedSubPath() throws IOException {
+        Optional<Path> confined = confinement.confine(root(), "assets/css/app.css");
+
+        assertTrue(confined.isPresent(), "a nested in-root sub-path must confine");
+        assertTrue(confined.get().startsWith(root().toAbsolutePath().normalize()),
+                () -> "the confined path must stay under the root, got: " + confined.get());
+    }
+
+    @Test
+    @DisplayName("A leading-slash sub-path is treated as root-relative, not absolute")
+    void shouldTreatLeadingSlashAsRootRelative() throws IOException {
+        Optional<Path> confined = confinement.confine(root(), "/index.html");
+
+        assertTrue(confined.isPresent(), "a leading-slash sub-path must confine root-relatively");
+        assertTrue(confined.get().startsWith(root().toAbsolutePath().normalize()),
+                () -> "a leading slash must not escape to the filesystem root, got: " + confined.get());
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceHttpFetcherTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceHttpFetcherTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+
+import de.cuioss.sheriff.api.asset.UpstreamAssetSource.UpstreamFetcher;
+import de.cuioss.test.mockwebserver.EnableMockWebServer;
+import de.cuioss.test.mockwebserver.URIBuilder;
+import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcher;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
+
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the SSRF-guarded {@linkplain UpstreamAssetSource#httpFetcher(Duration, Duration, long)
+ * default transport fetcher} against a real in-process server so the streaming
+ * {@code CappedByteArrayBodySubscriber} — header mapping, the mid-flight abort at the size
+ * cap, and the read-timeout mapping — is covered end-to-end rather than through the
+ * injectable seam. The seam-level governance and ordering assertions live in
+ * {@link UpstreamAssetSourceTest}.
+ */
+@EnableMockWebServer
+@ModuleDispatcher
+class UpstreamAssetSourceHttpFetcherTest {
+
+    private static final long CAP = 16;
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final String SMALL_BODY = "hello-asset";
+    private static final String OVERSIZED_BODY = "X".repeat(64);
+
+    /**
+     * Routes by request target: {@code /assets/large.*} serves an over-cap body,
+     * {@code /assets/slow.*} delays its body past a short read timeout, and every other
+     * target serves a small body with two mappable headers.
+     *
+     * @return the routing dispatcher
+     */
+    public ModuleDispatcherElement getModuleDispatcher() {
+        return new ModuleDispatcherElement() {
+
+            @Override
+            public String getBaseUrl() {
+                return "/assets";
+            }
+
+            @Override
+            public Optional<MockResponse> handleGet(RecordedRequest request) {
+                String target = request.getTarget();
+                if (target.contains("large")) {
+                    return Optional.of(new MockResponse.Builder()
+                            .code(200)
+                            .addHeader("Content-Type", "application/octet-stream")
+                            .body(OVERSIZED_BODY)
+                            .build());
+                }
+                if (target.contains("slow")) {
+                    return Optional.of(new MockResponse.Builder()
+                            .code(200)
+                            .addHeader("Content-Type", "text/plain")
+                            .headersDelay(5, TimeUnit.SECONDS)
+                            .body("late")
+                            .build());
+                }
+                return Optional.of(new MockResponse.Builder()
+                        .code(200)
+                        .addHeader("Content-Type", "text/javascript")
+                        .addHeader("X-Trace", "trace-1")
+                        .body(SMALL_BODY)
+                        .build());
+            }
+
+            @Override
+            public Set<HttpMethodMapper> supportedMethods() {
+                return Set.of(HttpMethodMapper.GET);
+            }
+        };
+    }
+
+    private static UpstreamFetcher fetcher(Duration readTimeout) {
+        return UpstreamAssetSource.httpFetcher(CONNECT_TIMEOUT, readTimeout, CAP);
+    }
+
+    private static String headerValue(Map<String, String> headers, String name) {
+        return headers.entrySet().stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Test
+    @DisplayName("Should stream a small body and map the first value per header name")
+    void shouldStreamBodyAndMapHeaders(URIBuilder uriBuilder) throws Exception {
+        // Arrange
+        URI target = uriBuilder.addPathSegments("assets", "small.js").build();
+
+        // Act
+        UpstreamFetcher.Fetched fetched = fetcher(Duration.ofSeconds(5)).fetch(target);
+
+        // Assert
+        assertAll(
+                () -> assertEquals(200, fetched.status()),
+                () -> assertEquals(SMALL_BODY, new String(fetched.body(), StandardCharsets.UTF_8),
+                        "the streamed body is delivered intact when under the cap"),
+                () -> assertEquals("text/javascript", headerValue(fetched.headers(), "Content-Type"),
+                        "each header contributes its first value"),
+                () -> assertEquals("trace-1", headerValue(fetched.headers(), "X-Trace")));
+    }
+
+    @Test
+    @DisplayName("Should abort the stream at the cap and cap the returned body at maxBytes + 1")
+    void shouldTrimBodyThatExceedsCap(URIBuilder uriBuilder) throws Exception {
+        // Arrange — the served body is far larger than the cap.
+        URI target = uriBuilder.addPathSegments("assets", "large.bin").build();
+
+        // Act
+        UpstreamFetcher.Fetched fetched = fetcher(Duration.ofSeconds(5)).fetch(target);
+
+        // Assert — the mid-flight abort stops pulling and the backstop trims to a stable
+        // over-cap signal (maxBytes + 1) so serve() can reject it deterministically.
+        assertAll(
+                () -> assertEquals(200, fetched.status()),
+                () -> assertTrue(fetched.body().length > CAP,
+                        "the over-cap signal is preserved for the serve() size check"),
+                () -> assertTrue(fetched.body().length <= CAP + 1,
+                        "the body never buffers past maxBytes + 1"));
+    }
+
+    @Test
+    @DisplayName("Should map a body delayed past the read timeout to an UpstreamTimeoutException")
+    void shouldRaiseTimeoutOnDelayedBody(URIBuilder uriBuilder) {
+        // Arrange — a 300 ms read timeout against a 2 s body delay.
+        URI target = uriBuilder.addPathSegments("assets", "slow.js").build();
+        UpstreamFetcher fetcher = fetcher(Duration.ofMillis(300));
+
+        // Act + Assert
+        assertThrows(UpstreamFetcher.UpstreamTimeoutException.class, () -> fetcher.fetch(target),
+                "a read-timeout on the transport surfaces as an UpstreamTimeoutException");
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.asset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import de.cuioss.sheriff.api.asset.UpstreamAssetSource.UpstreamFetcher;
+import de.cuioss.sheriff.api.config.model.AccessLevel;
+import de.cuioss.sheriff.api.config.model.HttpMethod;
+import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UpstreamAssetSource}: the gateway governs every upstream-asset
+ * response — a hostile upstream {@code Content-Type} is overridden by the fixed map,
+ * {@code Set-Cookie} is stripped, and an authenticated asset is forced to
+ * {@code no-store} even when the upstream sent {@code Cache-Control: public}. The
+ * SSRF posture is reused, not re-invented: the untrusted remainder is confined before
+ * the upstream is touched, a non-allowlisted scheme is refused, a redirect is never
+ * followed, and the response size is bounded. Governance and ordering are exercised
+ * through the injectable {@link UpstreamFetcher} seam so the assertions are
+ * deterministic; the default seam enforces {@code followRedirects(NEVER)} at the
+ * transport layer.
+ */
+class UpstreamAssetSourceTest {
+
+    private static final byte[] BODY = "console.log('x')".getBytes(StandardCharsets.UTF_8);
+    private static final int OK = 200;
+    private static final int FOUND = 302;
+    private static final int NOT_FOUND = 404;
+    private static final int METHOD_NOT_ALLOWED = 405;
+    private static final int PAYLOAD_TOO_LARGE = 413;
+    private static final int BAD_GATEWAY = 502;
+    private static final int GATEWAY_TIMEOUT = 504;
+    private static final long MAX_BYTES = 64;
+
+    private static final ResolvedUpstream HTTPS_UPSTREAM =
+            new ResolvedUpstream("https", "assets.internal", 443, "/static");
+
+    private static UpstreamFetcher cannedFetcher(int status, Map<String, String> headers, byte[] body) {
+        return target -> new UpstreamFetcher.Fetched(status, headers, body);
+    }
+
+    private static UpstreamFetcher mustNotFetch() {
+        return target -> {
+            throw new AssertionError("the upstream must not be touched: " + target);
+        };
+    }
+
+    private UpstreamAssetSource source(AccessLevel access, UpstreamFetcher fetcher) {
+        return new UpstreamAssetSource(HTTPS_UPSTREAM, access, new PathConfinement(), fetcher, MAX_BYTES);
+    }
+
+    private static Map<String, String> headers(String... pairs) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < pairs.length; i += 2) {
+            map.put(pairs[i], pairs[i + 1]);
+        }
+        return map;
+    }
+
+    @Test
+    @DisplayName("Should override a hostile upstream Content-Type from the fixed map and set nosniff")
+    void shouldOverrideHostileContentType() {
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/html-but-evil"), BODY);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertEquals("text/javascript; charset=utf-8",
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE),
+                        "the gateway map overrides the upstream Content-Type"),
+                () -> assertEquals(AssetResponseEnvelope.NOSNIFF,
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE_OPTIONS)),
+                () -> assertArrayEqualsBody(BODY, served.body()));
+    }
+
+    @Test
+    @DisplayName("Should strip an upstream Set-Cookie")
+    void shouldStripUpstreamSetCookie() {
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Set-Cookie", "SID=1; HttpOnly", "X-Keep", "yes"), BODY);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertAll(
+                () -> assertFalse(served.headers().keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Set-Cookie")),
+                        "an upstream Set-Cookie must never reach the client"),
+                () -> assertEquals("yes", served.headers().get("X-Keep")));
+    }
+
+    @Test
+    @DisplayName("Should force no-store for authenticated access even when the upstream sent Cache-Control: public")
+    void shouldForceNoStoreForAuthenticatedOverUpstreamPublic() {
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Cache-Control", "public, max-age=99999"), BODY);
+
+        UpstreamAssetSource.Served served =
+                source(AccessLevel.AUTHENTICATED, fetcher).serve(HttpMethod.GET, "secret.json");
+
+        assertEquals(AssetResponseEnvelope.NO_STORE, served.headers().get(AssetResponseEnvelope.CACHE_CONTROL),
+                "an authenticated upstream asset must be forced to no-store");
+    }
+
+    @Test
+    @DisplayName("Should keep the upstream caching for public access")
+    void shouldKeepUpstreamCachingForPublicAccess() {
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Cache-Control", "public, max-age=600"), BODY);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "logo.png");
+
+        assertEquals("public, max-age=600", served.headers().get(AssetResponseEnvelope.CACHE_CONTROL));
+    }
+
+    @Test
+    @DisplayName("Should confine the remainder and never touch the upstream on an out-of-root escape")
+    void shouldConfineBeforeTouchingUpstream() {
+        UpstreamAssetSource.Served served =
+                source(AccessLevel.PUBLIC, mustNotFetch()).serve(HttpMethod.GET, "../../secret");
+
+        assertEquals(NOT_FOUND, served.status(), "an escape must be denied before the upstream is touched");
+    }
+
+    @Test
+    @DisplayName("Should refuse a non-allowlisted upstream scheme without touching the upstream")
+    void shouldRefuseNonAllowlistedScheme() {
+        ResolvedUpstream fileScheme = new ResolvedUpstream("file", "assets.internal", 0, "/static");
+        UpstreamAssetSource source = new UpstreamAssetSource(
+                fileScheme, AccessLevel.PUBLIC, new PathConfinement(), mustNotFetch(), MAX_BYTES);
+
+        UpstreamAssetSource.Served served = source.serve(HttpMethod.GET, "app.js");
+
+        assertEquals(BAD_GATEWAY, served.status(), "only http/https are allowlisted egress schemes");
+    }
+
+    @Test
+    @DisplayName("Should reject a write verb without touching the upstream")
+    void shouldRejectWriteVerb() {
+        UpstreamAssetSource.Served served =
+                source(AccessLevel.PUBLIC, mustNotFetch()).serve(HttpMethod.POST, "app.js");
+
+        assertEquals(METHOD_NOT_ALLOWED, served.status());
+    }
+
+    @Test
+    @DisplayName("Should never follow a redirect — an upstream 302 is returned as-is with no body")
+    void shouldNotFollowRedirect() {
+        UpstreamFetcher fetcher = cannedFetcher(FOUND,
+                headers("Location", "https://evil.internal/loot"), new byte[0]);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertAll(
+                () -> assertEquals(FOUND, served.status(), "the 302 is surfaced, not followed"),
+                () -> assertEquals(0, served.body().length, "a non-2xx upstream carries no asset body"));
+    }
+
+    @Test
+    @DisplayName("Should bound the response size")
+    void shouldBoundResponseSize() {
+        byte[] oversized = new byte[(int) MAX_BYTES + 1];
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/plain"), oversized);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "big.bin");
+
+        assertEquals(PAYLOAD_TOO_LARGE, served.status(), "a body over the cap is refused");
+    }
+
+    @Test
+    @DisplayName("Should map an upstream timeout to 504")
+    void shouldMapTimeoutToGatewayTimeout() {
+        UpstreamFetcher fetcher = target -> {
+            throw new UpstreamFetcher.UpstreamTimeoutException(new java.net.http.HttpTimeoutException("slow"));
+        };
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertEquals(GATEWAY_TIMEOUT, served.status());
+    }
+
+    @Test
+    @DisplayName("Should serve HEAD with governed headers and no body")
+    void shouldServeHeadWithoutBody() {
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/plain"), BODY);
+
+        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.HEAD, "app.js");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertEquals(0, served.body().length, "HEAD carries no body"),
+                () -> assertEquals("text/javascript; charset=utf-8",
+                        served.headers().get(AssetResponseEnvelope.CONTENT_TYPE)));
+    }
+
+    @Test
+    @DisplayName("Should build the default SSRF-guarded fetcher without error")
+    void shouldBuildDefaultFetcher() {
+        UpstreamFetcher fetcher = UpstreamAssetSource.httpFetcher(
+                UpstreamAssetSource.DEFAULT_CONNECT_TIMEOUT,
+                UpstreamAssetSource.DEFAULT_READ_TIMEOUT,
+                UpstreamAssetSource.DEFAULT_MAX_BYTES);
+
+        assertNotNull(fetcher, "the default transport fetcher is wired");
+    }
+
+    private static void assertArrayEqualsBody(byte[] expected, byte[] actual) {
+        assertEquals(new String(expected, StandardCharsets.UTF_8), new String(actual, StandardCharsets.UTF_8),
+                "the upstream body should be streamed for a 2xx GET");
+    }
+
+    @Test
+    @DisplayName("Should not touch the upstream for a URI it could not build")
+    void shouldBuildResolvableUri() {
+        // A normal remainder resolves cleanly against the fixed-topology target.
+        UpstreamFetcher fetcher = target -> {
+            assertEquals(URI.create("https://assets.internal:443/static/nested/app.js"), target,
+                    "the confined remainder is appended to the resolved base path");
+            return new UpstreamFetcher.Fetched(OK, headers("Content-Type", "text/plain"), BODY);
+        };
+
+        UpstreamAssetSource.Served served =
+                source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "nested/app.js");
+
+        assertEquals(OK, served.status());
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -21,9 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URI;
+import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 
 import de.cuioss.sheriff.api.asset.UpstreamAssetSource.UpstreamFetcher;
 import de.cuioss.sheriff.api.config.model.AccessLevel;
@@ -107,7 +109,7 @@ class UpstreamAssetSourceTest {
         UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertAll(
-                () -> assertFalse(served.headers().keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Set-Cookie")),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch(k -> "Set-Cookie".equalsIgnoreCase(k)),
                         "an upstream Set-Cookie must never reach the client"),
                 () -> assertEquals("yes", served.headers().get("X-Keep")));
     }
@@ -192,7 +194,7 @@ class UpstreamAssetSourceTest {
     @DisplayName("Should map an upstream timeout to 504")
     void shouldMapTimeoutToGatewayTimeout() {
         UpstreamFetcher fetcher = target -> {
-            throw new UpstreamFetcher.UpstreamTimeoutException(new java.net.http.HttpTimeoutException("slow"));
+            throw new UpstreamFetcher.UpstreamTimeoutException(new HttpTimeoutException("slow"));
         };
 
         UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -233,7 +233,7 @@ class UpstreamAssetSourceTest {
     }
 
     @Test
-    @DisplayName("Should not touch the upstream for a URI it could not build")
+    @DisplayName("Should append the confined remainder to the resolved base path and fetch it")
     void shouldBuildResolvableUri() {
         // A normal remainder resolves cleanly against the fixed-topology target.
         UpstreamFetcher fetcher = target -> {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -16,10 +16,14 @@
 package de.cuioss.sheriff.api.asset;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
@@ -214,6 +218,69 @@ class UpstreamAssetSourceTest {
                 () -> assertEquals(0, served.body().length, "HEAD carries no body"),
                 () -> assertEquals("text/javascript; charset=utf-8",
                         served.headers().get(AssetResponseEnvelope.CONTENT_TYPE)));
+    }
+
+    @Test
+    @DisplayName("Should map a transport IOException to 502")
+    void shouldMapFetchFailureToBadGateway() {
+        UpstreamFetcher fetcher = target -> {
+            throw new IOException("connection refused");
+        };
+
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertEquals(BAD_GATEWAY, served.status(), "a transport failure surfaces as 502");
+    }
+
+    @Test
+    @DisplayName("Should construct the default source with the SSRF-guarded transport fetcher")
+    void shouldConstructWithDefaultFetcher() {
+        assertDoesNotThrow(() -> new UpstreamAssetSource(HTTPS_UPSTREAM, AccessLevel.PUBLIC),
+                "the two-arg constructor wires the default confinement, transport fetcher, timeouts, and cap");
+    }
+
+    @Test
+    @DisplayName("Fetched equals/hashCode compare the body by content, not array identity")
+    void fetchedEqualsIsContentBased() {
+        Map<String, String> headers = headers("Content-Type", "text/plain");
+        UpstreamFetcher.Fetched first = new UpstreamFetcher.Fetched(OK, headers, BODY.clone());
+        UpstreamFetcher.Fetched second = new UpstreamFetcher.Fetched(OK, headers, BODY.clone());
+
+        assertAll(
+                () -> assertEquals(first, second, "two Fetched with equal body bytes are equal"),
+                () -> assertEquals(first.hashCode(), second.hashCode(), "equal Fetched share a hashCode"),
+                () -> assertEquals(first, first, "a Fetched equals itself"));
+    }
+
+    @Test
+    @DisplayName("Fetched with differing body bytes are not equal")
+    void fetchedWithDifferentBodyNotEqual() {
+        Map<String, String> headers = headers("Content-Type", "text/plain");
+        UpstreamFetcher.Fetched first = new UpstreamFetcher.Fetched(OK, headers, BODY);
+        UpstreamFetcher.Fetched other =
+                new UpstreamFetcher.Fetched(OK, headers, "different".getBytes(StandardCharsets.UTF_8));
+
+        assertAll(
+                () -> assertNotEquals(first, other, "differing body bytes break equality"),
+                () -> assertNotEquals(first, new UpstreamFetcher.Fetched(NOT_FOUND, headers, BODY),
+                        "a differing status breaks equality"),
+                () -> assertNotEquals(BODY, first, "a Fetched never equals an unrelated type"));
+    }
+
+    @Test
+    @DisplayName("Fetched toString reports only the body length, never the raw bytes")
+    void fetchedToStringHidesBody() {
+        byte[] secret = "top-secret-token".getBytes(StandardCharsets.UTF_8);
+        UpstreamFetcher.Fetched fetched =
+                new UpstreamFetcher.Fetched(OK, headers("Content-Type", "text/plain"), secret);
+
+        String rendered = fetched.toString();
+
+        assertAll(
+                () -> assertTrue(rendered.contains("body.length=" + secret.length),
+                        "the length is rendered for diagnostics"),
+                () -> assertFalse(rendered.contains("top-secret-token"),
+                        "the raw upstream body bytes must never be dumped"));
     }
 
     @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -89,7 +89,7 @@ class UpstreamAssetSourceTest {
     void shouldOverrideHostileContentType() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/html-but-evil"), BODY);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertAll(
                 () -> assertEquals(OK, served.status()),
@@ -106,7 +106,7 @@ class UpstreamAssetSourceTest {
     void shouldStripUpstreamSetCookie() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Set-Cookie", "SID=1; HttpOnly", "X-Keep", "yes"), BODY);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertAll(
                 () -> assertFalse(served.headers().keySet().stream().anyMatch(k -> "Set-Cookie".equalsIgnoreCase(k)),
@@ -119,7 +119,7 @@ class UpstreamAssetSourceTest {
     void shouldForceNoStoreForAuthenticatedOverUpstreamPublic() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Cache-Control", "public, max-age=99999"), BODY);
 
-        UpstreamAssetSource.Served served =
+        AssetSource.Served served =
                 source(AccessLevel.AUTHENTICATED, fetcher).serve(HttpMethod.GET, "secret.json");
 
         assertEquals(AssetResponseEnvelope.NO_STORE, served.headers().get(AssetResponseEnvelope.CACHE_CONTROL),
@@ -131,7 +131,7 @@ class UpstreamAssetSourceTest {
     void shouldKeepUpstreamCachingForPublicAccess() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Cache-Control", "public, max-age=600"), BODY);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "logo.png");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "logo.png");
 
         assertEquals("public, max-age=600", served.headers().get(AssetResponseEnvelope.CACHE_CONTROL));
     }
@@ -139,7 +139,7 @@ class UpstreamAssetSourceTest {
     @Test
     @DisplayName("Should confine the remainder and never touch the upstream on an out-of-root escape")
     void shouldConfineBeforeTouchingUpstream() {
-        UpstreamAssetSource.Served served =
+        AssetSource.Served served =
                 source(AccessLevel.PUBLIC, mustNotFetch()).serve(HttpMethod.GET, "../../secret");
 
         assertEquals(NOT_FOUND, served.status(), "an escape must be denied before the upstream is touched");
@@ -152,7 +152,7 @@ class UpstreamAssetSourceTest {
         UpstreamAssetSource source = new UpstreamAssetSource(
                 fileScheme, AccessLevel.PUBLIC, new PathConfinement(), mustNotFetch(), MAX_BYTES);
 
-        UpstreamAssetSource.Served served = source.serve(HttpMethod.GET, "app.js");
+        AssetSource.Served served = source.serve(HttpMethod.GET, "app.js");
 
         assertEquals(BAD_GATEWAY, served.status(), "only http/https are allowlisted egress schemes");
     }
@@ -160,7 +160,7 @@ class UpstreamAssetSourceTest {
     @Test
     @DisplayName("Should reject a write verb without touching the upstream")
     void shouldRejectWriteVerb() {
-        UpstreamAssetSource.Served served =
+        AssetSource.Served served =
                 source(AccessLevel.PUBLIC, mustNotFetch()).serve(HttpMethod.POST, "app.js");
 
         assertEquals(METHOD_NOT_ALLOWED, served.status());
@@ -172,7 +172,7 @@ class UpstreamAssetSourceTest {
         UpstreamFetcher fetcher = cannedFetcher(FOUND,
                 headers("Location", "https://evil.internal/loot"), new byte[0]);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertAll(
                 () -> assertEquals(FOUND, served.status(), "the 302 is surfaced, not followed"),
@@ -185,7 +185,7 @@ class UpstreamAssetSourceTest {
         byte[] oversized = new byte[(int) MAX_BYTES + 1];
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/plain"), oversized);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "big.bin");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "big.bin");
 
         assertEquals(PAYLOAD_TOO_LARGE, served.status(), "a body over the cap is refused");
     }
@@ -197,7 +197,7 @@ class UpstreamAssetSourceTest {
             throw new UpstreamFetcher.UpstreamTimeoutException(new HttpTimeoutException("slow"));
         };
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertEquals(GATEWAY_TIMEOUT, served.status());
     }
@@ -207,7 +207,7 @@ class UpstreamAssetSourceTest {
     void shouldServeHeadWithoutBody() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Content-Type", "text/plain"), BODY);
 
-        UpstreamAssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.HEAD, "app.js");
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.HEAD, "app.js");
 
         assertAll(
                 () -> assertEquals(OK, served.status()),
@@ -242,7 +242,7 @@ class UpstreamAssetSourceTest {
             return new UpstreamFetcher.Fetched(OK, headers("Content-Type", "text/plain"), BODY);
         };
 
-        UpstreamAssetSource.Served served =
+        AssetSource.Served served =
                 source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "nested/app.js");
 
         assertEquals(OK, served.status());

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
 import de.cuioss.sheriff.api.config.model.AnchorType;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
@@ -39,6 +40,7 @@ import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.MatchConfig;
 import de.cuioss.sheriff.api.config.model.MatchConfig.HeaderMatcher;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
 import de.cuioss.sheriff.api.config.model.ResolvedRoute;
 import de.cuioss.sheriff.api.config.model.ResolvedTopology;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
@@ -255,7 +257,7 @@ class RouteTableBuilderTest {
 
             RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
 
-            assertEquals("orders.internal", find(table, "r").upstream().host());
+            assertEquals("orders.internal", find(table, "r").upstream().orElseThrow().host());
         }
 
         @Test
@@ -685,6 +687,107 @@ class RouteTableBuilderTest {
                     "an unforwarded route resolves to an empty, deny-by-default allowlist");
             assertTrue(resolved.effectiveForward().queryAllow().isEmpty());
             assertTrue(resolved.effectiveForward().setHeaders().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Asset terminal-action materialization (ADR-0014)")
+    class AssetTerminalAction {
+
+        private AnchorConfig assetAnchor(String name, String prefix, AccessLevel access, String require) {
+            return AnchorConfig.builder()
+                    .name(name)
+                    .pathPrefix(prefix)
+                    .type(AnchorType.ASSET)
+                    .access(access)
+                    .auth(require == null ? Optional.empty() : Optional.of(new AuthConfig(require, List.of())))
+                    .build();
+        }
+
+        private RouteConfig assetRoute(String id, String prefix, String anchorName, AssetConfig asset) {
+            return RouteConfig.builder()
+                    .id(id)
+                    .anchor(Optional.of(anchorName))
+                    .match(match(prefix, HttpMethod.GET))
+                    .asset(Optional.of(asset))
+                    .build();
+        }
+
+        @Test
+        @DisplayName("Should materialize a directory asset action and leave the proxy upstream empty")
+        void shouldMaterializeDirectoryAsset() {
+            GatewayConfig config = gateway()
+                    .anchors(Map.of("assets", assetAnchor("assets", "/assets", AccessLevel.PUBLIC, null))).build();
+            AssetConfig asset = AssetConfig.builder().source(AssetConfig.Source.DIRECTORY)
+                    .directory(Optional.of("/srv/assets")).build();
+            EndpointConfig endpoint = EndpointConfig.builder().id("web").enabled(true).baseUrl("WEB")
+                    .anchor(Optional.of("assets")).auth(Optional.of(new AuthConfig("none", List.of())))
+                    .routes(List.of(assetRoute("bundle", "/assets", "assets", asset))).build();
+
+            RouteTable table = builder.build(config, List.of(endpoint), topologyWith("WEB"));
+
+            ResolvedRoute resolved = find(table, "bundle");
+            assertTrue(resolved.upstream().isEmpty(), "an asset route carries no proxy upstream");
+            ResolvedAsset resolvedAsset = resolved.asset().orElseThrow();
+            assertAll("directory asset materialization",
+                    () -> assertEquals(AssetConfig.Source.DIRECTORY, resolvedAsset.source()),
+                    () -> assertEquals(Optional.of("/srv/assets"), resolvedAsset.directory()),
+                    () -> assertTrue(resolvedAsset.upstream().isEmpty(), "a directory action carries no upstream"),
+                    () -> assertEquals(AccessLevel.PUBLIC, resolvedAsset.access(),
+                            "the access level is inherited from the resolving anchor"));
+        }
+
+        @Test
+        @DisplayName("Should materialize an upstream asset action resolving its alias through the topology")
+        void shouldMaterializeUpstreamAsset() {
+            GatewayConfig config = gateway().anchors(Map.of("assets",
+                    assetAnchor("assets", "/assets", AccessLevel.AUTHENTICATED, "bearer"))).build();
+            AssetConfig asset = AssetConfig.builder().source(AssetConfig.Source.UPSTREAM)
+                    .upstream(Optional.of("SECONDARY")).build();
+            EndpointConfig endpoint = EndpointConfig.builder().id("web").enabled(true).baseUrl("WEB")
+                    .anchor(Optional.of("assets")).auth(Optional.empty())
+                    .routes(List.of(assetRoute("cdn", "/assets", "assets", asset))).build();
+
+            RouteTable table = builder.build(config, List.of(endpoint), topologyWith("WEB", "SECONDARY"));
+
+            ResolvedRoute resolved = find(table, "cdn");
+            ResolvedAsset resolvedAsset = resolved.asset().orElseThrow();
+            assertAll("upstream asset materialization",
+                    () -> assertEquals(AssetConfig.Source.UPSTREAM, resolvedAsset.source()),
+                    () -> assertEquals("secondary.internal", resolvedAsset.upstream().orElseThrow().host(),
+                            "the upstream alias resolves through the same topology the proxy action uses"),
+                    () -> assertTrue(resolvedAsset.directory().isEmpty(), "an upstream action carries no directory"),
+                    () -> assertEquals(AccessLevel.AUTHENTICATED, resolvedAsset.access()),
+                    () -> assertTrue(resolved.upstream().isEmpty(), "an asset route carries no proxy upstream"));
+        }
+
+        @Test
+        @DisplayName("Should reject an upstream asset action whose alias does not resolve")
+        void shouldRejectUnresolvableUpstreamAssetAlias() {
+            GatewayConfig config = gateway().anchors(Map.of("assets",
+                    assetAnchor("assets", "/assets", AccessLevel.PUBLIC, null))).build();
+            AssetConfig asset = AssetConfig.builder().source(AssetConfig.Source.UPSTREAM)
+                    .upstream(Optional.of("MISSING")).build();
+            EndpointConfig endpoint = EndpointConfig.builder().id("web").enabled(true).baseUrl("WEB")
+                    .anchor(Optional.of("assets")).auth(Optional.of(new AuthConfig("none", List.of())))
+                    .routes(List.of(assetRoute("cdn", "/assets", "assets", asset))).build();
+            ResolvedTopology topology = topologyWith("WEB");
+
+            assertThrows(RouteTableBuilder.RouteTableException.class,
+                    () -> builder.build(config, List.of(endpoint), topology));
+        }
+
+        @Test
+        @DisplayName("Should keep a proxy route's upstream present and its asset action empty (exclusivity)")
+        void shouldKeepProxyRouteExclusive() {
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(route("r", HttpMethod.GET))).build();
+
+            RouteTable table = builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS"));
+
+            ResolvedRoute resolved = find(table, "r");
+            assertTrue(resolved.upstream().isPresent(), "a proxy route resolves an upstream terminal action");
+            assertTrue(resolved.asset().isEmpty(), "a proxy route carries no asset terminal action");
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -762,6 +762,30 @@ class RouteTableBuilderTest {
         }
 
         @Test
+        @DisplayName("Should force AUTHENTICATED access when a route auth override strengthens a public-access anchor")
+        void shouldTreatRouteAuthOverrideAsAuthenticatedUnderPublicAccessAnchor() {
+            GatewayConfig config = gateway()
+                    .anchors(Map.of("assets", assetAnchor("assets", "/assets", AccessLevel.PUBLIC, null))).build();
+            AssetConfig asset = AssetConfig.builder().source(AssetConfig.Source.DIRECTORY)
+                    .directory(Optional.of("/srv/assets")).build();
+            RouteConfig route = RouteConfig.builder().id("bundle").anchor(Optional.of("assets"))
+                    .match(match("/assets", HttpMethod.GET))
+                    .auth(Optional.of(new AuthConfig("bearer", List.of())))
+                    .asset(Optional.of(asset)).build();
+            EndpointConfig endpoint = EndpointConfig.builder().id("web").enabled(true).baseUrl("WEB")
+                    .anchor(Optional.of("assets")).auth(Optional.empty()).routes(List.of(route)).build();
+
+            RouteTable table = builder.build(config, List.of(endpoint), topologyWith("WEB"));
+
+            ResolvedRoute resolved = find(table, "bundle");
+            assertEquals("bearer", resolved.effectiveAuth().require(),
+                    "the route-level override should strengthen the public anchor's absent auth floor");
+            assertEquals(AccessLevel.AUTHENTICATED, resolved.asset().orElseThrow().access(),
+                    "a route whose effective auth requires bearer must be governed AUTHENTICATED "
+                            + "for caching purposes even though its anchor stays access: public");
+        }
+
+        @Test
         @DisplayName("Should reject an upstream asset action whose alias does not resolve")
         void shouldRejectUnresolvableUpstreamAssetAlias() {
             GatewayConfig config = gateway().anchors(Map.of("assets",

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.Optional;
 
 
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AnchorType;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
@@ -145,6 +147,8 @@ class RouteTableBuilderTest {
         return AnchorConfig.builder()
                 .name(name)
                 .pathPrefix(prefix)
+                .type(AnchorType.PROXY)
+                .access(AccessLevel.AUTHENTICATED)
                 .auth(Optional.ofNullable(auth))
                 .securityFilter(Optional.ofNullable(filter))
                 .securityHeaders(Optional.ofNullable(headers))

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
@@ -31,7 +31,9 @@ import java.util.Map;
 import java.util.Optional;
 
 
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AnchorType;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
@@ -362,6 +364,8 @@ class ConfigLoaderTest {
                 anchors:
                   api:
                     path_prefix: /api
+                    type: proxy
+                    access: authenticated
                     auth:
                       require: bearer
                     security_filter:
@@ -380,6 +384,9 @@ class ConfigLoaderTest {
         assertEquals("bearer", api.auth().orElseThrow().require());
         assertEquals(Optional.of("strict"), api.securityFilter().orElseThrow().profile());
         assertEquals(List.of(HttpMethod.GET, HttpMethod.POST), api.allowedMethods());
+        assertEquals(AnchorType.PROXY, api.type(), "the required type axis binds (case-insensitive from 'proxy')");
+        assertEquals(AccessLevel.AUTHENTICATED, api.access(),
+                "the required access axis binds (case-insensitive from 'authenticated')");
     }
 
     @Test
@@ -389,6 +396,8 @@ class ConfigLoaderTest {
                 anchors:
                   api:
                     path_prefix: /api
+                    type: proxy
+                    access: authenticated
                     bogus_key: true
                 """);
 
@@ -407,6 +416,8 @@ class ConfigLoaderTest {
                 anchors:
                   api:
                     path_prefix: /api
+                    type: proxy
+                    access: authenticated
                     auth:
                       require: bearer
                 """);
@@ -437,6 +448,8 @@ class ConfigLoaderTest {
                 anchors:
                   api:
                     path_prefix: /api
+                    type: proxy
+                    access: authenticated
                     auth:
                       require: bearer
                 """);

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
@@ -190,7 +190,7 @@ class ConfigModelContractTest {
                 .effectiveSecurityHeaders(Optional.of(securityHeadersConfig()))
                 .retryEnabled(true)
                 .notModifiedEnabled(true)
-                .upstream(resolvedUpstream())
+                .upstream(Optional.of(resolvedUpstream()))
                 .effectiveForward(new ForwardConfig(List.of("Accept"), List.of("page"), Map.of("X-Gateway", "api-sheriff")))
                 .build();
     }
@@ -324,7 +324,7 @@ class ConfigModelContractTest {
                             RouteConfig.builder().id("other").match(matchConfig()).build()),
                     voCase("ResolvedRoute", resolvedRoute(), resolvedRoute(),
                             ResolvedRoute.builder().id("other").match(matchConfig()).effectiveAuth(auth())
-                                    .upstream(resolvedUpstream()).build()),
+                                    .upstream(Optional.of(resolvedUpstream())).build()),
                     voCase("MatchConfig", matchConfig(), matchConfig(),
                             MatchConfig.builder().pathPrefix("/other").build()),
                     voCase("MatchConfig.HeaderMatcher",
@@ -461,7 +461,7 @@ class ConfigModelContractTest {
         @Test
         void resolvedRouteNormalizesAbsentOptionals() {
             ResolvedRoute cfg = new ResolvedRoute("id", null, null, matchConfig(), auth(), null, null, null, true,
-                    true, resolvedUpstream(), null);
+                    true, Optional.of(resolvedUpstream()), Optional.empty(), null);
             assertTrue(cfg.anchor().isEmpty());
             assertTrue(cfg.effectiveSecurityFilter().isEmpty());
             assertTrue(cfg.effectiveSecurityHeaders().isEmpty());
@@ -619,17 +619,25 @@ class ConfigModelContractTest {
         }
 
         @Test
-        void resolvedRouteRequiresIdMatchAuthAndUpstream() {
+        void resolvedRouteRequiresIdMatchAuthAndExactlyOneTerminalAction() {
             assertThrows(NullPointerException.class, () -> new ResolvedRoute(null, Protocol.HTTP, Optional.empty(),
                     matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true,
-                    resolvedUpstream(), null));
+                    Optional.of(resolvedUpstream()), Optional.empty(), null));
             assertThrows(NullPointerException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(), null,
-                    auth(), List.of(), Optional.empty(), Optional.empty(), true, true, resolvedUpstream(), null));
+                    auth(), List.of(), Optional.empty(), Optional.empty(), true, true, Optional.of(resolvedUpstream()),
+                    Optional.empty(), null));
             assertThrows(NullPointerException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
-                    matchConfig(), null, List.of(), Optional.empty(), Optional.empty(), true, true, resolvedUpstream(),
-                    null));
-            assertThrows(NullPointerException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
-                    matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true, null, null));
+                    matchConfig(), null, List.of(), Optional.empty(), Optional.empty(), true, true,
+                    Optional.of(resolvedUpstream()), Optional.empty(), null));
+            assertThrows(IllegalArgumentException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
+                            matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true, Optional.empty(),
+                            Optional.empty(), null),
+                    "a route with neither an upstream nor an asset terminal action is rejected (XOR)");
+            assertThrows(IllegalArgumentException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
+                            matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true,
+                            Optional.of(resolvedUpstream()), Optional.of(ResolvedAsset.directory("/srv", AccessLevel.PUBLIC)),
+                            null),
+                    "a route with both an upstream and an asset terminal action is rejected (XOR)");
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
@@ -70,6 +70,8 @@ class ConfigModelContractTest {
         return AnchorConfig.builder()
                 .name("api")
                 .pathPrefix("/api")
+                .type(AnchorType.PROXY)
+                .access(AccessLevel.AUTHENTICATED)
                 .auth(Optional.of(auth()))
                 .securityFilter(Optional.of(securityFilterConfig()))
                 .securityHeaders(Optional.of(securityHeadersConfig()))
@@ -268,7 +270,8 @@ class ConfigModelContractTest {
                             new SecurityDefaultsConfig(Optional.of("strict")),
                             new SecurityDefaultsConfig(Optional.of("lenient"))),
                     voCase("AnchorConfig", anchorConfig(), anchorConfig(),
-                            AnchorConfig.builder().name("bff").pathPrefix("/bff").build()),
+                            AnchorConfig.builder().name("bff").pathPrefix("/bff").type(AnchorType.BFF)
+                                    .access(AccessLevel.AUTHENTICATED).build()),
                     voCase("ForwardedConfig",
                             new ForwardedConfig(List.of("10.0.0.0/8"), Optional.of(true), Optional.of("both")),
                             new ForwardedConfig(List.of("10.0.0.0/8"), Optional.of(true), Optional.of("both")),
@@ -378,9 +381,10 @@ class ConfigModelContractTest {
 
         @Test
         void anchorConfigBuilderMatchesConstructor() {
-            AnchorConfig viaCtor = new AnchorConfig("api", "/api", Optional.of(auth()), Optional.empty(),
-                    Optional.empty(), List.of(HttpMethod.GET));
-            AnchorConfig viaBuilder = AnchorConfig.builder().name("api").pathPrefix("/api").auth(Optional.of(auth()))
+            AnchorConfig viaCtor = new AnchorConfig("api", "/api", AnchorType.PROXY, AccessLevel.AUTHENTICATED,
+                    Optional.of(auth()), Optional.empty(), Optional.empty(), List.of(HttpMethod.GET));
+            AnchorConfig viaBuilder = AnchorConfig.builder().name("api").pathPrefix("/api").type(AnchorType.PROXY)
+                    .access(AccessLevel.AUTHENTICATED).auth(Optional.of(auth()))
                     .allowedMethods(List.of(HttpMethod.GET)).build();
             assertEquals(viaCtor, viaBuilder);
         }
@@ -447,7 +451,7 @@ class ConfigModelContractTest {
 
         @Test
         void anchorConfigNormalizesAbsentComponents() {
-            AnchorConfig cfg = new AnchorConfig("api", "/api", null, null, null, null);
+            AnchorConfig cfg = new AnchorConfig("api", "/api", AnchorType.PROXY, AccessLevel.AUTHENTICATED, null, null, null, null);
             assertTrue(cfg.auth().isEmpty());
             assertTrue(cfg.securityFilter().isEmpty());
             assertTrue(cfg.securityHeaders().isEmpty());
@@ -481,7 +485,7 @@ class ConfigModelContractTest {
             assertTrue(new SecurityFilterConfig(null, null, null, null, null, null, null, null, null, null)
                     .allowedPaths().isEmpty());
             assertTrue(new OidcConfig.Csrf(null).trustedOrigins().isEmpty());
-            assertTrue(new AnchorConfig("api", "/api", null, null, null, null).allowedMethods().isEmpty());
+            assertTrue(new AnchorConfig("api", "/api", AnchorType.PROXY, AccessLevel.AUTHENTICATED, null, null, null, null).allowedMethods().isEmpty());
         }
     }
 
@@ -552,15 +556,23 @@ class ConfigModelContractTest {
         }
 
         @Test
-        void anchorConfigRequiresNameAndPathPrefix() {
+        void anchorConfigRequiresNamePathPrefixTypeAndAccess() {
             NullPointerException noName = assertThrows(NullPointerException.class,
-                    () -> new AnchorConfig(null, "/api", Optional.empty(), Optional.empty(), Optional.empty(),
-                            List.of()));
+                    () -> new AnchorConfig(null, "/api", AnchorType.PROXY, AccessLevel.PUBLIC, Optional.empty(),
+                            Optional.empty(), Optional.empty(), List.of()));
             assertEquals("name", noName.getMessage());
             NullPointerException noPrefix = assertThrows(NullPointerException.class,
-                    () -> new AnchorConfig("api", null, Optional.empty(), Optional.empty(), Optional.empty(),
-                            List.of()));
+                    () -> new AnchorConfig("api", null, AnchorType.PROXY, AccessLevel.PUBLIC, Optional.empty(),
+                            Optional.empty(), Optional.empty(), List.of()));
             assertEquals("pathPrefix", noPrefix.getMessage());
+            NullPointerException noType = assertThrows(NullPointerException.class,
+                    () -> new AnchorConfig("api", "/api", null, AccessLevel.PUBLIC, Optional.empty(),
+                            Optional.empty(), Optional.empty(), List.of()));
+            assertEquals("type", noType.getMessage());
+            NullPointerException noAccess = assertThrows(NullPointerException.class,
+                    () -> new AnchorConfig("api", "/api", AnchorType.PROXY, null, Optional.empty(),
+                            Optional.empty(), Optional.empty(), List.of()));
+            assertEquals("access", noAccess.getMessage());
         }
 
         @Test
@@ -660,6 +672,8 @@ class ConfigModelContractTest {
             AnchorConfig cfg = anchorConfig();
             assertEquals("api", cfg.name());
             assertEquals("/api", cfg.pathPrefix());
+            assertEquals(AnchorType.PROXY, cfg.type());
+            assertEquals(AccessLevel.AUTHENTICATED, cfg.access());
             assertEquals(Optional.of(auth()), cfg.auth());
             assertTrue(cfg.securityFilter().isPresent());
             assertTrue(cfg.securityHeaders().isPresent());

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/model/ConfigModelContractTest.java
@@ -443,7 +443,7 @@ class ConfigModelContractTest {
 
         @Test
         void routeConfigNormalizesAbsentAnchor() {
-            RouteConfig cfg = new RouteConfig("id", null, null, matchConfig(), null, null, null, null, null);
+            RouteConfig cfg = new RouteConfig("id", null, null, matchConfig(), null, null, null, null, null, null);
             assertTrue(cfg.anchor().isEmpty());
             assertTrue(cfg.auth().isEmpty());
             assertTrue(cfg.securityFilter().isEmpty());
@@ -611,9 +611,11 @@ class ConfigModelContractTest {
         void routeConfigRequiresIdAndMatch() {
             MatchConfig match = matchConfig();
             assertThrows(NullPointerException.class, () -> new RouteConfig(null, Optional.empty(), Optional.empty(),
-                    match, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+                    match, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty()));
             assertThrows(NullPointerException.class, () -> new RouteConfig("id", Optional.empty(), Optional.empty(),
-                    null, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+                    null, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                    Optional.empty()));
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
@@ -31,6 +31,7 @@ import de.cuioss.sheriff.api.config.load.ConfigError;
 import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
 import de.cuioss.sheriff.api.config.model.AnchorType;
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardedConfig;
@@ -188,6 +189,130 @@ class ConfigValidatorTest {
                 .anchor(anchorName == null ? Optional.empty() : Optional.of(anchorName))
                 .match(match(prefix, methods))
                 .build();
+    }
+
+    private static RouteConfig assetRoute(String id, String prefix, String anchorName, AssetConfig asset,
+            HttpMethod... methods) {
+        return RouteConfig.builder()
+                .id(id)
+                .anchor(anchorName == null ? Optional.empty() : Optional.of(anchorName))
+                .match(match(prefix, methods))
+                .asset(Optional.of(asset))
+                .build();
+    }
+
+    private static AssetConfig directoryAsset(String root) {
+        return AssetConfig.builder().source(AssetConfig.Source.DIRECTORY)
+                .directory(root == null ? Optional.empty() : Optional.of(root)).build();
+    }
+
+    private static AssetConfig upstreamAsset(String alias) {
+        return AssetConfig.builder().source(AssetConfig.Source.UPSTREAM)
+                .upstream(alias == null ? Optional.empty() : Optional.of(alias)).build();
+    }
+
+    @Nested
+    @DisplayName("Terminal-action / anchor-type consistency (ADR-0014)")
+    class TerminalActionConsistency {
+
+        @Test
+        @DisplayName("Should accept a directory asset route under an asset anchor")
+        void shouldAcceptDirectoryAssetUnderAssetAnchor() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("assets",
+                    matrixAnchor("assets", "/assets", AnchorType.ASSET, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("web", "WEB", "assets",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    assetRoute("bundle", "/assets", "assets", directoryAsset("/srv/assets"), HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("WEB"));
+
+            assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should accept an upstream asset route whose alias resolves")
+        void shouldAcceptUpstreamAssetWithResolvableAlias() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("assets",
+                    matrixAnchor("assets", "/assets", AnchorType.ASSET, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("web", "WEB", "assets",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    assetRoute("cdn", "/assets", "assets", upstreamAsset("SECONDARY"), HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("WEB", "SECONDARY"));
+
+            assertTrue(errors.isEmpty(), () -> "expected no violations, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should reject an asset-type anchor route that declares no asset terminal action")
+        void shouldRejectAssetAnchorWithoutAssetBlock() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("assets",
+                    matrixAnchor("assets", "/assets", AnchorType.ASSET, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("web", "WEB", "assets",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    anchoredRoute("noasset", "/assets", "assets", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("WEB"));
+
+            assertHasError(errors, "/endpoint/routes", "declares no asset terminal action");
+        }
+
+        @Test
+        @DisplayName("Should reject an asset block on a route under a proxy anchor")
+        void shouldRejectAssetBlockUnderProxyAnchor() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("api",
+                    matrixAnchor("api", "/api", AnchorType.PROXY, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("api-ep", "API", "api",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    assetRoute("mixed", "/api", "api", directoryAsset("/srv/assets"), HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("API"));
+
+            assertHasError(errors, "/endpoint/routes", "requires an asset-type anchor");
+        }
+
+        @Test
+        @DisplayName("Should reject an asset block on an unanchored route")
+        void shouldRejectAssetBlockOnUnanchoredRoute() {
+            GatewayConfig gateway = validGateway().build();
+            EndpointConfig endpoint = EndpointConfig.builder()
+                    .id("plain").enabled(true).baseUrl("PLAIN")
+                    .auth(Optional.of(new AuthConfig("none", List.of())))
+                    .routes(List.of(assetRoute("loose", "/loose", null, directoryAsset("/srv/assets"), HttpMethod.GET)))
+                    .build();
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("PLAIN"));
+
+            assertHasError(errors, "/endpoint/routes", "the route is unanchored");
+        }
+
+        @Test
+        @DisplayName("Should reject an upstream asset source whose topology alias does not resolve")
+        void shouldRejectUnresolvableUpstreamAssetAlias() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("assets",
+                    matrixAnchor("assets", "/assets", AnchorType.ASSET, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("web", "WEB", "assets",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    assetRoute("cdn", "/assets", "assets", upstreamAsset("MISSING"), HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("WEB"));
+
+            assertHasError(errors, "/endpoint/routes", "does not resolve in the topology");
+        }
+
+        @Test
+        @DisplayName("Should reject a directory asset source that declares no directory root")
+        void shouldRejectDirectoryAssetWithoutRoot() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of("assets",
+                    matrixAnchor("assets", "/assets", AnchorType.ASSET, AccessLevel.PUBLIC, null)));
+            EndpointConfig endpoint = anchoredEndpoint("web", "WEB", "assets",
+                    Optional.of(new AuthConfig("none", List.of())),
+                    assetRoute("bundle", "/assets", "assets", directoryAsset(null), HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("WEB"));
+
+            assertHasError(errors, "/endpoint/routes", "no directory root");
+        }
     }
 
     @Nested

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
@@ -58,6 +58,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link ConfigValidator}: one negative case per enforced cross-cutting
@@ -131,12 +133,36 @@ class ConfigValidatorTest {
     }
 
     private static AnchorConfig anchor(String name, String prefix, String require) {
+        // The ADR-0007 anchor rules (prefix disjointness, namespace membership, auth floor) are
+        // orthogonal to the ADR-0013 access->auth matrix, so these fixtures stay matrix-consistent
+        // by construction: an anchor with no auth floor is access: public (public + no auth block is
+        // matrix-clean), while an anchor carrying a floor is access: authenticated (a non-'none'
+        // floor is what access: authenticated requires).
         return AnchorConfig.builder()
                 .name(name)
                 .pathPrefix(prefix)
                 .type(AnchorType.PROXY)
-                .access(AccessLevel.AUTHENTICATED)
+                .access(require == null ? AccessLevel.PUBLIC : AccessLevel.AUTHENTICATED)
                 .auth(require == null ? Optional.empty() : Optional.of(new AuthConfig(require, List.of())))
+                .build();
+    }
+
+    private static AnchorConfig matrixAnchor(String name, String prefix, AnchorType type, AccessLevel access,
+            String require) {
+        return AnchorConfig.builder()
+                .name(name)
+                .pathPrefix(prefix)
+                .type(type)
+                .access(access)
+                .auth(require == null ? Optional.empty() : Optional.of(new AuthConfig(require, List.of())))
+                .build();
+    }
+
+    private static GatewayConfig gatewayWithAnchorAndIssuer(AnchorConfig anchorConfig) {
+        return validGateway()
+                .anchors(Map.of(anchorConfig.name(), anchorConfig))
+                .tokenValidation(Optional.of(new TokenValidationConfig(List.of(
+                        IssuerConfig.builder().name("main").issuer("https://idp.example").build()))))
                 .build();
     }
 
@@ -786,6 +812,136 @@ class ConfigValidatorTest {
 
             assertTrue(errors.isEmpty(),
                     () -> "sibling anchors sharing only a leading substring must stay disjoint, got: " + errors);
+        }
+    }
+
+    @Nested
+    @DisplayName("The fail-closed access→auth matrix (ADR-0013)")
+    class AccessAuthMatrix {
+
+        @Test
+        @DisplayName("Rule bff→authenticated: Should reject a type 'bff' anchor that is not access: authenticated")
+        void shouldRejectBffAnchorThatIsNotAuthenticated() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "portal", matrixAnchor("portal", "/portal", AnchorType.BFF, AccessLevel.PUBLIC, null)));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/portal", "is type 'bff' and must declare access: authenticated");
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = AnchorType.class, names = {"PROXY", "ASSET"})
+        @DisplayName("Rule public+auth: Should reject an access: public anchor declaring an auth block for any non-bff type")
+        void shouldRejectPublicAnchorDeclaringAuthBlock(AnchorType type) {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "open", matrixAnchor("open", "/open", type, AccessLevel.PUBLIC, "bearer")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/open", "is access: public and must not declare an auth block");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"none", "bearer", "session"})
+        @DisplayName("Rule public+auth: Should reject an access: public anchor for every auth-floor value in the vocabulary")
+        void shouldRejectPublicAnchorForEveryAuthFloorValue(String require) {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "open", matrixAnchor("open", "/open", AnchorType.PROXY, AccessLevel.PUBLIC, require)));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/open", "is access: public and must not declare an auth block");
+        }
+
+        @Test
+        @DisplayName("Rule authenticated→floor: Should reject an access: authenticated anchor declaring no auth floor at all")
+        void shouldRejectAuthenticatedAnchorWithNoAuthBlock() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, null)));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/secure", "declares no non-'none' auth floor");
+        }
+
+        @Test
+        @DisplayName("Rule authenticated→floor: Should reject an access: authenticated anchor whose floor is 'none'")
+        void shouldRejectAuthenticatedAnchorWithNoneFloor() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "none")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/secure", "declares no non-'none' auth floor");
+        }
+
+        @Test
+        @DisplayName("Rule authenticated backing: Should reject an authenticated bearer floor with no token_validation issuer")
+        void shouldRejectAuthenticatedBearerFloorWithoutIssuer() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "bearer")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/secure",
+                    "access: authenticated bearer floor requires token_validation with at least one issuer");
+        }
+
+        @Test
+        @DisplayName("Rule authenticated backing: Should reject an authenticated session floor with no oidc block")
+        void shouldRejectAuthenticatedSessionFloorWithoutOidc() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "session")));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertHasError(errors, "/anchors/secure",
+                    "access: authenticated session floor requires an oidc block");
+        }
+
+        @Test
+        @DisplayName("Should accept a type 'bff' anchor that is access: authenticated with a backed bearer floor")
+        void shouldAcceptAuthenticatedBffWithBackedBearerFloor() {
+            GatewayConfig gateway = gatewayWithAnchorAndIssuer(
+                    matrixAnchor("portal", "/portal", AnchorType.BFF, AccessLevel.AUTHENTICATED, "bearer"));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertTrue(errors.isEmpty(),
+                    () -> "a bff+authenticated anchor with a backed bearer floor must satisfy the matrix, got: " + errors);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = AnchorType.class, names = {"PROXY", "ASSET"})
+        @DisplayName("Should accept an access: public anchor with no auth block for any non-bff type")
+        void shouldAcceptPublicAnchorWithoutAuthBlock(AnchorType type) {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "open", matrixAnchor("open", "/open", type, AccessLevel.PUBLIC, null)));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertTrue(errors.isEmpty(),
+                    () -> "a public anchor declaring no auth block must satisfy the matrix, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should report every matrix violation together in one pass")
+        void shouldAggregateMatrixViolationsInOnePass() {
+            GatewayConfig gateway = gatewayWithAnchors(Map.of(
+                    "portal", matrixAnchor("portal", "/portal", AnchorType.BFF, AccessLevel.PUBLIC, null),
+                    "open", matrixAnchor("open", "/open", AnchorType.PROXY, AccessLevel.PUBLIC, "bearer"),
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, null)));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
+
+            assertAll("all three matrix violations surface together",
+                    () -> assertTrue(errors.size() >= 3, () -> "expected at least three violations, got: " + errors),
+                    () -> assertHasError(errors, "/anchors/portal",
+                            "is type 'bff' and must declare access: authenticated"),
+                    () -> assertHasError(errors, "/anchors/open",
+                            "is access: public and must not declare an auth block"),
+                    () -> assertHasError(errors, "/anchors/secure", "declares no non-'none' auth floor"));
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/validation/ConfigValidatorTest.java
@@ -28,7 +28,9 @@ import java.util.Optional;
 
 import de.cuioss.sheriff.api.config.RouteTableBuilder;
 import de.cuioss.sheriff.api.config.load.ConfigError;
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AnchorConfig;
+import de.cuioss.sheriff.api.config.model.AnchorType;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.EndpointConfig;
 import de.cuioss.sheriff.api.config.model.ForwardedConfig;
@@ -132,6 +134,8 @@ class ConfigValidatorTest {
         return AnchorConfig.builder()
                 .name(name)
                 .pathPrefix(prefix)
+                .type(AnchorType.PROXY)
+                .access(AccessLevel.AUTHENTICATED)
                 .auth(require == null ? Optional.empty() : Optional.of(new AuthConfig(require, List.of())))
                 .build();
     }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 
+import de.cuioss.sheriff.api.asset.AssetSource;
 import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
 import de.cuioss.sheriff.api.asset.PathConfinement;
 import de.cuioss.sheriff.api.asset.UpstreamAssetSource;
@@ -289,7 +290,7 @@ class DispatchStageTest {
             Files.writeString(root.resolve("app.css"), "body{color:red}");
             DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
 
-            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.GET, "/app.css");
+            AssetSource.Served served = DispatchStage.serveAsset(source, HttpMethod.GET, "/app.css");
 
             assertEquals(200, served.status());
             assertEquals("text/css; charset=utf-8", served.headers().get("Content-Type"),
@@ -304,7 +305,7 @@ class DispatchStageTest {
             Files.writeString(root.resolve("app.css"), "body{color:red}");
             DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
 
-            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.HEAD, "/app.css");
+            AssetSource.Served served = DispatchStage.serveAsset(source, HttpMethod.HEAD, "/app.css");
 
             assertEquals(200, served.status());
             assertEquals(0, served.body().length, "a HEAD response carries the governed headers but no body");
@@ -316,7 +317,7 @@ class DispatchStageTest {
             Files.writeString(root.resolve("app.css"), "body{}");
             DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
 
-            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.POST, "/app.css");
+            AssetSource.Served served = DispatchStage.serveAsset(source, HttpMethod.POST, "/app.css");
 
             assertEquals(405, served.status(), "an asset action serves only GET and HEAD");
         }
@@ -331,7 +332,7 @@ class DispatchStageTest {
             UpstreamAssetSource source = new UpstreamAssetSource(upstream, AccessLevel.AUTHENTICATED,
                     new PathConfinement(), fetcher, 1024L);
 
-            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.GET, "/logo.png");
+            AssetSource.Served served = DispatchStage.serveAsset(source, HttpMethod.GET, "/logo.png");
 
             assertEquals(200, served.status());
             assertEquals("image/png", served.headers().get("Content-Type"),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
@@ -22,9 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,6 +37,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 
+import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
+import de.cuioss.sheriff.api.asset.PathConfinement;
+import de.cuioss.sheriff.api.asset.UpstreamAssetSource;
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.events.EventType;
@@ -48,6 +56,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @DisplayName("DispatchStage — stage 6 streamed upstream dispatch")
 class DispatchStageTest {
@@ -267,6 +276,68 @@ class DispatchStageTest {
             // Assert — reusing an already-subscribed one-shot body stream is refused, no re-send
             assertEquals(1, attempts.get(),
                     "a retry that would reuse an already-subscribed one-shot body stream must be refused");
+        }
+    }
+
+    @Nested
+    @DisplayName("asset terminal-action serving")
+    class AssetServing {
+
+        @Test
+        @DisplayName("serves a directory asset over GET behind the gateway response envelope")
+        void servesDirectoryAssetOverGet(@TempDir Path root) throws Exception {
+            Files.writeString(root.resolve("app.css"), "body{color:red}");
+            DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
+
+            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.GET, "/app.css");
+
+            assertEquals(200, served.status());
+            assertEquals("text/css; charset=utf-8", served.headers().get("Content-Type"),
+                    "the gateway sets the content type from its own extension map, not the source");
+            assertEquals("nosniff", served.headers().get("X-Content-Type-Options"));
+            assertEquals("body{color:red}", new String(served.body(), StandardCharsets.UTF_8));
+        }
+
+        @Test
+        @DisplayName("serves a directory asset over HEAD with an empty body")
+        void servesDirectoryAssetOverHead(@TempDir Path root) throws Exception {
+            Files.writeString(root.resolve("app.css"), "body{color:red}");
+            DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
+
+            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.HEAD, "/app.css");
+
+            assertEquals(200, served.status());
+            assertEquals(0, served.body().length, "a HEAD response carries the governed headers but no body");
+        }
+
+        @Test
+        @DisplayName("rejects a non-read verb with 405 on the dispatch path (GET/HEAD-only)")
+        void rejectsNonReadVerb(@TempDir Path root) throws Exception {
+            Files.writeString(root.resolve("app.css"), "body{}");
+            DirectoryAssetSource source = new DirectoryAssetSource(root, AccessLevel.PUBLIC);
+
+            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.POST, "/app.css");
+
+            assertEquals(405, served.status(), "an asset action serves only GET and HEAD");
+        }
+
+        @Test
+        @DisplayName("serves an upstream asset, forcing no-store on an authenticated route through the envelope")
+        void servesUpstreamAssetGoverned() {
+            ResolvedUpstream upstream = new ResolvedUpstream("https", "cdn.internal", 443, "");
+            UpstreamAssetSource.UpstreamFetcher fetcher = target -> new UpstreamAssetSource.UpstreamFetcher.Fetched(
+                    200, Map.of("Content-Type", "text/plain", "Cache-Control", "public"),
+                    "PNGDATA".getBytes(StandardCharsets.UTF_8));
+            UpstreamAssetSource source = new UpstreamAssetSource(upstream, AccessLevel.AUTHENTICATED,
+                    new PathConfinement(), fetcher, 1024L);
+
+            DispatchStage.AssetDispatch served = DispatchStage.serveAsset(source, HttpMethod.GET, "/logo.png");
+
+            assertEquals(200, served.status());
+            assertEquals("image/png", served.headers().get("Content-Type"),
+                    "the gateway overrides the upstream content type from the extension map");
+            assertEquals("no-store", served.headers().get("Cache-Control"),
+                    "an authenticated asset is forced to no-store regardless of the upstream's Cache-Control");
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/GatewayEdgePipelineTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/GatewayEdgePipelineTest.java
@@ -273,7 +273,7 @@ class GatewayEdgePipelineTest {
                 .match(MatchConfig.builder().pathPrefix(pathPrefix).build())
                 .effectiveAuth(AuthConfig.builder().require(require).build())
                 .effectiveAllowedMethods(List.of(methods))
-                .upstream(new ResolvedUpstream("http", "localhost", upstreamPort, ""))
+                .upstream(Optional.of(new ResolvedUpstream("http", "localhost", upstreamPort, "")))
                 .build();
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/GatewayEdgeRouteTest.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -249,7 +250,7 @@ class GatewayEdgeRouteTest {
                 .match(MatchConfig.builder().pathPrefix("/" + id).build())
                 .effectiveAuth(AuthConfig.builder().require(require).build())
                 .effectiveAllowedMethods(List.of(HttpMethod.GET))
-                .upstream(new ResolvedUpstream("https", id + ".example", 443, ""))
+                .upstream(Optional.of(new ResolvedUpstream("https", id + ".example", 443, "")))
                 .build();
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,11 +31,14 @@ import java.util.function.Supplier;
 
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.sheriff.api.asset.DirectoryAssetSource;
+import de.cuioss.sheriff.api.config.model.AccessLevel;
 import de.cuioss.sheriff.api.config.model.AuthConfig;
 import de.cuioss.sheriff.api.config.model.ForwardConfig;
 import de.cuioss.sheriff.api.config.model.HttpMethod;
 import de.cuioss.sheriff.api.config.model.MatchConfig;
 import de.cuioss.sheriff.api.config.model.Protocol;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
 import de.cuioss.sheriff.api.config.model.ResolvedRoute;
 import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteTable;
@@ -60,6 +64,7 @@ class RouteRuntimeAssemblerTest {
     private RouteRuntimeAssembler.SecurityConfigurationFactory securityConfigFactory;
     private RouteRuntimeAssembler.UpstreamClientFactory clientFactory;
     private RouteRuntimeAssembler.ResilienceGuardFactory guardFactory;
+    private RouteRuntimeAssembler.AssetSourceFactory assetSourceFactory;
 
     @BeforeEach
     void setUp() {
@@ -68,6 +73,8 @@ class RouteRuntimeAssemblerTest {
         securityConfigFactory = filter -> SecurityConfiguration.builder().build();
         clientFactory = target -> vertx.createHttpClient();
         guardFactory = shape -> new StoredOnlyGuard();
+        assetSourceFactory = asset -> new DirectoryAssetSource(Path.of(asset.directory().orElse("/tmp")),
+                asset.access());
     }
 
     @AfterEach
@@ -88,7 +95,7 @@ class RouteRuntimeAssemblerTest {
                 route("r1", Protocol.HTTP, "none", Optional.of(sharedFilter), upstream("a.example")),
                 route("r2", Protocol.HTTP, "none", Optional.of(sharedFilter), upstream("a.example"))));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertEquals(1, invocations.get(), "The factory runs once for the shared filter shape");
         assertSame(runtimes.getFirst().getSecurityConfiguration().orElseThrow(),
@@ -105,7 +112,7 @@ class RouteRuntimeAssemblerTest {
                 route("r2", Protocol.HTTP, "none",
                         Optional.of(SecurityFilterConfig.builder().allowedPaths(List.of("/b")).build()), upstream("a.example"))));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertNotSame(runtimes.getFirst().getSecurityConfiguration().orElseThrow(),
                 runtimes.get(1).getSecurityConfiguration().orElseThrow(),
@@ -120,11 +127,13 @@ class RouteRuntimeAssemblerTest {
                 route("r2", Protocol.HTTP, "none", Optional.empty(), upstream("a.example")),
                 route("r3", Protocol.HTTP, "none", Optional.empty(), upstream("b.example"))));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
-        assertSame(runtimes.getFirst().getHttpClient(), runtimes.get(1).getHttpClient(),
+        assertSame(runtimes.getFirst().getHttpClient().orElseThrow(),
+                runtimes.get(1).getHttpClient().orElseThrow(),
                 "Routes sharing an upstream tuple reuse one client");
-        assertNotSame(runtimes.getFirst().getHttpClient(), runtimes.get(2).getHttpClient(),
+        assertNotSame(runtimes.getFirst().getHttpClient().orElseThrow(),
+                runtimes.get(2).getHttpClient().orElseThrow(),
                 "A different upstream tuple gets a distinct client");
     }
 
@@ -135,7 +144,7 @@ class RouteRuntimeAssemblerTest {
                 route("first", Protocol.HTTP, "none", Optional.empty(), upstream("a.example")),
                 route("second", Protocol.GRAPHQL, "bearer", Optional.empty(), upstream("b.example"))));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertEquals(List.of("first", "second"), runtimes.stream().map(RouteRuntime::getId).toList(),
                 "Assembly preserves the longest-prefix-first order");
@@ -146,13 +155,13 @@ class RouteRuntimeAssemblerTest {
     void shouldFailBootForSessionAndUnsupportedProtocols() {
         var session = assertThrows(GatewayException.class, () -> assembler.assemble(
                 new RouteTable(List.of(route("s", Protocol.HTTP, "session", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory), "session auth must fail boot");
+                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "session auth must fail boot");
         var grpc = assertThrows(GatewayException.class, () -> assembler.assemble(
                 new RouteTable(List.of(route("g", Protocol.GRPC, "none", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory), "gRPC must fail boot");
+                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "gRPC must fail boot");
         var websocket = assertThrows(GatewayException.class, () -> assembler.assemble(
                 new RouteTable(List.of(route("w", Protocol.WEBSOCKET, "none", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory), "WebSocket must fail boot");
+                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "WebSocket must fail boot");
 
         assertEquals(EventType.CONFIG_INVALID, session.getEventType(), "session rejection is a config failure");
         assertEquals(EventType.CONFIG_INVALID, grpc.getEventType(), "gRPC rejection is a config failure");
@@ -166,9 +175,9 @@ class RouteRuntimeAssemblerTest {
         RouteTable table = new RouteTable(List.of(ResolvedRoute.builder()
                 .id("scoped").protocol(Protocol.HTTP).match(MatchConfig.builder().pathPrefix("/s").build())
                 .effectiveAuth(auth).effectiveAllowedMethods(List.of(HttpMethod.GET))
-                .upstream(upstream("a.example")).build()));
+                .upstream(Optional.of(upstream("a.example"))).build()));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertTrue(runtimes.getFirst().getRequiredScopes().containsAll(List.of("read", "write")),
                 "Required scopes flow from the effective auth to the runtime");
@@ -183,9 +192,9 @@ class RouteRuntimeAssemblerTest {
                 .id("fwd").protocol(Protocol.HTTP).match(MatchConfig.builder().pathPrefix("/f").build())
                 .effectiveAuth(AuthConfig.builder().require("none").build())
                 .effectiveAllowedMethods(List.of(HttpMethod.GET))
-                .upstream(upstream("a.example")).effectiveForward(forward).build()));
+                .upstream(Optional.of(upstream("a.example"))).effectiveForward(forward).build()));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertEquals(forward, runtimes.getFirst().getEffectiveForward(),
                 "The materialized forward allowlist flows to the runtime unchanged");
@@ -197,10 +206,32 @@ class RouteRuntimeAssemblerTest {
         RouteTable table = new RouteTable(List.of(
                 route("r1", Protocol.HTTP, "none", Optional.empty(), upstream("a.example"))));
 
-        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory);
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory);
 
         assertTrue(runtimes.getFirst().getEffectiveForward().headersAllow().isEmpty(),
                 "An unforwarded route carries an empty, deny-by-default allowlist");
+    }
+
+    @Test
+    @DisplayName("Should assemble an asset route with a live source and no client or guard")
+    void shouldAssembleAssetRouteWithoutClientOrGuard() {
+        ResolvedRoute assetRoute = ResolvedRoute.builder()
+                .id("bundle").protocol(Protocol.HTTP)
+                .match(MatchConfig.builder().pathPrefix("/assets").build())
+                .effectiveAuth(AuthConfig.builder().require("none").build())
+                .effectiveAllowedMethods(List.of(HttpMethod.GET))
+                .asset(Optional.of(ResolvedAsset.directory("/srv/assets", AccessLevel.PUBLIC)))
+                .build();
+        RouteTable table = new RouteTable(List.of(assetRoute));
+
+        List<RouteRuntime> runtimes = assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory,
+                assetSourceFactory);
+
+        RouteRuntime runtime = runtimes.getFirst();
+        assertTrue(runtime.getAssetSource().isPresent(), "an asset route carries a live asset source");
+        assertTrue(runtime.getUpstream().isEmpty(), "an asset route holds no proxy upstream");
+        assertTrue(runtime.getHttpClient().isEmpty(), "an asset route holds no Vert.x client");
+        assertTrue(runtime.getResilienceGuard().isEmpty(), "an asset route holds no resilience guard");
     }
 
     private static ResolvedRoute route(String id, Protocol protocol, String require,
@@ -212,7 +243,7 @@ class RouteRuntimeAssemblerTest {
                 .effectiveAuth(AuthConfig.builder().require(require).build())
                 .effectiveAllowedMethods(List.of(HttpMethod.GET))
                 .effectiveSecurityFilter(filter)
-                .upstream(upstream)
+                .upstream(Optional.of(upstream))
                 .build();
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
@@ -27,7 +27,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 
+import de.cuioss.sheriff.api.config.model.AssetConfig;
 import de.cuioss.sheriff.api.config.model.GatewayConfig;
+import de.cuioss.sheriff.api.config.model.ResolvedAsset;
+import de.cuioss.sheriff.api.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.api.config.model.RouteTable;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
@@ -315,5 +318,90 @@ class ConfigProducerTest {
         assertEquals(1, table.routes().size(), "the asset route is merged into the table");
         assertTrue(table.routes().getFirst().asset().isPresent(),
                 "the asset terminal action is materialized onto the resolved route");
+    }
+
+    /**
+     * A {@code source: upstream} asset route (the {@code /assets/cdn} shape from the integration
+     * config) whose upstream alias is declared in {@code topology.properties} must assemble cleanly
+     * through the startup path. An asset route's upstream is a per-route topology reference that the
+     * proxy-oriented {@code base_url} collection does not see, so {@code ConfigProducer} has to gather
+     * it into the topology-resolution set — otherwise a well-formed upstream asset route is rejected
+     * as unresolved. Asserting the decomposed upstream is materialized onto the route proves the alias
+     * reached the resolver and resolved (ADR-0014).
+     */
+    @Test
+    void shouldAssembleUpstreamAssetRouteWhenAliasIsDeclaredInTopology() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_ASSET_ANCHOR);
+        writeTopology("""
+                WEB_BACKEND=https://web.internal:8443
+                ASSET_ORIGIN=http://asset-origin:80
+                """);
+        writeEndpoint("""
+                endpoint:
+                  id: web
+                  enabled: true
+                  base_url: WEB_BACKEND
+                  anchor: assets
+                  auth:
+                    require: none
+                  routes:
+                    - id: assets-upstream
+                      match:
+                        path_prefix: /assets
+                      asset:
+                        source: upstream
+                        upstream: ASSET_ORIGIN
+                """);
+
+        assertDoesNotThrow(() -> producer.onStartup(null),
+                "an upstream asset route whose alias is declared in the topology must assemble without failing startup");
+        RouteTable table = producer.routeTable();
+        assertEquals(1, table.routes().size(), "the upstream asset route is merged into the table");
+        ResolvedAsset asset = table.routes().getFirst().asset()
+                .orElseThrow(() -> new AssertionError("the asset terminal action is materialized onto the resolved route"));
+        assertEquals(AssetConfig.Source.UPSTREAM, asset.source(), "the resolved asset carries the upstream source");
+        ResolvedUpstream upstream = asset.upstream()
+                .orElseThrow(() -> new AssertionError("the ASSET_ORIGIN alias resolved onto the asset action"));
+        assertEquals("asset-origin", upstream.host(), "the ASSET_ORIGIN alias decomposed to the declared host");
+        assertEquals(80, upstream.port(), "the ASSET_ORIGIN alias decomposed to the declared port");
+    }
+
+    /**
+     * The exact failure CI surfaced: a {@code source: upstream} asset route whose upstream alias is
+     * NOT declared in {@code topology.properties} must abort boot on the startup-event path with the
+     * ADR-0014 topology-resolution violation. The endpoint's own {@code base_url} alias IS declared,
+     * so the sole unresolved reference is the asset upstream — proving the asset alias is validated
+     * against the resolved topology, not merely the endpoints' {@code base_url} set, and that the
+     * violation is reported through {@code onStartup} → {@code buildOnce} → {@code ConfigValidator}.
+     */
+    @Test
+    void shouldFailBootThroughStartupEventWhenUpstreamAssetAliasIsUndeclared() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_ASSET_ANCHOR);
+        writeTopology("WEB_BACKEND=https://web.internal:8443\n");
+        writeEndpoint("""
+                endpoint:
+                  id: web
+                  enabled: true
+                  base_url: WEB_BACKEND
+                  anchor: assets
+                  auth:
+                    require: none
+                  routes:
+                    - id: assets-upstream
+                      match:
+                        path_prefix: /assets
+                      asset:
+                        source: upstream
+                        upstream: ASSET_ORIGIN
+                """);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> producer.onStartup(null),
+                "an upstream asset route whose alias is absent from the topology must abort boot");
+
+        assertTrue(exception.getMessage().contains("Refusing to start"),
+                "the abort should carry the refusing-to-start summary");
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR,
+                "upstream alias 'ASSET_ORIGIN' does not resolve in the topology");
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
@@ -63,6 +63,25 @@ class ConfigProducerTest {
                 "%s": "%s"
             """.formatted(PASSTHROUGH_HOST, PASSTHROUGH_ALIAS);
 
+    /**
+     * A gateway whose single anchor violates the ADR-0013 access→auth matrix: a
+     * {@code type: bff} anchor declared {@code access: public} (a bff surface must be
+     * {@code access: authenticated}). The document is schema-valid — both required
+     * classification axes are present — so the violation is caught by
+     * {@link de.cuioss.sheriff.api.config.validation.ConfigValidator}, not the schema,
+     * which is what makes it exercise the startup-event validation path.
+     */
+    private static final String GATEWAY_WITH_MATRIX_VIOLATION = """
+            version: 1
+            metadata:
+              config_version: "2026-07-13"
+            anchors:
+              portal:
+                path_prefix: /portal
+                type: bff
+                access: public
+            """;
+
     @TempDir
     Path configDir;
 
@@ -177,5 +196,27 @@ class ConfigProducerTest {
 
         assertTrue(exception.getMessage().contains("Refusing to start"),
                 "the abort should carry the refusing-to-start summary");
+    }
+
+    /**
+     * The fail-closed access→auth matrix (ADR-0013) must be enforced on the eager
+     * startup-event path, not only through a direct {@code ConfigValidator} call: a
+     * matrix-violating anchor aborts boot through {@code onStartup} → {@code buildOnce}
+     * → {@code ConfigValidator.validate}. The bff+public anchor is schema-valid, so
+     * reaching the abort proves the validator ran at startup, and the annotated ERROR
+     * record confirms it was the matrix rule that tripped.
+     */
+    @Test
+    void shouldFailBootThroughStartupEventWhenAccessAuthMatrixIsViolated() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_MATRIX_VIOLATION);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> producer.onStartup(null),
+                "a matrix-violating anchor must abort boot on the startup-event path");
+
+        assertTrue(exception.getMessage().contains("Refusing to start"),
+                "the abort should carry the refusing-to-start summary");
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR,
+                "is type 'bff' and must declare access: authenticated");
     }
 }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/quarkus/ConfigProducerTest.java
@@ -82,8 +82,34 @@ class ConfigProducerTest {
                 access: public
             """;
 
+    /**
+     * A gateway with a single {@code type: asset} / {@code access: public} anchor. Paired with an
+     * endpoint whose route declares (or omits) an {@code asset} block, it exercises the ADR-0014
+     * terminal-action consistency rules on the startup-event path: the documents are schema-valid,
+     * so the violation is caught by {@code ConfigValidator}, not the schema.
+     */
+    private static final String GATEWAY_WITH_ASSET_ANCHOR = """
+            version: 1
+            metadata:
+              config_version: "2026-07-13"
+            anchors:
+              assets:
+                path_prefix: /assets
+                type: asset
+                access: public
+            """;
+
     @TempDir
     Path configDir;
+
+    private void writeTopology(String aliasLine) throws IOException {
+        Files.writeString(configDir.resolve("topology.properties"), aliasLine);
+    }
+
+    private void writeEndpoint(String yaml) throws IOException {
+        Files.createDirectories(configDir.resolve("endpoints"));
+        Files.writeString(configDir.resolve("endpoints/web.yaml"), yaml);
+    }
 
     private ConfigProducer producerForGateway(String gatewayYaml) throws IOException {
         Files.writeString(configDir.resolve("gateway.yaml"), gatewayYaml);
@@ -218,5 +244,76 @@ class ConfigProducerTest {
                 "the abort should carry the refusing-to-start summary");
         LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR,
                 "is type 'bff' and must declare access: authenticated");
+    }
+
+    /**
+     * The ADR-0014 terminal-action consistency rules must fire on the eager startup-event path: an
+     * asset-type anchor whose route declares no {@code asset} block aborts boot through
+     * {@code onStartup} → {@code buildOnce} → {@code ConfigValidator.validate}. The documents are
+     * schema-valid (the route is a well-formed proxy route), so reaching the abort proves the
+     * validator ran at startup, and the annotated ERROR record confirms the terminal-action rule
+     * tripped.
+     */
+    @Test
+    void shouldFailBootThroughStartupEventWhenAssetAnchorRouteHasNoAssetAction() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_ASSET_ANCHOR);
+        writeTopology("WEB_BACKEND=https://web.internal:8443\n");
+        writeEndpoint("""
+                endpoint:
+                  id: web
+                  enabled: true
+                  base_url: WEB_BACKEND
+                  anchor: assets
+                  auth:
+                    require: none
+                  routes:
+                    - id: noasset
+                      match:
+                        path_prefix: /assets
+                        methods: ["GET"]
+                """);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> producer.onStartup(null),
+                "an asset-anchor route with no asset action must abort boot");
+
+        assertTrue(exception.getMessage().contains("Refusing to start"),
+                "the abort should carry the refusing-to-start summary");
+        LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR, "declares no asset terminal action");
+    }
+
+    /**
+     * A valid asset route assembles cleanly through the startup path, and its terminal action is
+     * materialized onto the resolved route — the end-to-end YAML → {@code AssetConfig} →
+     * {@code ResolvedAsset} binding through {@code onStartup}.
+     */
+    @Test
+    void shouldAssembleAssetRouteThroughStartupEvent() throws Exception {
+        ConfigProducer producer = producerForGateway(GATEWAY_WITH_ASSET_ANCHOR);
+        writeTopology("WEB_BACKEND=https://web.internal:8443\n");
+        writeEndpoint("""
+                endpoint:
+                  id: web
+                  enabled: true
+                  base_url: WEB_BACKEND
+                  anchor: assets
+                  auth:
+                    require: none
+                  routes:
+                    - id: bundle
+                      match:
+                        path_prefix: /assets
+                        methods: ["GET"]
+                      asset:
+                        source: directory
+                        directory: /srv/assets
+                """);
+
+        assertDoesNotThrow(() -> producer.onStartup(null),
+                "a valid asset route must assemble without failing startup");
+        RouteTable table = producer.routeTable();
+        assertEquals(1, table.routes().size(), "the asset route is merged into the table");
+        assertTrue(table.routes().getFirst().asset().isPresent(),
+                "the asset terminal action is materialized onto the resolved route");
     }
 }

--- a/api-sheriff/src/test/resources/config/anchor-squatter/gateway.yaml
+++ b/api-sheriff/src/test/resources/config/anchor-squatter/gateway.yaml
@@ -1,9 +1,15 @@
-# Anchor-squatter gateway: declares an 'api' anchor owning /api. The sibling
-# endpoints/squatter.yaml places a route inside /api without declaring the anchor,
-# so the ADR-0007 namespace-membership rule refuses the boot (ConfigFailFastTest).
+# Anchor-squatter gateway: declares an 'api' anchor owning /api, carrying the
+# required type/access axes (ADR-0013) so schema validation passes and the boot
+# reaches the semantic namespace check. The sibling endpoints/squatter.yaml places
+# a route inside /api without declaring the anchor, so the ADR-0007
+# namespace-membership rule refuses the boot (ConfigFailFastTest). The anchor is
+# access: public with no auth block, so it stays access->auth matrix consistent and
+# the boot fails only for the squatter reason.
 version: 1
 metadata:
   config_version: "anchor-squatter-test"
 anchors:
   api:
     path_prefix: /api
+    type: proxy
+    access: public

--- a/api-sheriff/src/test/resources/config/anchored/gateway.yaml
+++ b/api-sheriff/src/test/resources/config/anchored/gateway.yaml
@@ -1,21 +1,27 @@
-# Valid api+bff anchored gateway configuration (ADR-0007), consumed by the
-# ConfigValidatorTest positive path and the ConfigFailFastTest clean-boot case.
-# The two anchors own disjoint namespaces (/api, /bff); the api floor is bearer
-# (satisfied by token_validation), the bff floor is the public 'none' posture.
+# Valid api+bff anchored gateway configuration (ADR-0007) carrying the required
+# type/access axes (ADR-0013), consumed by the ConfigValidatorTest positive path
+# and the ConfigFailFastTest clean-boot case. The two anchors own disjoint
+# namespaces (/api, /bff); both declare access: authenticated backed by a bearer
+# floor (satisfied by token_validation), keeping the access->auth matrix consistent
+# (a public bff would trip the 'bff requires authenticated' matrix rule).
 version: 1
 metadata:
   config_version: "anchored-test"
 anchors:
   api:
     path_prefix: /api
+    type: proxy
+    access: authenticated
     auth:
       require: bearer
     security_filter:
       profile: strict
   bff:
     path_prefix: /bff
+    type: bff
+    access: authenticated
     auth:
-      require: none
+      require: bearer
     allowed_methods: [GET, POST]
 token_validation:
   issuers:

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -61,7 +61,10 @@ built* and *how the parts fit together*.
 
 | link:configuration.adoc[Configuration Model]
 | The static, immutable YAML mapping schema: routing, URL/parameter whitelisting,
-  security filtering, TLS (termination and passthrough), and per-route limits.
+  security filtering, TLS (termination and passthrough), and per-route limits. This document
+  has a *dual role* -- it is both the authoritative operator-facing configuration reference
+  (indexed from the link:user/README.adoc[operator guide]) and a design document; it stays
+  under `doc/` and is not relocated into `doc/user/`.
 
 | link:security-threat-model.adoc[Threat Model & CVE-Derived Validation Baseline]
 | Trust boundaries and STRIDE, plus a failure catalogue where every class that produced a

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -157,6 +157,20 @@ implementing it.
   skipped silently -- the configuration validator stays the single authoritative reporter
   of alias-resolvability violations.
   *(Status: accepted.)*
+
+| link:adr/0013-anchor-type-access-axes.adoc[ADR-0013]
+| Anchor type/access axes: two required, orthogonal classification axes on every anchor --
+  `type` (`proxy`/`bff`/`asset`) and `access` (`public`/`authenticated`) -- validated
+  fail-closed at boot, extending link:adr/0007-anchor-scoped-policy.adoc[ADR-0007]. The
+  `passthrough -> proxy` value rename does not touch `tls.passthrough_sni`.
+  *(Status: accepted.)*
+
+| link:adr/0014-asset-serving-terminal-action.adoc[ADR-0014]
+| Asset serving as a second terminal action alongside `upstream`, with `directory` and
+  `upstream` sources (the latter reusing the link:adr/0008-data-plane-transport.adoc[ADR-0008]
+  SSRF-controlled data plane, no parallel fetch stack), a gateway-owned response envelope, and
+  canonicalize-and-confine path safety with auth-before-source-resolution ordering.
+  *(Status: accepted.)*
 |===
 
 == Reading Order

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -102,6 +102,9 @@ link:plan/README.adoc[`plan/`]: base implementation and configuration management
 a doc/code reconciliation & quality-debt sweep, then endpoint anchors, the request pipeline,
 protocol processors, the TLS edge, the two BFF
 variants (server-session first), and release readiness -- the full sequence to the 1.0 cut.
+A later feature plan (link:plan/10-anchor-types-assets.adoc[plan 10]) adds two required anchor
+classification axes (`type`/`access`) with a fail-closed boot matrix and asset serving as a
+second terminal action (`directory` and `upstream` sources).
 Rate limiting is out of scope. Each plan names the design documents that must be read before
 implementing it.
 

--- a/doc/adr/0013-anchor-type-access-axes.adoc
+++ b/doc/adr/0013-anchor-type-access-axes.adoc
@@ -1,0 +1,111 @@
+= ADR-0013 -- Anchor Type and Access Axes
+:toc:
+:toclevels: 2
+
+== Status
+
+Accepted.
+
+== Context
+
+link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007] made the anchor the owner of a URL
+namespace and the carrier of an inherited, non-weakenable policy floor (`auth`,
+`security_filter`, `security_headers`, `allowed_methods`). What an anchor *is* -- a plain
+reverse proxy, a Backend-For-Frontend surface, or a static-asset surface -- and *who may reach
+it* -- an anonymous caller or an authenticated one -- were left implicit, inferred from the
+combination of `auth.require`, the presence of an `oidc` block, and the terminal action wired
+behind the route. Leaving both facts implicit costs a security gateway on two fronts:
+
+* *Fail-open by omission.* An anchor's intended audience lives only in the operator's head. A
+  surface meant to require authentication that is accidentally configured with `require: none`
+  reads as a deliberate public surface -- there is no declared expectation for the validator to
+  contradict, so the boot succeeds and the surface is silently open. This is the same
+  fail-open risk ADR-0007 removed for the *namespace* dimension, still present for the
+  *audience* dimension.
+* *Overloaded auth semantics.* Tying "what kind of surface is this" to the specific auth
+  mechanism couples anchor classification to OAuth/OIDC. A deployment that fronts a purely
+  internal, network-authenticated backend, or that serves public static assets, has no natural
+  place to state its posture without borrowing auth vocabulary that does not fit.
+
+=== Prior art
+
+Two traditions classify routes differently:
+
+* *Infrastructure proxies* (NGINX, Traefik, HAProxy, APISIX) type a route *implicitly and
+  positionally*: the presence of a `proxy_pass`, an `upstream`/`serviceRef`, or a `root`/static
+  directive is what makes a route a proxy or a file server. There is no explicit, mandatory
+  "this is what this route is" declaration, and access control is a bolt-on plugin that is
+  frequently optional -- a route with no auth plugin is simply open.
+* *Application security frameworks* (Spring Security, Jakarta Security, and the OWASP
+  access-control guidance behind them) make access an *explicit, first-class, mandatory* axis:
+  every URL pattern declares `permitAll` / `authenticated` / `hasRole(...)`, and the default
+  posture for an undeclared pattern is deny. The audience of a surface is a declared fact the
+  framework enforces, not an emergent property of which filters happen to be wired.
+
+API Sheriff is a security gateway, not a general-purpose proxy; the application-security
+tradition is the right fit. The audience of a surface, and the kind of surface it is, should be
+*declared* and *enforced at boot*, exactly as ADR-0007 declared and enforced namespace
+membership.
+
+== Decision
+
+Add two *required*, orthogonal classification axes to every anchor:
+
+* `type` (`proxy` \| `bff` \| `asset`) -- what the anchor is. `proxy` is a plain reverse-proxy
+  surface, `bff` a Backend-For-Frontend surface, `asset` a static-asset surface
+  (link:0014-asset-serving-terminal-action.adoc[ADR-0014]). The former `passthrough` `type`
+  value is renamed to `proxy` -- a clean-slate value rename (pre-1.0, no deprecation shim). This
+  is an anchor-`type` value rename only; it does *not* touch the unrelated TLS-L4
+  `tls.passthrough_sni` surface, which keeps its name.
+* `access` (`public` \| `authenticated`) -- who may reach the anchor. `public` is an anonymous
+  surface; `authenticated` requires a fully-backed auth posture.
+
+Both axes are *mandatory on every anchor*; a missing axis is a refused boot. The axes drive a
+fail-closed boot matrix (link:../plan/10-anchor-types-assets.adoc[Plan 10]): `access:
+authenticated` requires an effective non-`none` `require` with its backing block present;
+`access: public` combined with an auth block is a boot failure; `type: bff` requires `access:
+authenticated`. The matrix rules join `ConfigValidator.DEFAULT_RULES` and run on the eager
+startup-event path, collecting all violations in one pass (single-reporter,
+link:../adr/0009-asymmetric-alias-resolution-failure.adoc[ADR-0009]).
+
+Three arguments carry the decision:
+
+. *Non-OAuth extensibility.* An explicit `type` axis lets the gateway grow new terminal
+  behaviours (asset serving now, more later) without overloading auth semantics, and an
+  explicit `access` axis expresses audience independently of the specific mechanism -- a
+  network-authenticated or asset deployment declares its posture without borrowing OAuth
+  vocabulary.
+. *Fail-closed declaration.* Because both axes are required and the matrix is enforced at boot,
+  a surface's intended audience is a declared expectation the validator can contradict. An
+  authenticated surface accidentally left open no longer boots. This extends ADR-0007's
+  fail-closed namespace guarantee to the audience and kind dimensions.
+. *Linear, not combinatorial, growth.* Two orthogonal axes, declared independently, grow
+  linearly as the vocabulary expands -- adding a `type` value or an `access` value is one new
+  enum constant, not a new named "mode" for every type-x-access combination. A single fused
+  "mode" axis would grow combinatorially and re-entangle the two concerns.
+
+== Consequences
+
+* Every anchor gains two required fields; existing anchor-construction sites (model, schema,
+  fixtures, tests) must supply them. This is a breaking config change -- accepted under the
+  pre-1.0 rules.
+* The audience of every surface becomes structural and boot-enforced: an authenticated surface
+  cannot be silently public, and a `bff` surface cannot be public by construction.
+* The `type` axis gives the asset terminal action
+  (link:0014-asset-serving-terminal-action.adoc[ADR-0014]) a declared home without overloading
+  the proxy/BFF vocabulary.
+* `passthrough` disappears as an anchor `type` value; the TLS `tls.passthrough_sni` surface is
+  untouched, so the rename cannot be confused with a TLS-edge change.
+
+== References
+
+* link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007] -- anchor-scoped policy, the decision
+  this extends.
+* link:0014-asset-serving-terminal-action.adoc[ADR-0014] -- the asset terminal action the
+  `asset` type classifies.
+* link:../configuration.adoc[Configuration Model] -- the anchor schema and validation-rules
+  summary the axes extend.
+* link:../plan/10-anchor-types-assets.adoc[Plan 10] -- the implementation plan for the axes and
+  the fail-closed matrix.
+* https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 -- A01 Broken Access
+  Control] -- the deny-by-default, explicit-declaration posture this adopts.

--- a/doc/adr/0014-asset-serving-terminal-action.adoc
+++ b/doc/adr/0014-asset-serving-terminal-action.adoc
@@ -1,0 +1,84 @@
+= ADR-0014 -- Asset Serving as a Second Terminal Action
+:toc:
+:toclevels: 2
+
+== Status
+
+Accepted.
+
+== Context
+
+A route in API Sheriff has one terminal action: proxy the request to an `upstream`. Some
+deployments also need the gateway to *serve assets* directly -- a static bundle from a mounted
+directory, or a file fetched from a backend and re-served under gateway governance -- without
+standing up and securing a separate static-file server behind the proxy. Two forces shape how
+this should be added:
+
+* *Do not fork the data plane.* The gateway already has a hardened upstream client
+  (link:../adr/0008-data-plane-transport.adoc[ADR-0008]): fixed-topology upstream resolution, a
+  scheme allowlist, an `EgressPolicy`, `followRedirects(NEVER)`, a circuit breaker, and bounded
+  size/timeout. A "fetch a file from upstream" feature that grew its own HTTP client would
+  duplicate -- and inevitably drift from -- those SSRF controls. GW-05 in the
+  link:../security-threat-model.adoc[threat model] (SSRF via proxy/upstream control) is only
+  closed if every outbound fetch rides the same controlled path.
+* *File paths are a traversal surface.* Serving files introduces a path-traversal class the
+  threat model currently rates covered only for config-path handling. Encoded traversal,
+  encoded slashes, mixed/double encoding, `%00`, overlong sequences, backslashes, and `..;/`
+  are all spellings of the same escape; a control that blocks one spelling but not the class is
+  the Gravitee double-patch cautionary tale.
+
+== Decision
+
+Add *asset serving* as a second terminal action alongside `upstream`, with a two-source model:
+
+* `source: directory` -- serve from a local directory / volume mount (no classpath-embedded
+  resources; out of scope). Resolve the confined path under the configured directory root and
+  stream the file with bounded size.
+* `source: upstream` -- serve from an upstream target *reusing the existing upstream model*
+  (resolved `base_url` + `upstream.path` + remainder), the shared data-plane client, the circuit
+  breaker, `upstream_defaults`, and the SSRF controls -- *no parallel fetch stack*.
+
+Two cross-cutting rules govern both sources:
+
+* *Canonicalize-and-confine, before the source is touched.* The request path is canonicalized
+  through `cui-http`'s `URLPathValidationPipeline` (percent-decoding, `..`/dot-segment and
+  duplicate-slash collapse, unconditional traversal/`%00`/overlong/backslash rejection), then
+  the normalized path is confined to the configured root/prefix and any escape is rejected. The
+  confinement is proven against a generator-driven adversarial corpus that closes the *class*,
+  not a single spelling.
+* *Auth before source resolution.* Access is enforced before the source is resolved, so an
+  unauthorized request never causes a directory read or an upstream fetch.
+
+Both sources serve through a single *gateway-owned response envelope*: a fixed content-type map
+(the gateway sets the type, never the source), `X-Content-Type-Options: nosniff`, governed
+caching that forces `no-store` for `access: authenticated` regardless of source, stripped
+`Set-Cookie`, and GET/HEAD-only enforcement. For the `upstream` source the envelope is what lets
+the gateway override a hostile upstream `Content-Type`, strip an upstream `Set-Cookie`, and force
+`no-store` on an authenticated asset even when the upstream sent `Cache-Control: public`.
+
+== Consequences
+
+* The upstream asset source inherits every ADR-0008 / GW-05 control for free; there is one
+  outbound path to audit, not two. A hostile or compromised upstream cannot dictate the
+  gateway's response metadata.
+* Path traversal is closed for the whole asset surface by canonicalize-then-contain plus the
+  adversarial corpus; the threat-model path-traversal entry is reopened and re-closed to reflect
+  the new surface (link:../plan/10-anchor-types-assets.adoc[Plan 10]).
+* Asset serving gets a declared home through the `asset` anchor `type`
+  (link:0013-anchor-type-access-axes.adoc[ADR-0013]); an asset surface's audience is boot-enforced
+  like any other anchor.
+* A route still carries at most one terminal action -- `upstream` or `asset`, never both.
+* Classpath-embedded resources and any parallel outbound HTTP stack are explicitly out of scope.
+
+== References
+
+* link:../adr/0008-data-plane-transport.adoc[ADR-0008] -- the upstream client and SSRF controls
+  the `upstream` source reuses.
+* link:0013-anchor-type-access-axes.adoc[ADR-0013] -- the `asset` anchor `type` this action
+  classifies, and the access axis the envelope's caching keys on.
+* link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007] -- the anchor policy floor asset routes
+  inherit.
+* link:../security-threat-model.adoc[Threat Model] -- the path-traversal class and GW-05 this
+  decision reopens and closes.
+* link:../plan/10-anchor-types-assets.adoc[Plan 10] -- the implementation plan for the asset
+  action, its sources, envelope, and path safety.

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -76,7 +76,9 @@ forward-policy allowlists. See link:configuration.adoc#_security_filtering[Secur
 
 === Routing / Matching
 
-A static, immutable route table maps inbound requests to exactly one upstream. Matchers are
+A static, immutable route table maps inbound requests to exactly one route, and each route to
+exactly one *terminal action* -- a proxied `upstream` or a served `asset` (see "Asset Terminal
+Action"), never both. Matchers are
 bounded and composable with AND semantics (path prefix, HTTP method, host, header
 presence/value). The most specific matching route wins; a request that matches no route is rejected
 with `404` (deny-by-default). Routes from all endpoint files form one table ordered
@@ -214,6 +216,41 @@ the body. The `502`/`503`/`504` failure mapping is driven by the gateway's own e
 from the Vert.x client / fault-tolerance guard outcomes
 (link:adr/0008-data-plane-transport.adoc[ADR-0008]) -- `HttpResult` does not appear on the
 data plane.
+
+=== Asset Terminal Action
+
+Serving static content is the *second terminal action* a route can resolve to
+(link:adr/0014-asset-serving-terminal-action.adoc[ADR-0014]), alongside the proxy action above.
+An asset route runs the same fixed pipeline as a proxy route -- the stage-0 response-header and
+CORS-preflight preparation, the baseline security filter, route selection, the verb gate, the
+thorough checks, and *authentication* -- and only diverges at the terminal step: instead of the
+streamed upstream dispatch, the request is served by the route's boot-built *asset source* (a
+local-directory reader or a secondary-origin fetcher) and the buffered, governed response is
+written back.
+
+Three properties define the action:
+
+* *Auth before source resolution.* Because authentication is a pipeline stage that runs *before*
+  the terminal dispatch, an unauthorized request to an `access: authenticated` asset is rejected
+  `401` and no byte is ever read -- the source is never touched until authorization succeeds. The
+  ordering is structural, not a per-source check.
+* *A shared, gateway-owned response envelope.* Both sources serve through one envelope so the
+  gateway -- never the backing directory or the (possibly hostile) upstream -- governs the
+  response metadata: the `Content-Type` is set from the gateway's own extension map, `nosniff`
+  is always added, any source `Set-Cookie` is stripped, and an `access: authenticated` asset is
+  forced to `Cache-Control: no-store`. Only `GET`/`HEAD` are served. The untrusted request
+  sub-path is canonicalized and confined under the configured root before the source is touched,
+  closing the path-traversal class for the whole asset surface.
+* *The upstream source reuses the existing data plane.* A `source: upstream` asset resolves its
+  target through the same fixed-topology upstream model the proxy action uses (resolved
+  `base_url` + remainder) and rides the same SSRF controls -- a scheme allowlist,
+  `followRedirects(NEVER)`, and a bounded response size/timeout -- so there is *one* outbound
+  path to audit, not two. There is no parallel fetch stack: GW-05 in the threat model stays
+  closed because every outbound fetch rides the one controlled egress.
+
+Unlike a proxied body, an asset response is small and bounded, so it is buffered and re-served
+under the envelope rather than streamed; the streaming, never-materialize contract (ADR-0006)
+governs the *proxy* data plane specifically.
 
 [[_event_system]]
 == Event System

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -192,12 +192,24 @@ allowed_methods: [GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS]   # positive HTT
 anchors:                           # OPTIONAL namespace-scoped policy (see "Anchors"); each
   api:                             #   anchor OWNS a disjoint path namespace and carries the
     path_prefix: /api              #   policy floor for every route inside it
+    type: proxy                    # MANDATORY classification axis (proxy | bff | asset); `proxy`
+                                   #   is the former `passthrough` value, renamed (see "Type and
+                                   #   access axes"). Unrelated to tls.passthrough_sni.
+    access: authenticated          # MANDATORY audience axis (public | authenticated); a bearer
+                                   #   floor is what `authenticated` requires
     auth: { require: bearer }      # every /api route presents a bearer token; a member route
                                    #   may replace this block but never weaken it to `none`
     security_filter: { profile: strict }
   bff:
     path_prefix: /bff
+    type: bff                      # a bff surface MUST declare access: authenticated
+    access: authenticated
     auth: { require: session }     # the BFF surface: mediated OIDC session per the oidc block
+  static:                          # an asset surface (see "Asset terminal action")
+    path_prefix: /static
+    type: asset
+    access: public                 # a public anchor declares NO auth block (public is the
+                                   #   absence of auth); an auth block here fails the boot
 
 forwarded:                         # resolved by cui-http (de.cuioss.http.forwarded)
   trusted_proxies: [10.0.0.5/32, 10.0.0.6/32]   # MANDATORY; the exact proxy addresses --
@@ -305,6 +317,35 @@ under `/api` with bearer *and* under `/bff` with a session -- is *two routes* (i
 endpoint file, sharing the `base_url` alias), one per anchor. Multi-anchor membership does not
 exist; it would reintroduce merge-order ambiguity.
 
+=== Type and access axes
+
+Every anchor carries two *mandatory* classification axes (decision:
+link:adr/0013-anchor-type-access-axes.adoc[ADR-0013]), orthogonal to one another and to the
+policy blocks above:
+
+* *`type`* -- what terminal behaviour the anchor's routes expose: `proxy` (a reverse-proxy
+  surface), `bff` (a Backend-For-Frontend surface), or `asset` (a static-asset surface, see
+  "Asset terminal action"). `proxy` is the *former `passthrough` value, renamed*; this is an
+  anchor-`type` value rename only and does *not* touch the unrelated TLS-L4 `tls.passthrough_sni`
+  surface, which keeps its name.
+* *`access`* -- the audience the anchor admits: `public` (an anonymous surface, no
+  authentication) or `authenticated` (requires a fully-backed auth posture).
+
+The two axes are enforced fail-closed at boot by the *access -> auth matrix*, which aggregates
+every violation in the single validation pass (never fails fast):
+
+* A `type: bff` anchor *must* declare `access: authenticated` -- a BFF surface is authenticated
+  by construction.
+* An `access: authenticated` anchor *must* declare a non-`none` auth floor whose backing block is
+  present: a `bearer` floor needs `token_validation` with at least one issuer; a `session` floor
+  needs an `oidc` block.
+* An `access: public` anchor *must not* declare an `auth` block at all -- public is the *absence*
+  of auth, so the `require: none` posture lives on the endpoint (or route) rather than the anchor.
+
+Like the policy blocks, the axes vanish at runtime: `type` selects the route's terminal action
+during route-table assembly and `access` is materialized onto each asset route's response
+envelope; the request pipeline never consults an anchor.
+
 == Endpoint Configuration Files (`endpoints/*.yaml`)
 
 One file per endpoint (service / host / app) or logical group. The file binds to a single
@@ -395,6 +436,55 @@ endpoint:
         headers_allow: [content-type]
       upstream: { path: /realms/main/protocol/openid-connect/token }
 ----
+
+=== Asset terminal action
+
+A route carries *exactly one terminal action*: it either proxies to an `upstream` (every example
+above) *or* serves static content through an `asset` block -- `upstream` and `asset` are mutually
+exclusive (decision: link:adr/0014-asset-serving-terminal-action.adoc[ADR-0014]). An asset route
+rides an `type: asset` anchor; declaring an `asset` block on a non-asset route, or omitting it on
+an asset-anchor route, fails the boot.
+
+The `asset` block selects one of two sources:
+
+[source,yaml]
+----
+# endpoints/assets.yaml -- routes under an `type: asset` anchor
+routes:
+  - id: bundle                       # a local directory / volume mount
+    match: { path_prefix: /static/app }
+    asset:
+      source: directory              # directory | upstream
+      directory: /srv/app-bundle     # the configured root; the request sub-path is confined
+                                     #   UNDER this root and any escape is a 404. No
+                                     #   classpath-embedded resources.
+  - id: cdn                          # a secondary origin
+    match: { path_prefix: /static/cdn }
+    asset:
+      source: upstream               # reuses the existing upstream model -- the resolved
+      upstream: ASSET_ORIGIN         #   base_url + remainder -- the shared data-plane client and
+                                     #   the SSRF controls (scheme allowlist, followRedirects
+                                     #   NEVER, bounded size/timeout). No parallel fetch stack.
+----
+
+Two cross-cutting rules govern *both* sources:
+
+* *Canonicalize-and-confine, before the source is touched.* The request sub-path is canonicalized
+  through cui-http's `URLPathValidationPipeline` (percent-decoding, `..`/dot-segment and
+  duplicate-slash collapse, unconditional traversal / `%00` / overlong / backslash rejection),
+  then confined to the configured root / synthetic base; any escape is a `404`. No file is opened
+  and no upstream is fetched for a rejected path.
+* *Auth before source resolution.* The route's effective auth (materialized from its `access`
+  axis and auth floor) is enforced at stage 4 *before* the source is resolved, so an unauthorized
+  request to an `access: authenticated` asset is rejected `401` and never triggers a directory
+  read or an upstream fetch.
+
+Every served response passes through the *gateway-owned response envelope*, so the gateway -- never
+the backing directory or upstream -- governs the response metadata: the `Content-Type` is set from
+the gateway's own extension map (overriding whatever the source claimed), `X-Content-Type-Options:
+nosniff` is always added, any source `Set-Cookie` is stripped, and an `access: authenticated`
+asset is forced to `Cache-Control: no-store` even when the source sent `Cache-Control: public`.
+Only `GET` and `HEAD` are served; any other verb is rejected `405`.
 
 === Route ordering
 

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -1,0 +1,50 @@
+= API Sheriff -- Contributor Guide
+:toc:
+:toclevels: 2
+:sectnums:
+
+The *contributor layer* of the API Sheriff documentation. These documents are written for the
+people who *build* the gateway -- compiling and testing the modules, understanding the module
+layout, and following the project conventions. They describe how the codebase is put together
+and how to work in it, distinct from the link:../README.adoc[design documentation] (which
+defines *what* is built) and the link:../user/README.adoc[operator guide] (which describes how
+to *run* the finished gateway).
+
+This tree is seeded here and grows as contributor-facing material lands.
+
+== Contents
+
+[cols="1,3"]
+|===
+| Document | Purpose
+
+| link:../plan/README.adoc[Implementation Plans]
+| The sequenced plans that build the design, each naming its required-reading design docs, the
+  shared execution workflow, and the project *conventions* (integration-tests-in-plan,
+  benchmarks, dependency approvals, the three-layer documentation convention, pre-1.0 rules).
+
+| link:../technical_aspects.adoc[Technical Aspects]
+| The CUI libraries the codebase builds on -- `cui-http` (inbound security filtering,
+  forwarded-header resolution), `token-sheriff-validation`, `token-sheriff-client`, logging and
+  testing -- and how they are wired in.
+
+| link:../adr/0005-module-structure.adoc[ADR-0005 -- Module Structure]
+| Why the project is one Quarkus module today, with a package-layout + arch-gate seam kept
+  clean so a core module is cheap to extract later.
+|===
+
+== Scope of This Layer
+
+Documents in `doc/development/` cover:
+
+* *Build* -- the Maven module structure (`api-sheriff`, `integration-tests`, `benchmarks`) and
+  the canonical build commands.
+* *Test* -- the unit, module, and integration test layers, the CUI test generator, and the
+  coverage floor.
+* *Module layout* -- package structure, the framework-agnostic seam
+  (link:../adr/0005-module-structure.adoc[ADR-0005]), and the arch-gate that guards it.
+* *Conventions* -- the project-wide rules recorded in the link:../plan/README.adoc[plan
+  conventions] and `CLAUDE.md`.
+
+Design rationale lives in the link:../README.adoc[design documentation]; this layer describes
+how to *work in* the codebase that implements it.

--- a/doc/plan/10-anchor-types-assets.adoc
+++ b/doc/plan/10-anchor-types-assets.adoc
@@ -1,0 +1,252 @@
+= Plan 10 -- Anchor Type/Access Axes and Asset-Serving Terminal Action
+:toc:
+:toclevels: 3
+:sectnums:
+
+[IMPORTANT]
+====
+*Ordering: this plan extends anchors (link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007],
+Plan 03) and reuses the upstream data plane (Plan 04).* It adds two mandatory classification
+axes to every anchor and a second terminal action; both build on a materialized route table
+and the existing SSRF-controlled upstream client, so they land after those two plans are in
+place. It is independent of the BFF track (Plans 07/08).
+====
+
+== Goal
+
+Add two *required* declaration axes to every `gateway.yaml` anchor and a second terminal
+action to the route table:
+
+* `type` (`proxy` \| `bff` \| `asset`) and `access` (`public` \| `authenticated`) -- both
+  mandatory on every anchor, validated fail-closed at boot. The former `passthrough` anchor
+  `type` value is renamed to `proxy` (a clean-slate value rename, no deprecation shim); this
+  is an anchor-`type` rename only and does *not* touch the unrelated TLS-L4 `tls.passthrough_sni`
+  surface.
+* *Asset serving* as a second terminal action alongside `upstream`, with two sources --
+  `directory` (a local mount) and `upstream` (reusing the existing upstream model, data-plane
+  client, circuit breaker, and SSRF controls -- no parallel fetch stack). Both sources apply
+  canonicalize-and-confine path safety before the source is touched and enforce auth *before*
+  source resolution, and both serve through a single gateway-owned response envelope.
+
+The plan is authored *doc-first*: this design doc and the two ADRs land before the code that
+implements them. All nine deliverable groups (below) ship in this one plan -- the operator
+explicitly declined an (A)/(B) split.
+
+== Required Reading (before implementation)
+
+Read these documents *in full* before touching code; the semantics are specified there, not
+here:
+
+. link:../adr/0007-anchor-scoped-policy.adoc[ADR-0007 -- Anchor-Scoped Policy] -- the anchor
+  concept this plan extends: namespace-scoped policy floor, single declared membership,
+  wholesale replacement, boot-time erasure into the route table.
+. link:../configuration.adoc[Configuration Model] -- the anchor and route schema this plan
+  extends, the validation-rules conventions (collect *all* violations, single authoritative
+  reporter per link:../adr/0009-asymmetric-alias-resolution-failure.adoc[ADR-0009]), and the
+  `upstream` terminal action the asset action sits beside.
+. link:../adr/0008-data-plane-transport.adoc[ADR-0008 -- Data-Plane Transport] -- the shared
+  upstream client, resilience guards, and streaming model the `upstream` asset source reuses.
+. link:../security-threat-model.adoc[Threat Model] -- the path-traversal failure class
+  (currently rated covered for config-path handling) that the asset file-path surface
+  reopens, and GW-05 (SSRF via proxy/upstream control).
+. link:../architecture.adoc[Architecture] -- the request lifecycle and terminal-action seam
+  the asset action plugs into.
+
+The two ADRs this plan records -- ADR-0013 (anchor type/access axes) and ADR-0014
+(asset-serving terminal action) -- are authored as deliverable group 1 below; they become
+required reading for every later group in this plan.
+
+== Prerequisites
+
+* Plan 03 delivered: anchors are parsed, validated, and materialized into the route table
+  through `ConfigValidator.DEFAULT_RULES` and `RouteTableBuilder`.
+* Plan 04 delivered: the upstream data plane (fixed-topology upstream resolution, scheme
+  allowlist, `EgressPolicy`, `followRedirects(NEVER)`, circuit breaker, bounded size/timeout)
+  the `upstream` asset source reuses.
+* Boot validation is already forced eagerly through
+  `ConfigProducer.onStartup(@Observes StartupEvent)` -> `buildOnce()` ->
+  `ConfigValidator.validate(...)`; the new matrix rules join `DEFAULT_RULES` and run on that
+  same startup-event path (no lazy-CDI-proxy inertness, the failure mode PR #82 surfaced).
+* `cui-http`'s `URLPathValidationPipeline` is on the classpath (inbound path canonicalization:
+  percent-decoding, `..`/dot-segment and duplicate-slash collapse, unconditional
+  traversal/`%00`/overlong/backslash rejection).
+
+== Design Decisions
+
+Recorded in ADR-0013 / ADR-0014 (this plan) and the configuration/architecture docs; restated
+here only as implementation directives. Each `Dn` maps to one deliverable group.
+
+=== D1 -- Record the ADRs (type/access axes, asset terminal action)
+
+* ADR-0013 records the three-argument rationale for two *explicit* axes -- non-OAuth
+  extensibility, fail-closed declaration, and linear (not combinatorial) growth -- plus the
+  prior-art survey contrasting infrastructure proxies (implicit/positional route typing) with
+  application security frameworks (explicit access declaration). It cross-references ADR-0007,
+  which it extends.
+* ADR-0014 records asset serving as a second terminal action: the two-source model, the
+  reuse of the existing upstream model/client/circuit-breaker/SSRF controls (no parallel fetch
+  stack), the gateway-owned response envelope, and canonicalize-and-confine with
+  auth-before-source-resolution ordering.
+* Both ADRs are registered in link:../README.adoc[the documentation index]'s Architecture
+  Decisions table.
+
+=== D2 -- Required `type`/`access` axes on the anchor model and schema
+
+* New enum `AnchorType` (`proxy` \| `bff` \| `asset`) and `AccessLevel`
+  (`public` \| `authenticated`), following the existing `HttpMethod`/`Protocol` enum
+  conventions (`public` maps to a Java-safe constant name -- it is a reserved word).
+* `AnchorConfig` gains required `AnchorType type` and `AccessLevel access` components,
+  non-null-enforced in the canonical constructor (both mandatory on *every* anchor).
+* `gateway.schema.json` adds `type` and `access` to the `anchors` object, both `required`.
+  The `passthrough -> proxy` rename is a `type` *value* rename here; `tls.passthrough_sni` is
+  untouched.
+* Existing-consumer sweep: every test that constructs an `AnchorConfig` now supplies the two
+  new mandatory fields; the anchor-bearing YAML fixtures gain matrix-consistent `type`/`access`
+  axes (a `public` `bff` would trip the D3 rule, so positive fixtures stay matrix-consistent).
+
+=== D3 -- Fail-closed access->auth matrix on the startup-event path
+
+Add these rules to `ConfigValidator.DEFAULT_RULES` (collect into the shared `errors` list with
+file/pointer context, never fail-fast -- ADR-0009 single-reporter):
+
+. `access` is required on every anchor (schema/model enforce the structural default; the
+  validator asserts the resolved posture agrees);
+. `access: authenticated` requires a fully-backed auth posture (an effective non-`none`
+  `require` with its backing block present, reusing the existing
+  `effectiveAuth`/`validateEffectiveAuth` machinery);
+. `access: public` combined with an auth block is a boot failure;
+. `type: bff` requires `access: authenticated`.
+
+The rules are proven enforced through the *startup-event path* (`ConfigProducerTest` asserting
+`buildOnce()` aborts boot on an invalid matrix), not only a direct `ConfigValidator` call.
+
+=== D4 -- Asset terminal-action config, response envelope, and path-confinement core
+
+* `AssetConfig` -- the asset terminal-action config record: `source` (`directory` \|
+  `upstream`) plus source-specific fields. `RouteConfig` gains `Optional<AssetConfig> asset`
+  (a route carries at most one terminal action; existing `upstream` sites default to empty).
+  `endpoint.schema.json` adds the `asset` block with the `source` discriminator.
+* `AssetResponseEnvelope` -- the gateway-owned response envelope: fixed content-type map,
+  `X-Content-Type-Options: nosniff`, governed caching that forces `no-store` for
+  `access: authenticated` regardless of source, stripped `Set-Cookie`, GET/HEAD-only
+  enforcement.
+* `PathConfinement` -- canonicalize-and-confine: reuse `cui-http` `URLPathValidationPipeline`
+  for canonicalization, then confine the normalized path to the configured root/prefix (reject
+  any escape), applied *before* the source is touched.
+* `AssetSource` -- the sealed source seam permitting `DirectoryAssetSource` and
+  `UpstreamAssetSource` (D5/D6); it defines the auth-before-source-resolution ordering
+  contract.
+* The path-safety corpus is generator-driven (`@GeneratorsSource`): encoded traversal, encoded
+  slash, mixed/double encoding, `%00`, overlong, backslash, `..;/`, trailing-slash variants --
+  proving no path escapes confinement (closes the *class*, not one spelling).
+
+=== D5 -- Asset source: local directory
+
+`DirectoryAssetSource` serves from a local directory / volume mount (no classpath-embedded
+resources -- out of scope) through the shared `PathConfinement` and `AssetResponseEnvelope`:
+resolve the confined path under the configured directory root and stream the file with bounded
+size. Tests assert in-root serving, out-of-root denial, content-type resolution from the fixed
+map, and `no-store` forcing for authenticated access.
+
+=== D6 -- Asset source: upstream (reusing the SSRF-controlled data plane)
+
+`UpstreamAssetSource` serves from an upstream target reusing the existing upstream model
+(resolved `base_url` + `upstream.path` + remainder), the shared data-plane client, the circuit
+breaker, `upstream_defaults`, and the SSRF controls (fixed-topology upstream, scheme allowlist,
+`EgressPolicy`, `followRedirects(NEVER)`) plus bounded response size and timeout -- *no parallel
+fetch stack*. It applies `PathConfinement` to the remainder before the upstream is touched, and
+passes the response through `AssetResponseEnvelope` so the gateway overrides a hostile upstream
+`Content-Type`, strips `Set-Cookie`, and forces `no-store` on an authenticated asset even when
+the upstream sent `Cache-Control: public`. Governance tests use MockWebServer /
+`@ModuleDispatcher`.
+
+=== D7 -- Reopen and close the path-traversal threat-model entry
+
+Reopen the path-traversal entry (currently rated covered/eliminated for config-path handling)
+to account for the new asset-serving file-path surface; document that the class is closed for
+*both* sources via canonicalize-then-contain (`cui-http` `URLPathValidationPipeline` + gateway
+confinement) plus the generator-driven regression corpus (D4), citing the assertion. Review
+GW-05 (SSRF via proxy features / upstream control) and add an upstream-asset-source clause
+noting the reuse of fixed-topology upstream, scheme allowlist, `EgressPolicy`, and
+`followRedirects(NEVER)`. Update the validation matrix rows and statuses accordingly.
+
+=== D8 -- Integration tests: real mounted directory and real secondary server
+
+Two ITs under the established `de/cuioss/sheriff/api/integration/` package:
+`DirectoryAssetServingIT` (a real mounted directory / volume) and `UpstreamAssetServingIT` (a
+real secondary upstream server). The compose stack gains a mounted asset directory and a
+secondary static/upstream server (siblings: `docker-compose.jfr.yml`,
+`docker-compose.benchmark.yml`, `docker-compose.apisix.yml`); the IT gateway config
+(`integration-tests/src/main/docker/sheriff-config/gateway.yaml`) gains `type: asset` anchors
+with both `access` levels and routes for the two sources, plus the `type`/`access` axes on
+existing anchors. Per the *integration-tests-are-part-of-the-plan* convention, both sources are
+exercised end-to-end, positive and negative paths.
+
+=== D9 -- Document the axes and asset action in the reference/design docs
+
+* `configuration.adoc`: document the required `type`/`access` axes, the access->auth matrix
+  rules, the `passthrough -> proxy` value rename, and the asset terminal action with both
+  sources and its response-envelope / path-safety governance. Keep the dual reference/design
+  voice (per the Plan-01 documentation-tree classification fix).
+* `architecture.adoc`: document asset serving as a second terminal action in the request
+  lifecycle, the auth-before-source-resolution ordering, and the shared gateway-owned response
+  envelope; note the upstream-source reuse of the existing data plane (no parallel fetch stack).
+
+== Work Breakdown
+
+. *ADRs* (D1) -- ADR-0013 and ADR-0014, registered in link:../README.adoc[the doc index].
+. *Anchor axes* (D2) -- `AnchorType`/`AccessLevel` enums, `AnchorConfig` extension, schema
+  `required` axes, `passthrough -> proxy` rename, existing-consumer test + fixture sweep.
+. *Access->auth matrix* (D3) -- the four `DEFAULT_RULES`, generator-driven unit tests, and the
+  startup-event-path assertion in `ConfigProducerTest`.
+. *Asset core* (D4) -- `AssetConfig`/`RouteConfig` + `endpoint.schema.json`,
+  `AssetResponseEnvelope`, `PathConfinement`, the sealed `AssetSource` seam,
+  `package-info.java`, and the adversarial confinement + envelope-governance tests.
+. *Directory source* (D5) -- `DirectoryAssetSource` + tests.
+. *Upstream source* (D6) -- `UpstreamAssetSource` + governance/SSRF-reuse tests.
+. *Threat model* (D7) -- reopen/close the path-traversal entry and the GW-05 clause.
+. *Integration tests* (D8) -- the two asset ITs, the compose stack additions, and the IT
+  gateway config.
+. *Reference docs* (D9) -- `configuration.adoc` and `architecture.adoc`.
+
+== Execution Workflow
+
+Standard workflow per link:README.adoc#_execution_workflow_every_plan[the plan README];
+branch `feature/anchor-types-assets`. Doc-first: the ADRs and this design doc land before the
+code groups; the design docs govern, this plan only sequences. Deviations discovered during
+implementation are fixed in the design docs in the same PR, never silently in code.
+
+== Acceptance Criteria
+
+* Every anchor requires both `type` and `access`; a missing axis is a binding/validation
+  failure. No residual `passthrough` anchor `type` vocabulary remains; `tls.passthrough_sni`
+  is untouched.
+* Each of the four matrix conditions produces a boot failure with a file/pointer-annotated
+  `ConfigError`, aggregated in one pass, and is proven enforced via the startup-event path.
+* Canonicalize-and-confine is applied before any source access and rejects the full
+  adversarial corpus (the *class*, not one spelling). The response envelope forces `no-store`
+  for authenticated assets, strips `Set-Cookie`, sets `nosniff`, and limits to GET/HEAD.
+* A `source: directory` asset serves confined local files, and a `source: upstream` asset
+  serves through the existing SSRF-controlled data plane, both through the gateway-owned
+  envelope; the upstream source overrides hostile upstream response metadata with no parallel
+  fetch stack.
+* The path-traversal threat-model entry reflects the asset-serving surface and its closing
+  assertion; GW-05 carries an upstream-asset-source clause where the review finds it needed.
+* Both asset sources are exercised end-to-end against real infrastructure (mounted directory +
+  secondary server), positive and negative paths.
+* `configuration.adoc` and `architecture.adoc` describe the shipped axes, matrix, and asset
+  action consistent with the delivered schema and code.
+* Quality gate + full verify pass (canonical build commands, `CLAUDE.md`); coverage of the
+  changed packages >= 80%; the asset integration profile passes locally and on CI.
+
+== Out of Scope
+
+* Classpath-embedded asset resources -- only local directory mounts and upstream sources serve
+  assets.
+* A parallel fetch stack for the upstream asset source -- it reuses the existing upstream
+  model, client, circuit breaker, and SSRF controls unchanged.
+* Any anchor `type` value beyond `proxy` / `bff` / `asset`, or any `access` value beyond
+  `public` / `authenticated` (add later only with a doc-first change).
+* Multi-terminal-action routes -- a route carries at most one terminal action.
+* Rate limiting and dynamic configuration (out of scope project-wide;
+  link:../adr/0002-initial-scope.adoc[ADR-0002]).

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -159,3 +159,11 @@ deviation (e.g. an expected multi-PR split); it does not restate this sequence.
   than adding them. The remaining approval-gated additions are `cui-http:2.1.0` and
   `quarkus-smallrye-fault-tolerance` (Plan 04).
 * Pre-1.0 rules apply throughout: delete instead of deprecate, break freely, keep APIs clean.
+* *Three-layer documentation*: project documentation is organized in three audience layers --
+  the *design and reference* layer under `doc/` (these design docs, the ADRs, and
+  link:../configuration.adoc[`configuration.adoc`] in its dual reference/design role), the
+  *operator* layer under link:../user/README.adoc[`doc/user/`] (deployment, configuration
+  operation, running the gateway), and the *contributor* layer under
+  link:../development/README.adoc[`doc/development/`] (build, test, module layout, conventions).
+  A new document lands in the layer that matches its audience; design rationale stays under
+  `doc/` and is never duplicated into the operator or contributor layers.

--- a/doc/plan/README.adoc
+++ b/doc/plan/README.adoc
@@ -99,6 +99,15 @@ The plans build strictly on one another:
   full-surface security audit, benchmark completion with per-variant baselines, native +
   container hardening, the 1.0.0 release (and the flip of the pre-1.0 rules).
 | All of 05-08
+
+| link:10-anchor-types-assets.adoc[10 -- Anchor Type/Access Axes + Asset Serving]
+| Two required anchor axes -- `type` (`proxy`/`bff`/`asset`) and `access`
+  (`public`/`authenticated`) -- with a fail-closed access->auth matrix validated at boot (and
+  the `passthrough -> proxy` value rename), plus asset serving as a second terminal action with
+  `directory` and `upstream` sources through a gateway-owned response envelope and
+  canonicalize-and-confine path safety (the upstream source reuses the existing SSRF-controlled
+  data plane, no parallel fetch stack).
+| Plans 03 + 04
 |===
 
 Sequencing rationale: 02b is a pure correction sweep with no feature content -- it runs

--- a/doc/security-threat-model.adoc
+++ b/doc/security-threat-model.adoc
@@ -404,12 +404,22 @@ keeps `EgressPolicy.secureDefault()`, and each entry exempts exactly one host (h
 wildcard form). Operators should egress-restrict the gateway and
 avoid pointing a topology alias at link-local/metadata ranges (guide note, Plan 09).
 
+The `source: upstream` asset action (link:adr/0014-asset-serving-terminal-action.adoc[ADR-0014])
+reuses this exact posture rather than opening a parallel fetch stack: a fixed, boot-resolved
+topology upstream (never selected by request content), the `http`/`https` scheme allowlist,
+`followRedirects(NEVER)`, and a bounded response size and read/connect timeout. A hostile asset
+upstream can therefore neither redirect the fetch to an internal address nor be chosen by the
+client; its response metadata is additionally overridden by the gateway-owned asset envelope
+(fixed content type, stripped `Set-Cookie`, forced `no-store` for authenticated access).
+
 *Status:* COVERED (design). No request-controlled upstream exists; scheme allowlist is Plan
-03 D5; redirect-follow-off is a documented default.
+03 D5; redirect-follow-off is a documented default; the upstream asset source reuses the same
+fixed-topology + scheme-allowlist + no-redirect controls (ADR-0014).
 
 *Assertion.* No request input (path, header, body) can change the resolved upstream host; a
 topology alias with a non-http(s) scheme fails boot; the data-plane client does not follow
-upstream 3xx to a new host.
+upstream 3xx to a new host; the upstream asset source honours the same no-redirect and
+fixed-topology guarantees and bounds the response size and timeout.
 
 [#gw-06]
 === GW-06 -- TLS/SNI fail-open, upstream cert verification, mTLS bypass
@@ -570,11 +580,25 @@ enforce the secrets rule on the *pre-substitution* scalar (Plan 03 D5). The Grav
 double-patch is the lesson for the validator: close the whole *class* (canonicalize-then-
 contain + a full traversal/encoding regression corpus), not one spelling.
 
+The asset-serving action (link:adr/0014-asset-serving-terminal-action.adoc[ADR-0014]) *reopens*
+this class with a second client-supplied file-path surface: the request-path remainder of a
+`source: directory` or `source: upstream` asset route. Both sources close it through one shared
+`PathConfinement`, applied *before* the backing store is touched: `cui-http`'s
+`URLPathValidationPipeline` canonicalizes the untrusted remainder (rejecting encoded traversal,
+encoded slash, mixed/double encoding, `%00`, overlong UTF-8, backslash, and `..;/`), then the
+gateway confines the normalized path under the configured root/prefix and rejects any escape.
+Honouring the Gravitee lesson, a generator-driven traversal/encoding regression corpus
+(`PathConfinementTest`) asserts the whole *class* is closed for the shared confinement, not one
+spelling.
+
 *Status:* COVERED/ELIMINATED. No SQL, no SAML, no management endpoints; config-path handling
-and secrets-on-raw-value are Plan 03 D5.
+and secrets-on-raw-value are Plan 03 D5; the asset-serving file-path surface (ADR-0014) is
+confined by the shared `PathConfinement` and proven by the traversal/encoding corpus.
 
 *Assertion.* No SQL or SAML code path exists; config file resolution cannot escape the config
-directory via `..`/encoding; a full traversal corpus is rejected; the secrets rule is
+directory via `..`/encoding; a full traversal corpus is rejected; asset file resolution -- for
+both the local-directory and upstream sources -- cannot escape the configured root/prefix via
+`..`/encoding, proven by the same full corpus (`PathConfinementTest`); the secrets rule is
 evaluated on the raw scalar (a literal secret is rejected even if it would substitute to a
 valid value).
 
@@ -966,13 +990,13 @@ plan amendment (next section).
 | <<gw-02>> | Reject ambiguous HTTP framing | Gateway/web-server (cui-http out of scope) -- Plan 04 | GAP
 | <<gw-03>> | Header CR/LF reject; hop-by-hop cannot strip framing/trust | cui-http (CR/LF) + Plan 04 (hop-by-hop) | PARTIAL
 | <<gw-04>> | TCP-peer forwarded gate; regenerate; CIDR validation | cui-http resolver + ADR-0003 / Plan 04 (peer gate) / 03 D5 (trust-all) | COVERED
-| <<gw-05>> | Fixed topology upstream; scheme allowlist; egress-policy (control plane) | ADR-0004 / Plan 03 D5 / token-sheriff `EgressPolicy` | COVERED
+| <<gw-05>> | Fixed topology upstream; scheme allowlist; egress-policy (control plane); upstream-asset reuse (no redirect, bounded) | ADR-0004 / Plan 03 D5 / ADR-0014 / token-sheriff `EgressPolicy` | COVERED
 | <<gw-06>> | Fail-closed SNI/mTLS; test behaviour not flag | Plan 06 | PARTIAL
 | <<gw-07>> | Streaming + body cap; idle timeout; admission cap; YAML limits | Gateway (cui-http no streaming body) -- ADR-0006 / Plan 04 / 03 D5 | PARTIAL
 | <<gw-08>> | h2 stream-reset/CONTINUATION bounds; no h2c forward | Plan 04 / 05 | GAP
 | <<gw-09>> | WebSocket Origin validation on upgrade | Plan 05 | GAP
 | <<gw-10>> | No admin API / no scripting / no default creds | Design / Plan 04 | ELIMINATED
-| <<gw-11>> | No SQL/SAML/mgmt endpoints; safe config-path handling | Design / Plan 03 D5 | COVERED
+| <<gw-11>> | No SQL/SAML/mgmt endpoints; safe config-path + asset-path handling (canonicalize-then-confine + corpus) | Design / Plan 03 D5 / ADR-0014 (`PathConfinement`) | COVERED
 | <<gw-12>> | problem+json category-only; no secret in logs | cui-http + token-sheriff mappers / Plan 04 / 03 D5 | PARTIAL
 | <<bff-01>> | Exact-match redirect URI | Engine (logout) + AS (auth) / Plan 07 D2 | COVERED
 | <<bff-02>> | Browser-bound `state`; single-use | Engine `FlowContext` + Plan 07 D2b (binding cookie) | COVERED (server) / PARTIAL-accepted (cookie: TTL replay window)

--- a/doc/user/README.adoc
+++ b/doc/user/README.adoc
@@ -1,0 +1,43 @@
+= API Sheriff -- Operator Guide
+:toc:
+:toclevels: 2
+:sectnums:
+
+The *operator layer* of the API Sheriff documentation. These documents are written for the
+people who *run* the gateway -- deploying the binary or container, authoring and operating
+`gateway.yaml`, and keeping a running deployment healthy. They describe the gateway as a
+finished artifact to be configured and operated, distinct from the
+link:../README.adoc[design documentation] under `doc/` (which defines *what* is built) and the
+link:../development/README.adoc[contributor guide] (which describes how to *build* it).
+
+This tree is seeded here and grows as operator-facing material lands; the 1.0 operator
+configuration guide (link:../plan/09-release-readiness.adoc[plan 09]) is authored into this
+layer.
+
+== Contents
+
+[cols="1,3"]
+|===
+| Document | Purpose
+
+| link:../configuration.adoc[Configuration Reference]
+| The authoritative reference for every `gateway.yaml` key -- routing, anchors and their
+  required `type`/`access` axes, security filtering, TLS, and per-route limits. It carries a
+  *dual role*: the operator-facing YAML reference and a design document (see the
+  link:../README.adoc[design documentation index]). Operators read it as the configuration
+  contract; it stays under `doc/` and is not relocated here.
+|===
+
+== Scope of This Layer
+
+Documents in `doc/user/` cover:
+
+* *Deployment* -- running the native binary and the production container image, and the
+  configuration mounted into them.
+* *Configuration operation* -- authoring `gateway.yaml`, the anchor `type`/`access` axes, the
+  asset terminal action, and the access-to-auth rules enforced at boot.
+* *Running the gateway* -- health, metrics, and the operational signals a deployment exposes.
+
+Design rationale for these features lives in the link:../README.adoc[design documentation] and
+the link:../adr/0007-anchor-scoped-policy.adoc[Architecture Decision Records]; this layer
+describes how to *use* them, never why they were chosen.

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -46,6 +46,19 @@ services:
       - api-sheriff
     restart: unless-stopped
 
+  # Secondary static origin backing the source: upstream asset route (/assets/cdn).
+  # nginx serves the mounted static content at http://asset-origin:80 on the internal
+  # network; the gateway fetches confined assets from it over the fixed-topology,
+  # SSRF-controlled egress and re-serves them under the response envelope. No host
+  # port is published — it is reached only by the gateway on the compose network.
+  asset-origin:
+    image: nginx:1.27-alpine
+    volumes:
+      - ./src/main/docker/asset-origin:/usr/share/nginx/html:ro
+    networks:
+      - api-sheriff
+    restart: unless-stopped
+
   api-sheriff:
     image: "api-sheriff:distroless"
     build:
@@ -80,12 +93,18 @@ services:
     depends_on:
       - keycloak
       - go-httpbin
+      - asset-origin
 
     volumes:
       # Read-only certificate mount (production pattern)
       - ./src/main/docker/certificates:/app/certificates:ro
       # Read-only file-based gateway configuration mount (production pattern)
       - ./src/main/docker/sheriff-config:/app/sheriff-config:ro
+      # Read-only static-asset directory backing the source: directory asset route
+      # (/assets/static and /secure-assets). Mounted at /app/assets, matching the
+      # `directory:` root in the asset endpoint config. A read-only mount into the
+      # read_only container is fine — bind mounts are independent of the root fs.
+      - ./src/main/docker/assets:/app/assets:ro
       # Mount target directory for log files (defaults to ./target)
       - ${LOG_TARGET_DIR:-./target}:/logs:rw
 

--- a/integration-tests/scripts/verify-invalid-config-fails.sh
+++ b/integration-tests/scripts/verify-invalid-config-fails.sh
@@ -119,12 +119,12 @@ metadata:
 anchors:
   api:
     path_prefix: /api
-    auth:
-      require: none
+    type: proxy
+    access: public
   apiv1:
     path_prefix: /api/v1
-    auth:
-      require: none
+    type: proxy
+    access: public
 YAML
 chmod 755 "${ANCHOR_INVALID_DIR}"
 chmod 644 "${ANCHOR_INVALID_DIR}/gateway.yaml"

--- a/integration-tests/src/main/docker/asset-origin/logo.svg
+++ b/integration-tests/src/main/docker/asset-origin/logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Static asset served by the secondary 'asset-origin' server and re-served by the
+     gateway through the source: upstream asset route (/assets/cdn/logo.svg). The
+     gateway overrides the content type to image/svg+xml from the .svg extension and
+     adds X-Content-Type-Options: nosniff, regardless of what the origin claimed. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="API Sheriff">
+  <rect width="64" height="64" rx="8" fill="#1f6feb"/>
+  <path d="M32 12 L48 20 V32 C48 44 40 50 32 52 C24 50 16 44 16 32 V20 Z" fill="#fff"/>
+</svg>

--- a/integration-tests/src/main/docker/assets/app.css
+++ b/integration-tests/src/main/docker/assets/app.css
@@ -1,0 +1,13 @@
+/* Static asset served by the source: directory asset route (/assets/static/app.css).
+   Mounted read-only into the api-sheriff container at /app/assets. The gateway sets
+   Content-Type: text/css from the .css extension (never from the source) and adds
+   X-Content-Type-Options: nosniff. */
+:root {
+    --sheriff-accent: #1f6feb;
+}
+
+body {
+    color: #222;
+    background: #fff;
+    font-family: system-ui, sans-serif;
+}

--- a/integration-tests/src/main/docker/sheriff-config/endpoints/assets-secure.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/endpoints/assets-secure.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../../../../../api-sheriff/src/main/resources/schema/endpoint.schema.json
+# Bearer-gated asset endpoint (ADR-0014). Its single directory-source route rides
+# the 'assets-secure' anchor (/secure-assets, type: asset, access: authenticated,
+# require: bearer), so the endpoint declares no auth block of its own and inherits
+# the anchor's bearer floor. DirectoryAssetServingIT drives the auth-before-source
+# ordering against it: an unauthenticated request is rejected 401 at stage 4 and
+# never reaches the filesystem, proving no byte is read before authorization.
+#
+# base_url is mandatory but unused by an asset route; it points at the resolvable
+# UPSTREAM alias the proxy endpoints use.
+endpoint:
+  id: assets-secure
+  enabled: true
+  base_url: UPSTREAM
+  anchor: assets-secure
+  routes:
+    - id: assets-secure-directory
+      match:
+        path_prefix: /secure-assets
+      asset:
+        source: directory
+        directory: /app/assets

--- a/integration-tests/src/main/docker/sheriff-config/endpoints/assets.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/endpoints/assets.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=../../../../../../api-sheriff/src/main/resources/schema/endpoint.schema.json
+# Public asset endpoint (ADR-0014) exercised by DirectoryAssetServingIT and
+# UpstreamAssetServingIT. It carries two asset terminal-action routes under the
+# 'assets-public' anchor (/assets, access: public):
+#
+#   * /assets/static/*  -> source: directory, root /app/assets (the read-only
+#     volume mount). The gateway confines the request sub-path under the root and
+#     serves the file through the response envelope.
+#   * /assets/cdn/*     -> source: upstream, alias ASSET_ORIGIN (the secondary
+#     static server 'asset-origin'). The gateway fetches the confined remainder over
+#     the same SSRF-controlled egress the proxy uses and re-serves it under
+#     gateway-owned response governance.
+#
+# base_url is mandatory on every endpoint; an asset route never proxies to it, so it
+# points at the same resolvable UPSTREAM alias the proxy endpoints use and is unused.
+# The endpoint declares require: none because the 'assets-public' anchor is
+# access: public and carries no auth block (ADR-0013).
+endpoint:
+  id: assets
+  enabled: true
+  base_url: UPSTREAM
+  anchor: assets-public
+  auth:
+    require: none
+  routes:
+    - id: assets-directory
+      anchor: assets-public
+      match:
+        path_prefix: /assets/static
+      asset:
+        source: directory
+        directory: /app/assets
+    - id: assets-upstream
+      anchor: assets-public
+      match:
+        path_prefix: /assets/cdn
+      asset:
+        source: upstream
+        upstream: ASSET_ORIGIN

--- a/integration-tests/src/main/docker/sheriff-config/endpoints/httpbin.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/endpoints/httpbin.yaml
@@ -5,13 +5,19 @@
 # removed static ProxyConfiguration). The UPSTREAM topology alias resolves to the
 # go-httpbin echo backend (topology.properties), overridable per environment by an
 # in-file ${VAR} placeholder (the benchmark overlay repoints it at nginx-static).
-# The endpoint is anchored to the 'api' namespace (/proxy); it declares no auth
-# block of its own and inherits the anchor's require: none posture (ADR-0007).
+# The endpoint is anchored to the 'api' namespace (/proxy). Its anchors (api,
+# graphql, upload) are now access: public and therefore carry no auth block
+# (ADR-0013 forbids an auth block on a public anchor), so the endpoint declares the
+# require: none posture itself — inherited wholesale by every route, including the
+# routes that override the default anchor to graphql/upload (endpoint auth wins over
+# anchor auth in the resolution chain).
 endpoint:
   id: httpbin
   enabled: true
   base_url: UPSTREAM
   anchor: api
+  auth:
+    require: none
   routes:
     - id: httpbin-proxy
       match:

--- a/integration-tests/src/main/docker/sheriff-config/gateway.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/gateway.yaml
@@ -4,8 +4,16 @@
 # the single httpbin endpoint's /proxy route under the 'api' anchor; the disjoint
 # 'bff' anchor demonstrates the two-anchor namespace model (ADR-0007). Anchor
 # materialization is behaviour-neutral for this conforming config, so the existing
-# routed-request IT keeps passing. require: none on the anchor means no
-# token_validation / oidc block is required here.
+# routed-request IT keeps passing.
+#
+# Every anchor carries the two mandatory classification axes (ADR-0013): `type`
+# (proxy | bff | asset) and `access` (public | authenticated), boot-validated by the
+# fail-closed access->auth matrix. A `public` anchor declares NO auth block (public is
+# the absence of auth), so the require: none postures that previously lived on the
+# public anchors now live on their endpoints; the `authenticated` anchors keep their
+# non-none auth floor. The two `asset` anchors (ADR-0014) serve static content through
+# the gateway-owned response envelope: `assets-public` (public directory + upstream
+# sources) and `assets-secure` (authenticated directory source, bearer-gated).
 version: 1
 metadata:
   config_version: "integration-test"
@@ -18,12 +26,12 @@ tls:
 anchors:
   api:
     path_prefix: /proxy
-    auth:
-      require: none
+    type: proxy
+    access: public
   bff:
     path_prefix: /bff
-    auth:
-      require: none
+    type: proxy
+    access: public
   # Bearer-protected namespace exercised by BearerValidationIT. The gateway's own
   # token_validation issuer loads its key set from the mounted static JWKS file
   # (no Keycloak dependency), so the validator is ready offline at boot. The IT
@@ -31,6 +39,8 @@ anchors:
   # reach the upstream — proving upstream count = 0 on every bearer rejection.
   secure:
     path_prefix: /secure
+    type: proxy
+    access: authenticated
     auth:
       require: bearer
   # --- Benchmark aspect namespaces (plan 04b) -------------------------------
@@ -38,13 +48,13 @@ anchors:
   # on-demand APISIX comparison has a route-for-route counterpart.
   graphql:
     path_prefix: /graphql
-    auth:
-      require: none
+    type: proxy
+    access: public
     allowed_methods: ["POST"]
   upload:
     path_prefix: /upload
-    auth:
-      require: none
+    type: proxy
+    access: public
     allowed_methods: ["POST"]
     security_filter:
       # 64 MiB — above the 50 MB upload aspect so the large-body run is MEASURED
@@ -57,12 +67,36 @@ anchors:
   # owns that behaviour and slots it in without re-touching this topology.
   ws:
     path_prefix: /ws
-    auth:
-      require: none
+    type: proxy
+    access: public
   grpc:
     path_prefix: /grpc
+    type: proxy
+    access: public
+  # --- Asset terminal-action namespaces (ADR-0014) --------------------------
+  # A public asset surface serving static content two ways: a directory source
+  # backed by the read-only /app/assets volume mount, and an upstream source
+  # backed by the secondary 'asset-origin' static server (topology alias
+  # ASSET_ORIGIN). Only GET/HEAD are served; the gateway-owned response envelope
+  # sets the content type from the file extension, adds X-Content-Type-Options:
+  # nosniff, and strips any upstream Set-Cookie.
+  assets-public:
+    path_prefix: /assets
+    type: asset
+    access: public
+    allowed_methods: ["GET", "HEAD"]
+  # A bearer-gated asset surface (directory source). access: authenticated forces
+  # the envelope to Cache-Control: no-store and, crucially, enforces auth BEFORE the
+  # source is resolved — an unauthenticated request is rejected 401 and never reads
+  # a file (auth-before-source, ADR-0014). The bearer floor reuses the same offline
+  # token_validation issuers the 'secure' anchor relies on.
+  assets-secure:
+    path_prefix: /secure-assets
+    type: asset
+    access: authenticated
+    allowed_methods: ["GET", "HEAD"]
     auth:
-      require: none
+      require: bearer
 token_validation:
   issuers:
     # Retained: BearerValidationIT's rejection scenarios resolve against this

--- a/integration-tests/src/main/docker/sheriff-config/topology.properties
+++ b/integration-tests/src/main/docker/sheriff-config/topology.properties
@@ -5,3 +5,10 @@
 # the proxy ITs can assert exactly what was forwarded. The benchmark overlay
 # overrides this at runtime with TOPOLOGY_UPSTREAM=http://nginx-static:8080.
 UPSTREAM=http://go-httpbin:8080/anything
+
+# ASSET_ORIGIN is the secondary static server ('asset-origin', nginx) that backs the
+# source: upstream asset route (/assets/cdn). The gateway fetches confined assets from
+# it over the fixed-topology, SSRF-controlled egress and re-serves them under the
+# gateway-owned response envelope. Reached on the internal compose network by service
+# name; it publishes no host port.
+ASSET_ORIGIN=http://asset-origin:80

--- a/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/DirectoryAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/DirectoryAssetServingIT.java
@@ -102,6 +102,9 @@ class DirectoryAssetServingIT extends BaseIntegrationTest {
     }
 
     private static String problemType(String contentType) {
+        if (contentType == null) {
+            return "";
+        }
         int semicolon = contentType.indexOf(';');
         return (semicolon < 0 ? contentType : contentType.substring(0, semicolon)).trim();
     }

--- a/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/DirectoryAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/DirectoryAssetServingIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the {@code source: directory} asset terminal action (ADR-0014) over the public HTTPS
+ * edge against the {@code /assets/static} route, and the auth-before-source ordering against the
+ * bearer-gated {@code /secure-assets} route.
+ * <p>
+ * The {@code assets-public} anchor ({@code type: asset}, {@code access: public}) serves files from
+ * the read-only {@code /app/assets} volume mount through the gateway-owned response envelope: the
+ * {@code Content-Type} is set from the file extension (never from the source), {@code nosniff} is
+ * added, and only {@code GET}/{@code HEAD} are served. The {@code assets-secure} anchor
+ * ({@code access: authenticated}) proves auth precedes source resolution — an unauthenticated
+ * request is rejected {@code 401} at stage 4 and no file is ever read.
+ */
+class DirectoryAssetServingIT extends BaseIntegrationTest {
+
+    @Test
+    @DisplayName("GET serves a mounted file with the gateway-governed content type and nosniff")
+    void getServesGovernedFile() {
+        var response = given()
+                .when()
+                .get("/assets/static/app.css")
+                .then()
+                .statusCode(200)
+                .header("X-Content-Type-Options", "nosniff")
+                .extract();
+
+        assertTrue(response.contentType().contains("text/css"),
+                "the gateway sets Content-Type from the .css extension, not the source");
+        assertTrue(response.asString().contains("color"), "the served body is the mounted file's content");
+    }
+
+    @Test
+    @DisplayName("HEAD serves the governed headers with an empty body")
+    void headServesEmptyBody() {
+        var response = given()
+                .when()
+                .head("/assets/static/app.css")
+                .then()
+                .statusCode(200)
+                .header("X-Content-Type-Options", "nosniff")
+                .extract();
+
+        assertTrue(response.asString().isEmpty(), "a HEAD response carries the governed headers but no body");
+    }
+
+    @Test
+    @DisplayName("GET for a missing file is a confinement-clean 404")
+    void getMissingFileIsNotFound() {
+        given()
+                .when()
+                .get("/assets/static/does-not-exist.css")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("POST is rejected 405 — an asset action serves only GET and HEAD")
+    void postRejected() {
+        given()
+                .when()
+                .post("/assets/static/app.css")
+                .then()
+                .statusCode(405);
+    }
+
+    @Test
+    @DisplayName("an unauthenticated request to a bearer-gated asset is rejected 401 before any file is read")
+    void authenticatedAssetRejectsWithoutToken() {
+        var response = given()
+                .when()
+                .get("/secure-assets/app.css")
+                .then()
+                .statusCode(401)
+                .header("WWW-Authenticate", "Bearer")
+                .extract();
+
+        assertEquals("application/problem+json", problemType(response.contentType()),
+                "the rejection is rendered as an RFC 9457 problem document");
+    }
+
+    private static String problemType(String contentType) {
+        int semicolon = contentType.indexOf(';');
+        return (semicolon < 0 ? contentType : contentType.substring(0, semicolon)).trim();
+    }
+}

--- a/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/UpstreamAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/api/integration/UpstreamAssetServingIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.api.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the {@code source: upstream} asset terminal action (ADR-0014) over the public HTTPS
+ * edge against the {@code /assets/cdn} route.
+ * <p>
+ * The {@code assets-public} anchor's upstream asset route fetches from the secondary
+ * {@code asset-origin} static server (topology alias {@code ASSET_ORIGIN}) over the same
+ * fixed-topology, SSRF-controlled egress the proxy action uses — no parallel fetch stack — and
+ * re-serves the response under the gateway-owned envelope. The envelope overrides the
+ * {@code Content-Type} from the file extension (so a hostile or misconfigured origin cannot dictate
+ * it), adds {@code X-Content-Type-Options: nosniff}, and serves only {@code GET}/{@code HEAD}.
+ */
+class UpstreamAssetServingIT extends BaseIntegrationTest {
+
+    @Test
+    @DisplayName("GET fetches the secondary origin and re-serves it under gateway governance")
+    void getServesGovernedUpstreamAsset() {
+        var response = given()
+                .when()
+                .get("/assets/cdn/logo.svg")
+                .then()
+                .statusCode(200)
+                .header("X-Content-Type-Options", "nosniff")
+                .extract();
+
+        assertTrue(response.contentType().contains("image/svg+xml"),
+                "the gateway overrides the content type from the .svg extension, not the origin");
+        assertTrue(response.asString().contains("<svg"), "the served body is the secondary origin's asset");
+    }
+
+    @Test
+    @DisplayName("HEAD serves the governed headers with an empty body")
+    void headServesEmptyBody() {
+        var response = given()
+                .when()
+                .head("/assets/cdn/logo.svg")
+                .then()
+                .statusCode(200)
+                .header("X-Content-Type-Options", "nosniff")
+                .extract();
+
+        assertTrue(response.asString().isEmpty(), "a HEAD response carries the governed headers but no body");
+    }
+
+    @Test
+    @DisplayName("POST is rejected 405 — an asset action serves only GET and HEAD")
+    void postRejected() {
+        given()
+                .when()
+                .post("/assets/cdn/logo.svg")
+                .then()
+                .statusCode(405);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two explicit `type` (`proxy` | `bff` | `asset`) and `access` (`public` | `authenticated`) axes to every `gateway.yaml` anchor — replacing `passthrough` with `proxy` + `access: public` as a clean-slate breaking rename — and introduces asset serving as a new terminal action with two sources (`directory` and `upstream`). Fail-closed boot validation covers the full access/auth matrix, wired through the startup-event path so validation cannot be bypassed by CDI-proxy laziness. Asset responses go through a gateway-owned envelope (fixed content-type map, `nosniff`, governed caching, stripped `Set-Cookie`, GET/HEAD only), with canonicalize-and-confine path safety applied to both sources before the source is touched. The path-traversal threat-model entry is reopened and closed with a generator-driven traversal/encoding regression corpus. The change also bootstraps the `doc/user/` and `doc/development/` documentation tree and records the design rationale in two new ADRs.

## Changes

- **Anchor type/access axes** — `AnchorType`, `AccessLevel`, `AnchorConfig`, `RouteConfig`, `RouteTableBuilder`, `ConfigValidator`, `ConfigModelReflection`, and the `gateway.schema.json` / `endpoint.schema.json` schemas now require and enforce `type` + `access` on every anchor; `passthrough` is renamed to `proxy` + `access: public`.
- **Fail-closed boot validation** — `ConfigValidator` enforces the access→auth matrix (`access: authenticated` requires a fully-backed auth posture; `access: public` + auth block fails boot; `type: bff` requires `access: authenticated`), asserted via the startup-event path in `ConfigValidatorTest` / `ConfigProducerTest` (not a direct-call test), per the PR #82 lazy-CDI-proxy lesson.
- **Asset serving terminal action** — new `de.cuioss.sheriff.api.asset` package: `AssetSource`, `DirectoryAssetSource`, `UpstreamAssetSource`, `PathConfinement`, `AssetResponseEnvelope`, plus `AssetConfig` / `ResolvedAsset` config-model support and `RouteRuntime` / `GatewayEdgeRoute` / `DispatchStage` / `RouteRuntimeAssembler` wiring. `UpstreamAssetSource` reuses the existing upstream client, circuit breaker, and SSRF controls (scheme allowlist, `EgressPolicy`, `followRedirects(NEVER)`, bounded size/timeout) rather than a parallel fetch stack.
- **Path safety** — `PathConfinement` applies canonicalize-and-confine to both sources before the source is touched, with auth-before-source-resolution ordering enforced in the edge pipeline.
- **Threat model** — `doc/security-threat-model.adoc` path-traversal entry reopened and closed against the canonicalize-then-contain design and the new adversarial traversal corpus (`DirectoryAssetSourceTest`, `UpstreamAssetSourceTest`, `PathConfinementTest`).
- **ADRs and docs** — `doc/adr/0013-anchor-type-access-axes.adoc`, `doc/adr/0014-asset-serving-terminal-action.adoc`, plus updates to `doc/configuration.adoc` and `doc/architecture.adoc`.
- **Documentation-tree bootstrap** — new `doc/user/README.adoc` and `doc/development/README.adoc`, a fifth Conventions bullet in `doc/plan/README.adoc` for the three-layer documentation convention, and a `doc/README.adoc` classification fix for `configuration.adoc`'s dual reference/design role.
- **Integration tests** — `DirectoryAssetServingIT` and `UpstreamAssetServingIT` against a real mounted directory and a real secondary origin server, with supporting `integration-tests` docker-compose / sheriff-config fixtures (`assets.yaml`, `assets-secure.yaml`, asset-origin content).

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [ ] Full verify passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`)
- [ ] Manual testing completed (if applicable)

## Related Issues

None.

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `asset` terminal action for routes, supporting `directory` and `upstream` sources with confined paths, size limits, SSRF protections, and auth-before-resolution behavior.
  * Asset responses are gateway-governed: fixed content-type mapping, `X-Content-Type-Options: nosniff`, `Set-Cookie` stripping, and `Cache-Control: no-store` for authenticated access.
  * Only `GET`/`HEAD` are allowed; upstream redirects and upstream failures are handled safely.

* **Documentation**
  * Added and updated configuration, architecture, security, operator, contributor docs, and ADRs for asset serving and anchor `type`/`access` fail-closed validation.

* **Tests**
  * Added unit and integration tests for directory and upstream assets, header governance, method enforcement, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->