### PR TITLE
chore(steward): land plan-marshall 0.1.1172 upgrade and cui-java-parent 1.5.4 bump

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -290,7 +290,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1166",
-    "config_seed_fingerprint": "38d03331"
+    "provisioned_version": "0.1.1172",
+    "config_seed_fingerprint": "daa4978b"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.sheriff.api</groupId>


### PR DESCRIPTION
## Summary

Steward landing after the plan-marshall marketplace update:

- `.plan/marshal.json` — provisioning stamps refreshed to plan-marshall **0.1.1172** (`provisioned_version`, `config_seed_fingerprint`) by the steward upgrade flow (executor regenerated, config reconciled, preflight verified fresh).
- `pom.xml` — parent POM `de.cuioss:cui-java-parent` bumped **1.5.3 → 1.5.4**.

## Verification

- `generate_executor preflight`: executor fresh, marshal fresh, all at 0.1.1172
- `build-map drift`: in sync
- Config/dependency-only change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
