### PR TITLE
chore(steward): register sonar provider credentials config

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -205,6 +205,13 @@
       ]
     }
   },
+  "credentials_config": {
+    "plan-marshall:workflow-integration-sonar": {
+      "url": "https://sonarcloud.io",
+      "organization": "cuioss-github",
+      "project_key": "cuioss_API-Sheriff"
+    }
+  },
   "project": {
     "default_base_branch": "main",
     "working_prefixes": [


### PR DESCRIPTION
## Summary

Register the SonarCloud provider configuration in `.plan/marshal.json` (`credentials_config` block for `plan-marshall:workflow-integration-sonar`):

- URL: `https://sonarcloud.io`
- Organization: `cuioss-github`
- Project key: `cuioss_API-Sheriff`

Contains **no secrets** — the token lives in `~/.plan-marshall/credentials/` outside the repo. Connectivity was verified against SonarCloud (`/api/system/status`). This enables the `sonar-roundtrip` finalize step to fetch and dismiss Sonar findings during plan finalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
