### PR TITLE
chore(steward): land plan-marshall 0.1.1182 upgrade artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -297,7 +297,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1172",
+    "provisioned_version": "0.1.1182",
     "config_seed_fingerprint": "daa4978b"
   }
 }

--- a/.plan/project-architecture/api-sheriff-parent/enriched.json
+++ b/.plan/project-architecture/api-sheriff-parent/enriched.json
@@ -1,7 +1,8 @@
 {
   "best_practices": [],
   "insights": [
-    "CI aggregation gates (build/conclusion, integration-tests/conclusion) fail only as derivatives of their upstream jobs, and a red build/sonar-build with successful scanner auth means a genuine server-side SonarCloud new-code quality-gate verdict (fetchable without credentials via the public sonarcloud.io API) \u2014 triage the upstream cause, never the aggregation gate."
+    "CI aggregation gates (build/conclusion, integration-tests/conclusion) fail only as derivatives of their upstream jobs, and a red build/sonar-build with successful scanner auth means a genuine server-side SonarCloud new-code quality-gate verdict (fetchable without credentials via the public sonarcloud.io API) \u2014 triage the upstream cause, never the aggregation gate.",
+    "CI rollup 'conclusion' gate jobs (build / conclusion, integration-tests / conclusion) fail solely as mirrors of their failing child job; the project treats them as carrying no independent root cause and dispositions them taken_into_account, triaging only the child job's failure."
   ],
   "internal_dependencies": [
     "api-sheriff",

--- a/.plan/project-architecture/api-sheriff/enriched.json
+++ b/.plan/project-architecture/api-sheriff/enriched.json
@@ -1,7 +1,8 @@
 {
   "best_practices": [
     "Placeholder-substitution coercion in ConfigLoader.coerce() is schema-agnostic (accepted limitation, recurring review finding): a whole-value placeholder resolving to an all-digit or true/false string is coerced regardless of the target field's schema type. When touching the substitution path, prefer threading the expected schema type through substitute()/coerce() (destination-type-aware coercion) rather than adding value-shape heuristics.",
-    "Asset-serving hot path is deliberately virtual-thread-blocking (pipeline dispatched via virtualThreadExecutor; event-loop hop only for the write) and security guards re-resolve per request (root toRealPath TOCTOU check in DirectoryAssetSource) \u2014 decline review-bot suggestions to wrap in vertx.executeBlocking or to cache the resolved root, both recur and both are by-design."
+    "Asset-serving hot path is deliberately virtual-thread-blocking (pipeline dispatched via virtualThreadExecutor; event-loop hop only for the write) and security guards re-resolve per request (root toRealPath TOCTOU check in DirectoryAssetSource) \u2014 decline review-bot suggestions to wrap in vertx.executeBlocking or to cache the resolved root, both recur and both are by-design.",
+    "Verify review-bot claims that a Vert.x API does not exist against the green build before acting: gemini-code-assist repeatedly asserted compilation errors for real Vert.x methods (e.g. HttpServerResponse.ended()) on edge-relay code, and the project consistently accepts these as false positives when the whole-tree build and native ITs are green."
   ],
   "insights": [],
   "internal_dependencies": [],


### PR DESCRIPTION
## Summary

Steward `upgrade` reconciliation after the plan-marshall marketplace update to 0.1.1182:

- Regenerated `.plan/execute-script.py` executor against plan-marshall 0.1.1182 (135 scripts discovered)
- Reconciled `marshal.json` provisioning stamps (`sync-defaults` / `steps-sort` — no defaults added, step order unchanged)
- Refreshed `project-architecture` enriched metadata for `api-sheriff-parent` and `api-sheriff`

Verify stage passed: executor and config both fresh at 0.1.1182; `build.map` in sync with the live-tree derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
