### PR TITLE
fix(sonar): drive open findings to zero and document gate policy

### DIFF
--- a/.plan/project-architecture/api-sheriff-parent/enriched.json
+++ b/.plan/project-architecture/api-sheriff-parent/enriched.json
@@ -91,6 +91,7 @@
   },
   "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Maven parent/aggregator POM; java-cui: inherits cui-java-parent, CUI build conventions",
   "tips": [
-    "Java 25 auto-imports java.lang.IO (println/print/readln) into every source file via JEP 512, so IO.println needs no explicit import. Review bots (gemini) false-positive 'IO cannot find symbol / add an import' and suggest reverting to System.out.println; do NOT apply that suggestion. Verify with mvn test-compile before dispositioning."
+    "Java 25 auto-imports java.lang.IO (println/print/readln) into every source file via JEP 512, so IO.println needs no explicit import. Review bots (gemini) false-positive 'IO cannot find symbol / add an import' and suggest reverting to System.out.println; do NOT apply that suggestion. Verify with mvn test-compile before dispositioning.",
+    "Sonar provider registration must use an HTTPS base URL: when a Sonar auth token is configured, workflow-integration-sonar fetch_findings rejects an http:// URL with 'HTTPS required when authentication is configured' (observed failing twice on PR 89 before the config was corrected mid-run). Always use an https:// scheme in the sonar provider config."
   ]
 }

--- a/.plan/project-architecture/api-sheriff/enriched.json
+++ b/.plan/project-architecture/api-sheriff/enriched.json
@@ -163,6 +163,7 @@
   },
   "skills_by_profile_reasoning": "general-dev: cross-cutting; java: Quarkus application using CDI producers and Lombok \u2014 all optionals apply; java-cui: CUI standards (CuiLogger/LogRecord); cui-http and cui-testing/cui-http-testing used from Plans 02/03 onward",
   "tips": [
-    "When deleting or moving a Java package's contents, package-info.java is a sibling that is easy to miss in consumer/deletion sweeps (caught here by the outline Q-Gate). Always include package-info.java in the deletion deliverable when a package is being emptied or removed."
+    "When deleting or moving a Java package's contents, package-info.java is a sibling that is easy to miss in consumer/deletion sweeps (caught here by the outline Q-Gate). Always include package-info.java in the deletion deliverable when a package is being emptied or removed.",
+    "api-sheriff source uses Java unnamed variables ('_' in catch and lambda params, e.g. catch (IOException _), _ -> vertx.createHttpClient()) across edge/forward/asset packages. Unnamed variables (JEP 456) require compiler release >= 22. Keep maven.compiler.release at the project Java level (25); a stale or lowered -source below 22 fails compilation with 'unnamed variables are not supported in -source 21 (use -source 22 or higher)'."
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,14 @@ As a security-focused API Gateway:
 - Follow OWASP guidelines, validate all inputs/outputs
 - Use secure defaults
 
+## Sonar / Quality Gate
+
+The cuioss-organization SonarCloud gate (project `cuioss_API-Sheriff`, declared via `.github/project.yml`) is the **authoritative, blocking source of truth** for code quality — target zero new findings, and never merge over a red gate or a stale green while analysis is pending. Thresholds are org-owned; reference the gate, never restate them here.
+
+**Fix by default.** Where a fix is genuinely not sensible (false positive, deliberate idiom, a rule fighting the design), suppress in-code with a rationale — `// NOSONAR java:SXXXX <why>` or `@SuppressWarnings("java:SXXXX")` — never by silently marking issues won't-fix / false-positive in the Sonar UI.
+
+See `doc/development/sonar-quality-gate.adoc` for the complete compliance policy (including the PR-new-code vs post-merge project-gate auditability nuance).
+
 ## Dependency Management
 
 - **Parent POM**: `de.cuioss:cui-java-parent:1.5.1`

--- a/README.adoc
+++ b/README.adoc
@@ -22,8 +22,8 @@ image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_API-Sherif
 
 *Benchmarks*
 
-image:https://img.shields.io/endpoint?url=https://cuioss.github.io/api-sheriff/benchmarks/badges/integration-performance-badge.json[Integration Performance,link=https://cuioss.github.io/api-sheriff/benchmarks/integration-index.html]
-image:https://img.shields.io/endpoint?url=https://cuioss.github.io/api-sheriff/benchmarks/badges/integration-trend-badge.json[Integration Trend,link=https://cuioss.github.io/api-sheriff/benchmarks/integration-performance-trends.html]
+image:https://img.shields.io/endpoint?url=https://cuioss.github.io/api-sheriff/benchmarks/badges/integration-performance-badge.json[Integration Performance,link=https://cuioss.github.io/api-sheriff/benchmarks/integration/index.html]
+image:https://img.shields.io/endpoint?url=https://cuioss.github.io/api-sheriff/benchmarks/badges/integration-trend-badge.json[Integration Trend,link=https://cuioss.github.io/api-sheriff/benchmarks/integration/trends.html]
 
 https://github.com/cuioss/TokenSheriff/blob/main/benchmarking/doc/benchmark-metrics.adoc[Understand Performance Metrics]
 
@@ -56,7 +56,7 @@ Integration test coordinator — Docker infrastructure, native container builds,
 
 === Performance Benchmarking
 
-Integration benchmarks using WRK HTTP load testing with containerized environments.
+Integration benchmarks using k6 HTTP load testing with containerized environments.
 
 == Deployment
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/AssetSource.java
@@ -104,10 +104,10 @@ public sealed interface AssetSource permits DirectoryAssetSource, UpstreamAssetS
             if (this == other) {
                 return true;
             }
-            return other instanceof Served served
-                    && status == served.status
-                    && headers.equals(served.headers)
-                    && Arrays.equals(body, served.body);
+            return other instanceof Served(var otherStatus, var otherHeaders, var otherBody)
+                    && status == otherStatus
+                    && headers.equals(otherHeaders)
+                    && Arrays.equals(body, otherBody);
         }
 
         /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/DirectoryAssetSource.java
@@ -128,7 +128,7 @@ public final class DirectoryAssetSource implements AssetSource {
                     file.getFileName().toString(), access, Map.of());
             byte[] body = method == HttpMethod.HEAD ? EMPTY_BODY : Files.readAllBytes(file);
             return new Served(OK, headers, body);
-        } catch (IOException readFailure) {
+        } catch (IOException _) {
             return new Served(SERVER_ERROR, Map.of(), EMPTY_BODY);
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/PathConfinement.java
@@ -110,7 +110,7 @@ public final class PathConfinement {
                 return Optional.empty();
             }
             return Optional.of(resolved);
-        } catch (InvalidPathException malformed) {
+        } catch (InvalidPathException _) {
             return Optional.empty();
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/asset/UpstreamAssetSource.java
@@ -154,7 +154,7 @@ public final class UpstreamAssetSource implements AssetSource {
         URI target;
         try {
             target = upstreamUri(confined.get());
-        } catch (URISyntaxException malformed) {
+        } catch (URISyntaxException _) {
             return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);
         }
         UpstreamFetcher.Fetched fetched;
@@ -162,7 +162,7 @@ public final class UpstreamAssetSource implements AssetSource {
             fetched = fetcher.fetch(target);
         } catch (UpstreamFetcher.UpstreamTimeoutException timeout) {
             return new Served(GATEWAY_TIMEOUT, Map.of(), EMPTY_BODY);
-        } catch (IOException fetchFailure) {
+        } catch (IOException _) {
             return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);
         }
         if (fetched.body().length > maxBytes) {
@@ -375,10 +375,10 @@ public final class UpstreamAssetSource implements AssetSource {
                 if (this == other) {
                     return true;
                 }
-                return other instanceof Fetched fetched
-                        && status == fetched.status
-                        && headers.equals(fetched.headers)
-                        && Arrays.equals(body, fetched.body);
+                return other instanceof Fetched(var otherStatus, var otherHeaders, var otherBody)
+                        && status == otherStatus
+                        && headers.equals(otherHeaders)
+                        && Arrays.equals(body, otherBody);
             }
 
             /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/auth/TokenValidatorProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/auth/TokenValidatorProducer.java
@@ -53,6 +53,8 @@ public class TokenValidatorProducer {
 
     private static final String SOURCE_HTTP = "http";
     private static final String SOURCE_FILE = "file";
+    /** Shared prefix for the per-issuer {@code CONFIG_INVALID} error messages. */
+    private static final String ISSUER_PREFIX = "Issuer '";
 
     private final GatewayConfig gatewayConfig;
     private final JwksTrustProfileResolver trustProfileResolver;
@@ -127,7 +129,7 @@ public class TokenValidatorProducer {
                 builder::expectedAudience,
                 () -> builder.audienceValidationDisabled(true));
         IssuerConfig.Jwks jwks = issuer.jwks().orElseThrow(() -> new GatewayException(EventType.CONFIG_INVALID,
-                "Issuer '" + issuer.name() + "' declares no jwks source"));
+                ISSUER_PREFIX + issuer.name() + "' declares no jwks source"));
         applyJwks(builder, issuer, jwks);
         return builder.build();
     }
@@ -138,11 +140,11 @@ public class TokenValidatorProducer {
             builder.httpJwksLoaderConfig(toHttpJwksLoaderConfig(issuer, jwks));
         } else if (SOURCE_FILE.equals(jwks.source())) {
             String file = jwks.file().orElseThrow(() -> new GatewayException(EventType.CONFIG_INVALID,
-                    "Issuer '" + issuer.name() + "' jwks source 'file' declares no file path"));
+                    ISSUER_PREFIX + issuer.name() + "' jwks source 'file' declares no file path"));
             builder.jwksFilePath(file);
         } else {
             throw new GatewayException(EventType.CONFIG_INVALID,
-                    "Issuer '" + issuer.name() + "' declares unsupported jwks source '" + jwks.source() + "'");
+                    ISSUER_PREFIX + issuer.name() + "' declares unsupported jwks source '" + jwks.source() + "'");
         }
     }
 
@@ -175,7 +177,7 @@ public class TokenValidatorProducer {
      */
     HttpJwksLoaderConfig toHttpJwksLoaderConfig(IssuerConfig issuer, IssuerConfig.Jwks jwks) {
         String url = jwks.url().orElseThrow(() -> new GatewayException(EventType.CONFIG_INVALID,
-                "Issuer '" + issuer.name() + "' jwks source 'http' declares no url"));
+                ISSUER_PREFIX + issuer.name() + "' jwks source 'http' declares no url"));
         HttpJwksLoaderConfig.HttpJwksLoaderConfigBuilder builder = HttpJwksLoaderConfig.builder()
                 .issuerIdentifier(issuer.issuer())
                 .jwksUrl(url);

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java
@@ -175,8 +175,9 @@ public final class RouteTableBuilder {
         // A route resolves to exactly one terminal action: an asset action (when the route
         // declares an asset block) is materialized here; otherwise the route proxies to its
         // endpoint upstream. ADR-0014: upstream XOR asset.
-        if (route.asset().isPresent()) {
-            builder.asset(Optional.of(resolveAsset(route, route.asset().get(), anchor, auth, topology)));
+        Optional<AssetConfig> asset = route.asset();
+        if (asset.isPresent()) {
+            builder.asset(Optional.of(resolveAsset(route, asset.get(), anchor, auth, topology)));
         } else {
             builder.upstream(Optional.of(upstream));
         }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/load/EnvSecretResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/load/EnvSecretResolver.java
@@ -54,8 +54,8 @@ import org.jspecify.annotations.Nullable;
 public final class EnvSecretResolver {
 
     private static final Pattern PLACEHOLDER = Pattern
-            .compile("\\$\\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:(?!\\$\\{).)*?))?}");
-    private static final Pattern BARE_REFERENCE = Pattern.compile("\\$\\{[A-Za-z_][A-Za-z0-9_]*}");
+            .compile("\\$\\{([A-Za-z_]\\w*)(?::-((?:(?!\\$\\{).)*?))?}");
+    private static final Pattern BARE_REFERENCE = Pattern.compile("\\$\\{[A-Za-z_]\\w*}");
     private static final String OPEN = "${";
 
     private final UnaryOperator<@Nullable String> lookup;

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -425,12 +425,12 @@ public final class ConfigValidator {
                 requires.add(effectiveRequire(gateway, endpoint, route));
             }
         }
-        if (requires.contains("bearer")
+        if (requires.contains(REQUIRE_BEARER)
                 && gateway.tokenValidation().map(tv -> tv.issuers().isEmpty()).orElse(true)) {
             errors.add(new ConfigError(GATEWAY_FILE, "/token_validation",
                     "effective auth 'bearer' requires token_validation with at least one issuer"));
         }
-        if (requires.contains("session") && gateway.oidc().isEmpty()) {
+        if (requires.contains(REQUIRE_SESSION) && gateway.oidc().isEmpty()) {
             errors.add(new ConfigError(GATEWAY_FILE, "/oidc", "effective auth 'session' requires an oidc block"));
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java
@@ -328,21 +328,40 @@ public final class ConfigValidator {
             for (RouteConfig route : endpoint.routes()) {
                 Optional<String> declaredName = declaredAnchorName(endpoint, route);
                 String routePrefix = route.match().pathPrefix();
-                declaredName.map(gateway.anchors()::get).filter(Objects::nonNull).ifPresent(anchor -> {
-                    if (!prefixContains(anchor.pathPrefix(), routePrefix)) {
-                        errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
-                                "route '%s' path '%s' is not inside its declared anchor '%s' namespace '%s'"
-                                        .formatted(route.id(), routePrefix, anchor.name(), anchor.pathPrefix())));
-                    }
-                });
-                for (AnchorConfig anchor : gateway.anchors().values()) {
-                    if (prefixContains(anchor.pathPrefix(), routePrefix)
-                            && !declaredName.map(anchor.name()::equals).orElse(false)) {
-                        errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
-                                "route '%s' path '%s' lies inside anchor '%s' namespace '%s' but does not declare it"
-                                        .formatted(route.id(), routePrefix, anchor.name(), anchor.pathPrefix())));
-                    }
-                }
+                checkRouteInsideDeclaredAnchorNamespace(gateway, endpoint, route, declaredName, routePrefix, errors);
+                checkRouteDeclaresContainingAnchor(gateway, endpoint, route, declaredName, routePrefix, errors);
+            }
+        }
+    }
+
+    /**
+     * Rule (3): an enabled route's {@code match.path_prefix} must lie inside its declared anchor's
+     * namespace (ADR-0007). A no-op when the route declares no anchor, or its declared anchor name
+     * is not a defined anchor.
+     */
+    private static void checkRouteInsideDeclaredAnchorNamespace(GatewayConfig gateway, EndpointConfig endpoint,
+            RouteConfig route, Optional<String> declaredName, String routePrefix, List<ConfigError> errors) {
+        declaredName.map(gateway.anchors()::get).filter(Objects::nonNull).ifPresent(anchor -> {
+            if (!prefixContains(anchor.pathPrefix(), routePrefix)) {
+                errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                        "route '%s' path '%s' is not inside its declared anchor '%s' namespace '%s'"
+                                .formatted(route.id(), routePrefix, anchor.name(), anchor.pathPrefix())));
+            }
+        });
+    }
+
+    /**
+     * Rule (4): an enabled route whose path lies inside any anchor namespace must declare exactly
+     * that anchor — an undeclared squatter fails the boot (ADR-0007).
+     */
+    private static void checkRouteDeclaresContainingAnchor(GatewayConfig gateway, EndpointConfig endpoint,
+            RouteConfig route, Optional<String> declaredName, String routePrefix, List<ConfigError> errors) {
+        for (AnchorConfig anchor : gateway.anchors().values()) {
+            if (prefixContains(anchor.pathPrefix(), routePrefix)
+                    && !declaredName.map(anchor.name()::equals).orElse(false)) {
+                errors.add(new ConfigError(endpointFile(endpoint), ENDPOINT_ROUTES_POINTER,
+                        "route '%s' path '%s' lies inside anchor '%s' namespace '%s' but does not declare it"
+                                .formatted(route.id(), routePrefix, anchor.name(), anchor.pathPrefix())));
             }
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java
@@ -104,8 +104,9 @@ public final class DispatchStage {
     public static String upstreamRequestUri(ResolvedUpstream upstream, String pathRemainder, String rawQuery) {
         Objects.requireNonNull(upstream, "upstream");
         Objects.requireNonNull(pathRemainder, "pathRemainder");
+        Objects.requireNonNull(rawQuery, "rawQuery");
         String path = stripTrailingSlash(upstream.basePath()) + pathRemainder;
-        return rawQuery == null || rawQuery.isEmpty() ? path : path + rawQuery;
+        return rawQuery.isEmpty() ? path : path + rawQuery;
     }
 
     /**
@@ -225,7 +226,7 @@ public final class DispatchStage {
 
     private HttpClientResponse awaitDispatch(RouteRuntime route, io.vertx.core.http.HttpMethod method,
             String requestUri, Map<String, String> forwardHeaders, ReadStream<Buffer> requestBody,
-            AtomicLong bytesSent, AtomicBoolean bodyStreamSubscribed) throws Exception {
+            AtomicLong bytesSent, AtomicBoolean bodyStreamSubscribed) throws InterruptedException, ExecutionException {
         ResolvedUpstream upstream = route.getUpstream()
                 .orElseThrow(() -> new IllegalStateException("proxy dispatch requires a resolved upstream"));
         HttpClient httpClient = route.getHttpClient()

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/GatewayEdgeRoute.java
@@ -213,7 +213,7 @@ public class GatewayEdgeRoute {
         RouteRuntimeAssembler assembler = new RouteRuntimeAssembler(new ProtocolProcessorRegistry());
         this.routes = assembler.assemble(routeTable,
                 GatewayEdgeRoute::securityConfigurationFor,
-                target -> vertx.createHttpClient(),
+                _ -> vertx.createHttpClient(),
                 this::guardFor,
                 GatewayEdgeRoute::assetSourceFor);
         LOGGER.info(ApiSheriffLogMessages.INFO.ROUTE_TABLE_COMPILED, routes.size());
@@ -257,7 +257,7 @@ public class GatewayEdgeRoute {
         while (inFlight.get() > 0 && System.nanoTime() < deadline) {
             try {
                 Thread.sleep(DRAIN_POLL_INTERVAL_MILLIS);
-            } catch (InterruptedException interrupted) {
+            } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
                 return;
             }
@@ -563,7 +563,7 @@ public class GatewayEdgeRoute {
         }
         try {
             return Long.parseLong(value.strip());
-        } catch (NumberFormatException notANumber) {
+        } catch (NumberFormatException _) {
             return -1L;
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssembler.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssembler.java
@@ -129,8 +129,9 @@ public final class RouteRuntimeAssembler {
             // A route resolves exactly one terminal action (ADR-0014). An asset route builds its
             // live source and skips the Vert.x client / resilience-guard dedup entirely — its
             // egress rides the source's own SSRF-controlled fetch seam, not the proxy data plane.
-            if (route.asset().isPresent()) {
-                runtime.assetSource(Optional.of(assetSourceFactory.create(route.asset().get())));
+            Optional<ResolvedAsset> asset = route.asset();
+            if (asset.isPresent()) {
+                runtime.assetSource(Optional.of(assetSourceFactory.create(asset.get())));
             } else {
                 ResolvedUpstream resolvedUpstream = route.upstream().orElseThrow(() -> new GatewayException(
                         EventType.CONFIG_INVALID,

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/forward/ForwardPolicyStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/forward/ForwardPolicyStage.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 
 import de.cuioss.http.forwarded.ForwardedHeaderResolver;
@@ -121,7 +121,7 @@ public final class ForwardPolicyStage {
 
     private void applyRegeneratedForwarding(PipelineRequest request, Map<String, String> headers) {
         boolean peerTrusted = peerGate.isTrustedPeer(request.peerAddress());
-        Function<String, String> lookup = name -> {
+        UnaryOperator<String> lookup = name -> {
             if (!peerTrusted && FORWARDING_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
                 return null;
             }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/api/forward/TcpPeerGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/api/forward/TcpPeerGate.java
@@ -64,7 +64,7 @@ public final class TcpPeerGate {
         InetAddress peer;
         try {
             peer = InetAddress.ofLiteral(peerAddress.strip());
-        } catch (IllegalArgumentException notALiteral) {
+        } catch (IllegalArgumentException _) {
             return false;
         }
         for (Cidr range : trustedRanges) {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/asset/UpstreamAssetSourceTest.java
@@ -67,7 +67,7 @@ class UpstreamAssetSourceTest {
             new ResolvedUpstream("https", "assets.internal", 443, "/static");
 
     private static UpstreamFetcher cannedFetcher(int status, Map<String, String> headers, byte[] body) {
-        return target -> new UpstreamFetcher.Fetched(status, headers, body);
+        return _ -> new UpstreamFetcher.Fetched(status, headers, body);
     }
 
     private static UpstreamFetcher mustNotFetch() {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.api.config;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -812,6 +813,25 @@ class RouteTableBuilderTest {
             ResolvedRoute resolved = find(table, "r");
             assertTrue(resolved.upstream().isPresent(), "a proxy route resolves an upstream terminal action");
             assertTrue(resolved.asset().isEmpty(), "a proxy route carries no asset terminal action");
+        }
+
+        @Test
+        @DisplayName("Should resolve the empty-Optional (no-asset) path to the upstream action without throwing (S3655 guard)")
+        void shouldResolveNoAssetPathWithoutThrowing() {
+            EndpointConfig endpoint = endpoint("orders", "ORDERS")
+                    .routes(List.of(route("proxy-only", HttpMethod.GET))).build();
+
+            RouteTable table = assertDoesNotThrow(
+                    () -> builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS")),
+                    "the empty-Optional asset branch must resolve the upstream action without throwing");
+
+            ResolvedRoute resolved = find(table, "proxy-only");
+            assertAll("empty-Optional asset branch drives the upstream terminal action",
+                    () -> assertTrue(resolved.asset().isEmpty(), "the no-asset path leaves the asset action empty"),
+                    () -> assertTrue(resolved.upstream().isPresent(),
+                            "the guarded empty-asset branch resolves the upstream terminal action"),
+                    () -> assertEquals("orders.internal", resolved.upstream().orElseThrow().host(),
+                            "the resolved upstream host is driven from the guarded empty-asset branch"));
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/RouteTableBuilderTest.java
@@ -246,8 +246,11 @@ class RouteTableBuilderTest {
             EndpointConfig endpoint = endpoint("orders", "MISSING")
                     .routes(List.of(route("r", HttpMethod.GET))).build();
 
+            GatewayConfig config = gateway().build();
+            ResolvedTopology topology = topologyWith("ORDERS");
+            List<EndpointConfig> endpoints = List.of(endpoint);
             assertThrows(RouteTableBuilder.RouteTableException.class,
-                    () -> builder.build(gateway().build(), List.of(endpoint), topologyWith("ORDERS")));
+                    () -> builder.build(config, endpoints, topology));
         }
 
         @Test
@@ -439,9 +442,10 @@ class RouteTableBuilderTest {
             EndpointConfig endpoint = anchoredEndpoint("orders", "ORDERS", "api")
                     .routes(List.of(routeWithPrefix("r", "/api/orders", HttpMethod.GET))).build();
             ResolvedTopology topology = topologyWith("ORDERS");
+            List<EndpointConfig> endpoints = List.of(endpoint);
 
             assertThrows(RouteTableBuilder.RouteTableException.class,
-                    () -> builder.build(config, List.of(endpoint), topology));
+                    () -> builder.build(config, endpoints, topology));
         }
 
         @Test
@@ -797,9 +801,10 @@ class RouteTableBuilderTest {
                     .anchor(Optional.of("assets")).auth(Optional.of(new AuthConfig("none", List.of())))
                     .routes(List.of(assetRoute("cdn", "/assets", "assets", asset))).build();
             ResolvedTopology topology = topologyWith("WEB");
+            List<EndpointConfig> endpoints = List.of(endpoint);
 
             assertThrows(RouteTableBuilder.RouteTableException.class,
-                    () -> builder.build(config, List.of(endpoint), topology));
+                    () -> builder.build(config, endpoints, topology));
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/config/load/ConfigLoaderTest.java
@@ -97,7 +97,8 @@ class ConfigLoaderTest {
     void reportsMissingEnvSecretWithPointer() throws Exception {
         copyFixtureAs("/config/valid/gateway.yaml", "gateway.yaml");
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> error.pointer().contains("client_secret")
@@ -109,7 +110,8 @@ class ConfigLoaderTest {
     void aggregatesSchemaErrorsWithPathAnnotation() throws Exception {
         copyFixtureAs("/config/invalid/unknown-key.yaml", "gateway.yaml");
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertFalse(exception.errors().isEmpty());
         assertTrue(exception.errors().stream().allMatch(error -> "gateway.yaml".equals(error.file())));
@@ -119,7 +121,8 @@ class ConfigLoaderTest {
 
     @Test
     void reportsMissingGatewayFile() {
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> "gateway.yaml".equals(error.file())
@@ -245,7 +248,8 @@ class ConfigLoaderTest {
                 """);
 
         // Act
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         // Assert — the schema refuses it at boot rather than silently ignoring the widening
         assertTrue(exception.errors().stream()
@@ -316,7 +320,8 @@ class ConfigLoaderTest {
                 """);
 
         // Act
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         // Assert — refused at boot rather than silently ignored, which would leave the issuer on
         // default trust while the operator believes a profile is in force
@@ -334,7 +339,8 @@ class ConfigLoaderTest {
                   trust_scheme_host: true
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> "gateway.yaml".equals(error.file())
@@ -401,7 +407,8 @@ class ConfigLoaderTest {
                     bogus_key: true
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> "gateway.yaml".equals(error.file()) && error.pointer().contains("anchors")),
@@ -493,7 +500,8 @@ class ConfigLoaderTest {
                   redirect_uri: "https://gw.example.com/callback"
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> error.pointer().contains("client_secret")
@@ -512,8 +520,8 @@ class ConfigLoaderTest {
                   redirect_uri: "https://gw.example.com/callback"
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class,
-                () -> loader(Map.of("OIDC_CLIENT_SECRET", "s3cr3t")).load());
+        ConfigLoader loader = loader(Map.of("OIDC_CLIENT_SECRET", "s3cr3t"));
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> error.pointer().contains("client_secret")),
@@ -530,7 +538,8 @@ class ConfigLoaderTest {
                   base_url: ORDERS
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .anyMatch(error -> error.file().contains("orders.yml")
@@ -550,8 +559,8 @@ class ConfigLoaderTest {
                   bogus_unknown_key: "trigger-an-error"
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class,
-                () -> loader(Map.of("OIDC_CLIENT_SECRET", "s3cr3t-topsecret-value")).load());
+        ConfigLoader loader = loader(Map.of("OIDC_CLIENT_SECRET", "s3cr3t-topsecret-value"));
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream()
                         .noneMatch(error -> error.message().contains("s3cr3t-topsecret-value")),
@@ -572,7 +581,8 @@ class ConfigLoaderTest {
         }
         writeConfig("gateway.yaml", yaml.toString());
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load(),
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load,
                 "a YAML document exceeding the alias-expansion limit must fail the boot");
 
         assertTrue(exception.errors().stream()
@@ -600,7 +610,8 @@ class ConfigLoaderTest {
         }
         writeConfig("gateway.yaml", yaml.toString());
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load(),
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load,
                 "a nested/exponential alias bomb must fail the boot");
 
         assertTrue(exception.errors().stream()
@@ -620,7 +631,8 @@ class ConfigLoaderTest {
                 reuse: [*b, *b, *b]
                 """);
 
-        ConfigLoadException exception = assertThrows(ConfigLoadException.class, () -> loader(Map.of()).load());
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
 
         assertTrue(exception.errors().stream().noneMatch(error -> error.message().contains("bomb protection tripped")),
                 () -> "a modest number of aliases must not trip the alias-expansion guard, got: "

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
@@ -327,7 +327,7 @@ class DispatchStageTest {
         @DisplayName("serves an upstream asset, forcing no-store on an authenticated route through the envelope")
         void servesUpstreamAssetGoverned() {
             ResolvedUpstream upstream = new ResolvedUpstream("https", "cdn.internal", 443, "");
-            UpstreamAssetSource.UpstreamFetcher fetcher = target -> new UpstreamAssetSource.UpstreamFetcher.Fetched(
+            UpstreamAssetSource.UpstreamFetcher fetcher = _ -> new UpstreamAssetSource.UpstreamFetcher.Fetched(
                     200, Map.of("Content-Type", "text/plain", "Cache-Control", "public"),
                     "PNGDATA".getBytes(StandardCharsets.UTF_8));
             UpstreamAssetSource source = new UpstreamAssetSource(upstream, AccessLevel.AUTHENTICATED,

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/DispatchStageTest.java
@@ -190,8 +190,9 @@ class DispatchStageTest {
             AtomicLong bytesSent = new AtomicLong();
             Callable<HttpClientResponse> failing = () -> {
                 attempts.incrementAndGet();
-                // awaitDispatch surfaces upstream failures as ExecutionException (from Future#get);
-                // guardedDispatch must unwrap it before mapping/retrying.
+                // NOSONAR java:S125 — explanatory prose about the ExecutionException-wrapping contract
+                // (awaitDispatch surfaces upstream failures via Future#get; guardedDispatch must unwrap
+                // it before mapping/retrying), NOT commented-out code — the throw below is live.
                 throw new ExecutionException("upstream down", new IllegalStateException("upstream down"));
             };
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
@@ -71,9 +71,9 @@ class RouteRuntimeAssemblerTest {
     void setUp() {
         vertx = Vertx.vertx();
         assembler = new RouteRuntimeAssembler(new ProtocolProcessorRegistry());
-        securityConfigFactory = filter -> SecurityConfiguration.builder().build();
-        clientFactory = target -> vertx.createHttpClient();
-        guardFactory = shape -> new StoredOnlyGuard();
+        securityConfigFactory = _ -> SecurityConfiguration.builder().build();
+        clientFactory = _ -> vertx.createHttpClient();
+        guardFactory = _ -> new StoredOnlyGuard();
         assetSourceFactory = asset -> new DirectoryAssetSource(Path.of(asset.directory().orElse("/tmp")),
                 asset.access());
     }
@@ -154,15 +154,18 @@ class RouteRuntimeAssemblerTest {
     @Test
     @DisplayName("Should fail boot for session auth and unsupported protocols")
     void shouldFailBootForSessionAndUnsupportedProtocols() {
-        var session = assertThrows(GatewayException.class, () -> assembler.assemble(
-                new RouteTable(List.of(route("s", Protocol.HTTP, "session", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "session auth must fail boot");
-        var grpc = assertThrows(GatewayException.class, () -> assembler.assemble(
-                new RouteTable(List.of(route("g", Protocol.GRPC, "none", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "gRPC must fail boot");
-        var websocket = assertThrows(GatewayException.class, () -> assembler.assemble(
-                new RouteTable(List.of(route("w", Protocol.WEBSOCKET, "none", Optional.empty(), upstream("a.example")))),
-                securityConfigFactory, clientFactory, guardFactory, assetSourceFactory), "WebSocket must fail boot");
+        RouteTable sessionTable = new RouteTable(List.of(route("s", Protocol.HTTP, "session", Optional.empty(), upstream("a.example"))));
+        var session = assertThrows(GatewayException.class,
+                () -> assembler.assemble(sessionTable, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory),
+                "session auth must fail boot");
+        RouteTable grpcTable = new RouteTable(List.of(route("g", Protocol.GRPC, "none", Optional.empty(), upstream("a.example"))));
+        var grpc = assertThrows(GatewayException.class,
+                () -> assembler.assemble(grpcTable, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory),
+                "gRPC must fail boot");
+        RouteTable webSocketTable = new RouteTable(List.of(route("w", Protocol.WEBSOCKET, "none", Optional.empty(), upstream("a.example"))));
+        var websocket = assertThrows(GatewayException.class,
+                () -> assembler.assemble(webSocketTable, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory),
+                "WebSocket must fail boot");
 
         assertEquals(EventType.CONFIG_INVALID, session.getEventType(), "session rejection is a config failure");
         assertEquals(EventType.CONFIG_INVALID, grpc.getEventType(), "gRPC rejection is a config failure");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssemblerTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.api.edge;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -232,6 +233,23 @@ class RouteRuntimeAssemblerTest {
         assertTrue(runtime.getUpstream().isEmpty(), "an asset route holds no proxy upstream");
         assertTrue(runtime.getHttpClient().isEmpty(), "an asset route holds no Vert.x client");
         assertTrue(runtime.getResilienceGuard().isEmpty(), "an asset route holds no resilience guard");
+    }
+
+    @Test
+    @DisplayName("Should assemble the empty-Optional (no-asset) proxy path into an upstream/client/guard runtime without throwing (S3655 guard)")
+    void shouldAssembleNoAssetProxyPathWithoutThrowing() {
+        RouteTable table = new RouteTable(List.of(
+                route("proxy-only", Protocol.HTTP, "none", Optional.empty(), upstream("a.example"))));
+
+        List<RouteRuntime> runtimes = assertDoesNotThrow(
+                () -> assembler.assemble(table, securityConfigFactory, clientFactory, guardFactory, assetSourceFactory),
+                "the empty-Optional asset branch must assemble the proxy runtime without throwing");
+
+        RouteRuntime runtime = runtimes.getFirst();
+        assertTrue(runtime.getAssetSource().isEmpty(), "the no-asset path carries no asset source");
+        assertTrue(runtime.getUpstream().isPresent(), "the guarded empty-asset branch resolves the proxy upstream");
+        assertTrue(runtime.getHttpClient().isPresent(), "the proxy path builds a Vert.x client");
+        assertTrue(runtime.getResilienceGuard().isPresent(), "the proxy path builds a resilience guard");
     }
 
     private static ResolvedRoute route(String id, Protocol protocol, String require,

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/events/GatewayEventCounterTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/events/GatewayEventCounterTest.java
@@ -57,7 +57,7 @@ class GatewayEventCounterTest {
         int increments = 10_000;
 
         IntStream.range(0, increments).parallel()
-                .forEach(i -> counter.increment(EventType.SECURITY_FILTER_VIOLATION));
+                .forEach(_ -> counter.increment(EventType.SECURITY_FILTER_VIOLATION));
 
         assertEquals(increments, counter.getCount(EventType.SECURITY_FILTER_VIOLATION),
                 "Every concurrent increment must be counted");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/api/forward/TcpPeerGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/api/forward/TcpPeerGateTest.java
@@ -165,7 +165,8 @@ class TcpPeerGateTest {
         @DisplayName("rejects a malformed trusted-proxy CIDR at construction")
         void rejectsMalformedCidr(String badCidr) {
             // Act + Assert
-            assertThrows(IllegalArgumentException.class, () -> new TcpPeerGate(List.of(badCidr)),
+            List<String> cidrs = List.of(badCidr);
+            assertThrows(IllegalArgumentException.class, () -> new TcpPeerGate(cidrs),
                     "malformed CIDR must fail loud at boot");
         }
 

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -31,6 +31,11 @@ This tree is seeded here and grows as contributor-facing material lands.
 | link:../adr/0005-module-structure.adoc[ADR-0005 -- Module Structure]
 | Why the project is one Quarkus module today, with a package-layout + arch-gate seam kept
   clean so a core module is cheap to extract later.
+
+| link:sonar-quality-gate.adoc[SonarCloud Quality Gate -- Compliance Policy]
+| The rules around the authoritative, blocking SonarCloud gate -- zero new findings, never
+  merging over a red or stale-green gate, PR-new-code vs post-merge project-gate auditability,
+  and the fix-by-default / suppress-with-rationale escape hatch.
 |===
 
 == Scope of This Layer

--- a/doc/development/sonar-quality-gate.adoc
+++ b/doc/development/sonar-quality-gate.adoc
@@ -1,0 +1,70 @@
+= SonarCloud Quality Gate -- Compliance Policy
+:toc:
+:toclevels: 2
+:sectnums:
+
+The rules a contributor follows around the SonarCloud analysis of API Sheriff. This page states
+*the policy*; it deliberately does not restate the gate's concrete thresholds -- those are owned
+by the cuioss-organization and would drift if copied here.
+
+== The gate is authoritative, blocking, and required
+
+API Sheriff is analysed by the cuioss-organization SonarCloud project
+link:https://sonarcloud.io/project/overview?id=cuioss_API-Sheriff[`cuioss_API-Sheriff`]. The
+quality gate on that project is the *authoritative, blocking, required* check:
+
+* It is declared for this repository via link:../../.github/project.yml[`.github/project.yml`]
+  (`sonar.project-key: cuioss_API-Sheriff`) and runs inside the cuioss-organization *reusable
+  Maven build* -- it is not a step this repository configures or can weaken locally.
+* The gate thresholds, quality profiles, and new-code definition are *organization assets*. This
+  page *references* them as the single source of truth; it does not copy them. If the gate itself
+  needs to change, that is an organization-admin escalation, not a change to this repository.
+
+The target is *zero new findings*: a change must not introduce a new bug, vulnerability, security
+hotspot, or code smell that the gate counts against the new-code period.
+
+== Never merge over a red gate or a stale green
+
+* A *red* gate blocks the merge. Do not merge, and do not seek an administrative override -- fix
+  the finding (or suppress it with a rationale, see below) and let the gate go green on its own.
+* A *stale green* is equally disqualifying. When analysis is still pending (the SonarCloud
+  Compute Engine has not finished processing the latest commit), a previously-green status does
+  not describe the code you are about to ship. Wait for the analysis of the *current* commit to
+  complete before treating the gate as green.
+
+== PR new-code green is not project green
+
+SonarCloud reports two distinct things, and they are audited separately:
+
+* *PR new-code analysis* -- the findings the gate attributes to the changes on the pull request
+  branch. A green PR new-code gate is the *merge precondition*.
+* *Project analysis* -- the findings on `main` after the merge lands, over the whole project's
+  new-code period.
+
+A plan is *not "done" / "all green"* until the *post-merge PROJECT gate* is green. A transient
+PR-scoped new-code green is necessary but not sufficient: the completion report must reflect the
+project gate on `main`, not merely the PR gate. This is the auditability nuance -- always confirm
+the project dashboard, not just the PR check, before declaring compliance.
+
+== Fix by default; suppress only with a documented rationale
+
+Fixing the finding is the goal. Where a fix is genuinely not sensible -- a false positive, a
+deliberate idiom, or a rule fighting the design -- an *auditable in-code suppression* is the
+accepted escape hatch:
+
+* `// NOSONAR java:SXXXX <why>` on the flagged line, or
+* `@SuppressWarnings("java:SXXXX")` on the element,
+
+each carrying a short comment that justifies *why* the finding does not apply. The suppression
+lives in the source, in version control, where a reviewer can see and challenge it.
+
+Reaching zero by *silently marking issues won't-fix or false-positive in the SonarCloud UI* is
+*not acceptable* -- that decision leaves no trace in the codebase and cannot be reviewed in a pull
+request. Every deviation from a clean gate must be visible and justified in the source.
+
+== See also
+
+* link:../../.github/project.yml[`.github/project.yml`] -- the repository's SonarCloud declaration.
+* link:https://sonarcloud.io/project/overview?id=cuioss_API-Sheriff[SonarCloud project dashboard]
+  -- the authoritative gate status and the owner of the concrete thresholds.
+* link:README.adoc[Contributor Guide] -- the index for this documentation layer.


### PR DESCRIPTION
## Summary

Drives the API Sheriff codebase toward zero open SonarCloud findings and documents the zero-findings compliance policy. Fixes the two gate-failing `java:S3655` unguarded-Optional bugs first (`RouteTableBuilder`, `RouteRuntimeAssembler`), investigates and remediates the four flagged care-item findings, extracts duplicated string literals to constants, applies a mechanical Java-25 modernization sweep across `api-sheriff`, and adds contributor-facing documentation of the SonarCloud compliance policy.

## Changes

- **Bug fixes** (`java:S3655` unguarded-Optional): `api-sheriff/src/main/java/de/cuioss/sheriff/api/config/RouteTableBuilder.java`, `api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/RouteRuntimeAssembler.java`, with matching empty-Optional regression tests in `RouteTableBuilderTest.java` and `RouteRuntimeAssemblerTest.java`.
- **Care-item investigation/remediation**: `api-sheriff/src/main/java/de/cuioss/sheriff/api/edge/DispatchStage.java` and `DispatchStageTest.java`.
- **Duplicated-literal extraction** (`java:S1192`): `api-sheriff/src/main/java/de/cuioss/sheriff/api/config/validation/ConfigValidator.java`, `api-sheriff/src/main/java/de/cuioss/sheriff/api/auth/TokenValidatorProducer.java`.
- **Mechanical Java-25 modernization sweep** across `api-sheriff/src/main/java/de/cuioss/sheriff/api/` (asset, config, edge, forward packages) and matching test files: `AssetSource.java`, `DirectoryAssetSource.java`, `PathConfinement.java`, `UpstreamAssetSource.java` (+ `UpstreamAssetSourceTest.java`), `EnvSecretResolver.java` (+ `ConfigLoaderTest.java`), `GatewayEdgeRoute.java`, `ForwardPolicyStage.java`, `TcpPeerGate.java` (+ `TcpPeerGateTest.java`), `GatewayEventCounterTest.java`.
- **Documentation**: new contributor page `doc/development/sonar-quality-gate.adoc` (with `doc/development/README.adoc` index update) documenting the org-owned SonarCloud gate as authoritative and blocking, zero-new-findings policy, never-merge-over-red-or-stale-green rule, PR-new-code-vs-project-analysis auditability nuance, and fix-by-default / suppress-with-rationale rule; new "Sonar / Quality Gate" section in `CLAUDE.md` referencing the org gate and the new page.
- **Operator addendum**: `README.adoc` benchmark badge link fixes and WRK→k6 prose update.

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`)
- [ ] Post-push SonarCloud new-code gate green
- [ ] Manual testing completed (if applicable)

## Related Issues

None.

---
Generated by plan-finalize skill
