### PR TITLE
chore(quality): drive Sonar findings to zero and close deps backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ See `doc/development/sonar-quality-gate.adoc` for the complete compliance policy
 
 ## Dependency Management
 
-- **Parent POM**: `de.cuioss:cui-java-parent:1.5.1`
+- **Parent POM**: `de.cuioss:cui-java-parent:1.5.4`
 - **CRITICAL**: Never add dependencies without explicit user approval
 
 ## Git Workflow

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffApplication.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffLogMessages.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
@@ -150,7 +150,7 @@ public final class DirectoryAssetSource implements AssetSource {
     private boolean realPathWithinRoot(Path file) {
         try {
             return file.toRealPath().startsWith(root.toRealPath());
-        } catch (IOException unresolvable) {
+        } catch (IOException _) {
             return false;
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
@@ -99,7 +99,7 @@ public final class PathConfinement {
         try {
             String asAbsolute = "/" + stripLeadingSlashes(requestSubPath);
             canonical = pathValidator.validate(asAbsolute).orElse("/");
-        } catch (UrlSecurityException rejected) {
+        } catch (UrlSecurityException _) {
             return Optional.empty();
         }
         String relative = stripLeadingSlashes(canonical);

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
@@ -76,7 +76,6 @@ public final class UpstreamAssetSource implements AssetSource {
     /** The default upstream read timeout. */
     public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(10);
 
-    private static final int OK = 200;
     private static final int NOT_FOUND = 404;
     private static final int METHOD_NOT_ALLOWED = 405;
     private static final int PAYLOAD_TOO_LARGE = 413;
@@ -160,7 +159,7 @@ public final class UpstreamAssetSource implements AssetSource {
         UpstreamFetcher.Fetched fetched;
         try {
             fetched = fetcher.fetch(target);
-        } catch (UpstreamFetcher.UpstreamTimeoutException timeout) {
+        } catch (UpstreamFetcher.UpstreamTimeoutException _) {
             return new Served(GATEWAY_TIMEOUT, Map.of(), EMPTY_BODY);
         } catch (IOException _) {
             return new Served(BAD_GATEWAY, Map.of(), EMPTY_BODY);

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/AuthenticationStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/AuthenticationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/GatewayValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/GatewayValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/ConfigLogMessages.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/ConfigLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/RouteTableBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/RouteTableBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigError.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoadException.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
@@ -374,7 +374,7 @@ public final class ConfigLoader {
                     return IntNode.valueOf((int) parsed);
                 }
                 return LongNode.valueOf(parsed);
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException _) {
                 return TextNode.valueOf(value);
             }
         }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AccessLevel.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AccessLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorType.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AuthConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AuthConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EndpointConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardedConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/GatewayConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/GatewayConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/HttpMethod.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/IssuerConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/IssuerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/MatchConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/MatchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Metadata.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/OidcConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/OidcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Protocol.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RateLimitConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RateLimitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
@@ -64,6 +64,12 @@ Optional<ResolvedUpstream> upstream) {
      * upstream, an {@link AssetConfig.Source#UPSTREAM} action carries a resolved
      * upstream and no directory.
      */
+    // NOSONAR java:S6916 - the rule suggests replacing each case's if with a `when` guard, but
+    // guards attach only to PATTERN labels; `case DIRECTORY when ...` on an enum CONSTANT label
+    // is a compile error (verified against javac --release 25). The suggested remedy is therefore
+    // inapplicable at this site, and the alternative (switching on a type pattern) would restructure
+    // the invariant check rather than address the finding.
+    @SuppressWarnings("java:S6916")
     public ResolvedAsset {
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(access, "access");

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedTopology.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedUpstream.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedUpstream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteTable.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityFilterConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityFilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityHeadersConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityHeadersConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TlsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TlsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TokenValidationConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TokenValidationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamDefaultsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/WebSocketConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/WebSocketConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
@@ -120,7 +120,7 @@ public final class ConfigValidator {
             (gateway, endpoints, topology, errors) -> validateAnchorAuthFloor(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateEffectiveAuth(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateAccessAuthMatrix(gateway, errors),
-            (gateway, endpoints, topology, errors) -> validateTerminalAction(gateway, endpoints, topology, errors),
+            ConfigValidator::validateTerminalAction,
             (gateway, endpoints, topology, errors) -> validateMethodMembership(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validateForwardedTrust(gateway, errors),
             (gateway, endpoints, topology, errors) -> validateCors(gateway, errors),
@@ -553,6 +553,11 @@ public final class ConfigValidator {
      * action requires a {@code directory} root; a {@code source: upstream} action requires an
      * {@code upstream} topology alias that resolves.
      */
+    // NOSONAR java:S6916 - the rule suggests replacing each case's if with a `when` guard, but
+    // guards attach only to PATTERN labels; `case DIRECTORY when ...` on an enum CONSTANT label
+    // is a compile error (verified against javac --release 25). Restructuring further would move
+    // alias-resolvability error reporting out of this method, which ADR-9 forbids.
+    @SuppressWarnings("java:S6916")
     private static void validateAssetSource(EndpointConfig endpoint, RouteConfig route, AssetConfig asset,
             ResolvedTopology topology, List<ConfigError> errors) {
         switch (asset.source()) {
@@ -675,13 +680,13 @@ public final class ConfigValidator {
         int prefixLength;
         try {
             prefixLength = Integer.parseInt(cidr.substring(slash + 1));
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException _) {
             return Optional.empty();
         }
         byte[] bytes;
         try {
             bytes = InetAddress.ofLiteral(cidr.substring(0, slash)).getAddress();
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
             return Optional.empty();
         }
         int bits = bytes.length * 8;

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/ValidationRule.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/ValidationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/DispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/DispatchStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningOptions.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -682,7 +682,7 @@ public class GatewayEdgeRoute {
     private static Optional<HttpMethod> parseMethod(String name) {
         try {
             return Optional.of(HttpMethod.valueOf(name));
-        } catch (IllegalArgumentException unsupported) {
+        } catch (IllegalArgumentException _) {
             return Optional.empty();
         }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapper.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssembler.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapper.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventCategory.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventType.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayEventCounter.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayException.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/TcpPeerGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/TcpPeerGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuard.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/FramingGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/FramingGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PipelineRequest.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PipelineRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflection.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/GatewayReadinessCheck.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/GatewayReadinessCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetrics.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/HttpProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/HttpProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessorRegistry.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteMatcher.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteRuntime.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/FrameworkAgnosticArchTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/FrameworkAgnosticArchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
@@ -149,7 +149,7 @@ class AssetResponseEnvelopeTest {
                     "app.js", AccessLevel.PUBLIC, sourceHeaders);
 
             assertAll(
-                    () -> assertFalse(governed.keySet().stream().anyMatch(k -> "Set-Cookie".equalsIgnoreCase(k)),
+                    () -> assertFalse(governed.keySet().stream().anyMatch("Set-Cookie"::equalsIgnoreCase),
                             "an asset action must never establish a session"),
                     () -> assertEquals("kept", governed.get("X-Custom"),
                             "unrelated source headers pass through"));

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetSourceServedTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetSourceServedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
@@ -19,12 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 
 import de.cuioss.sheriff.gateway.config.model.AccessLevel;
@@ -124,6 +127,56 @@ class DirectoryAssetSourceTest {
                         "a symlink resolving outside the root must be denied even though it lexically "
                                 + "sits inside root"),
                 () -> assertEquals(0, served.body().length, "no byte of the symlink target is served"));
+    }
+
+    @Test
+    @DisplayName("Should deny an in-root entry whose real path cannot be resolved (fails closed)")
+    void shouldDenyUnresolvableRealPath() throws Exception {
+        Path procFd = Path.of("/proc/self/fd");
+        assumeTrue(Files.isDirectory(procFd), "requires the Linux /proc filesystem to stage the entry");
+        Path vanishing = Files.write(tempDir.resolve("vanishing.bin"), INDEX_BODY);
+        try (InputStream _ = Files.newInputStream(vanishing)) {
+            // A held descriptor of a deleted file still stats as a regular file through its /proc magic
+            // link, but its real path no longer resolves — the deterministic stand-in for the TOCTOU
+            // removal the real-path check must survive.
+            Files.delete(vanishing);
+            Path magicLink = deletedDescriptorLink(procFd, vanishing);
+            assumeTrue(magicLink != null, "no /proc/self/fd entry resolved to the deleted file");
+            Path link = root.resolve("unresolvable.html");
+            try {
+                Files.createSymbolicLink(link, magicLink);
+            } catch (IOException | UnsupportedOperationException unsupported) {
+                assumeTrue(false, "symbolic links are not supported/permitted in this environment: "
+                        + unsupported.getMessage());
+            }
+            assumeTrue(Files.isRegularFile(link), "the staged entry must still stat as a regular file");
+            assertThrows(IOException.class, link::toRealPath,
+                    "the staged entry must fail real-path resolution for this test to exercise the "
+                            + "fail-closed branch");
+
+            AssetSource.Served served = publicSource().serve(HttpMethod.GET, "unresolvable.html");
+
+            assertAll(
+                    () -> assertEquals(NOT_FOUND, served.status(),
+                            "an entry whose real path cannot be resolved must be denied"),
+                    () -> assertEquals(0, served.body().length, "no byte is served for an unresolvable entry"));
+        }
+    }
+
+    /**
+     * Locates the {@code /proc/self/fd} magic link that still refers to the just-deleted
+     * {@code deleted} file (the kernel renders such a target as {@code <path> (deleted)}).
+     */
+    private static Path deletedDescriptorLink(Path procFd, Path deleted) throws IOException {
+        try (Stream<Path> entries = Files.list(procFd)) {
+            return entries.filter(entry -> {
+                try {
+                    return Files.readSymbolicLink(entry).toString().startsWith(deleted.toString());
+                } catch (IOException | UnsupportedOperationException _) {
+                    return false;
+                }
+            }).findFirst().orElse(null);
+        }
     }
 
     @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -135,7 +134,7 @@ class DirectoryAssetSourceTest {
         Path procFd = Path.of("/proc/self/fd");
         assumeTrue(Files.isDirectory(procFd), "requires the Linux /proc filesystem to stage the entry");
         Path vanishing = Files.write(tempDir.resolve("vanishing.bin"), INDEX_BODY);
-        try (InputStream _ = Files.newInputStream(vanishing)) {
+        try (var _ = Files.newInputStream(vanishing)) {
             // A held descriptor of a deleted file still stats as a regular file through its /proc magic
             // link, but its real path no longer resolves — the deterministic stand-in for the TOCTOU
             // removal the real-path check must survive.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/PathConfinementTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/PathConfinementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceHttpFetcherTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceHttpFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
@@ -113,7 +113,7 @@ class UpstreamAssetSourceTest {
         AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
 
         assertAll(
-                () -> assertFalse(served.headers().keySet().stream().anyMatch(k -> "Set-Cookie".equalsIgnoreCase(k)),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch("Set-Cookie"::equalsIgnoreCase),
                         "an upstream Set-Cookie must never reach the client"),
                 () -> assertEquals("yes", served.headers().get("X-Keep")));
     }

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TestTlsConfigurationRegistry.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TestTlsConfigurationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
@@ -40,6 +40,8 @@ import de.cuioss.sheriff.token.validation.TokenValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("TokenValidatorProducer — builds the shared gateway validator from token_validation")
 class TokenValidatorProducerTest {
@@ -112,48 +114,20 @@ class TokenValidatorProducerTest {
         assertEquals(EventType.CONFIG_INVALID, thrown.getEventType());
     }
 
-    @Test
-    @DisplayName("fails config-invalid when an http jwks source declares no url")
-    void failsWhenHttpJwksHasNoUrl() {
+    /**
+     * Covers the three unusable jwks-source shapes that must all fail config-invalid:
+     * an {@code http} source without a url, a {@code file} source without a file path,
+     * and a source that is not supported at all.
+     */
+    @ParameterizedTest(name = "jwks source ''{0}''")
+    @ValueSource(strings = {"http", "file", "ldap"})
+    @DisplayName("fails config-invalid when a jwks source is incomplete or unsupported")
+    void failsForUnusableJwksSource(String source) {
         // Arrange
         TokenValidatorProducer producer = producerFor(IssuerConfig.builder()
                 .name("primary")
                 .issuer(ISSUER)
-                .jwks(Optional.of(IssuerConfig.Jwks.builder().source("http").build()))
-                .build());
-
-        // Act
-        GatewayException thrown = assertThrows(GatewayException.class, producer::gatewayTokenValidator);
-
-        // Assert
-        assertEquals(EventType.CONFIG_INVALID, thrown.getEventType());
-    }
-
-    @Test
-    @DisplayName("fails config-invalid when a file jwks source declares no file path")
-    void failsWhenFileJwksHasNoFile() {
-        // Arrange
-        TokenValidatorProducer producer = producerFor(IssuerConfig.builder()
-                .name("primary")
-                .issuer(ISSUER)
-                .jwks(Optional.of(IssuerConfig.Jwks.builder().source("file").build()))
-                .build());
-
-        // Act
-        GatewayException thrown = assertThrows(GatewayException.class, producer::gatewayTokenValidator);
-
-        // Assert
-        assertEquals(EventType.CONFIG_INVALID, thrown.getEventType());
-    }
-
-    @Test
-    @DisplayName("fails config-invalid for an unsupported jwks source")
-    void failsForUnsupportedJwksSource() {
-        // Arrange
-        TokenValidatorProducer producer = producerFor(IssuerConfig.builder()
-                .name("primary")
-                .issuer(ISSUER)
-                .jwks(Optional.of(IssuerConfig.Jwks.builder().source("ldap").build()))
+                .jwks(Optional.of(IssuerConfig.Jwks.builder().source(source).build()))
                 .build());
 
         // Act
@@ -371,8 +345,8 @@ class TokenValidatorProducerTest {
                     .build());
 
             // Act
-            GatewayException thrown = assertThrows(GatewayException.class,
-                    () -> producerFor(issuer, TestTlsConfigurationRegistry.empty()).gatewayTokenValidator());
+            TokenValidatorProducer producer = producerFor(issuer, TestTlsConfigurationRegistry.empty());
+            GatewayException thrown = assertThrows(GatewayException.class, producer::gatewayTokenValidator);
 
             // Assert — the failure surfaces at validator assembly, which boot forces, so the
             // gateway refuses to start instead of silently validating against default trust

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
@@ -490,6 +490,18 @@ class ConfigLoaderTest {
     }
 
     @Test
+    void keepsAnAllDigitSubstitutionTooLargeForALongAsText() throws Exception {
+        copyFixtureAs("/config/valid/gateway.yaml", "gateway.yaml");
+        String tooLargeForALong = "9".repeat(20);
+
+        ConfigLoader.LoadedConfig loaded = loader(Map.of("OIDC_CLIENT_SECRET", tooLargeForALong)).load();
+
+        assertEquals(Optional.of(tooLargeForALong), loaded.gateway().oidc().orElseThrow().clientSecret(),
+                "an all-digit substitution that overflows a long must fall back to a text node rather than "
+                        + "propagate the parse failure");
+    }
+
+    @Test
     void rejectsLiteralSecretValue() throws Exception {
         writeConfig("gateway.yaml", """
                 version: 1

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
@@ -530,7 +530,8 @@ class ConfigModelContractTest {
         @Test
         void listComponentIsUnmodifiable() {
             GatewayConfig cfg = GatewayConfig.builder().version(1).allowedMethods(List.of(HttpMethod.GET)).build();
-            assertThrows(UnsupportedOperationException.class, () -> cfg.allowedMethods().add(HttpMethod.PUT));
+            List<HttpMethod> methods = cfg.allowedMethods();
+            assertThrows(UnsupportedOperationException.class, () -> methods.add(HttpMethod.PUT));
         }
 
         @Test
@@ -541,7 +542,9 @@ class ConfigModelContractTest {
             source.put("bff", anchorConfig());
             assertEquals(Map.of("api", anchorConfig()), cfg.anchors(),
                     "mutating the source map after construction must not affect the record");
-            assertThrows(UnsupportedOperationException.class, () -> cfg.anchors().put("extra", anchorConfig()));
+            Map<String, AnchorConfig> anchors = cfg.anchors();
+            AnchorConfig extra = anchorConfig();
+            assertThrows(UnsupportedOperationException.class, () -> anchors.put("extra", extra));
         }
 
         @Test
@@ -551,7 +554,8 @@ class ConfigModelContractTest {
             ForwardConfig cfg = ForwardConfig.builder().setHeaders(source).build();
             source.put("X-Extra", "leak");
             assertEquals(Map.of("X-Gateway", "sheriff"), cfg.setHeaders());
-            assertThrows(UnsupportedOperationException.class, () -> cfg.setHeaders().put("X-New", "v"));
+            Map<String, String> headers = cfg.setHeaders();
+            assertThrows(UnsupportedOperationException.class, () -> headers.put("X-New", "v"));
         }
 
         @Test
@@ -574,12 +578,17 @@ class ConfigModelContractTest {
 
         @Test
         void endpointConfigRequiresIdAndBaseUrl() {
-            assertThrows(NullPointerException.class,
-                    () -> new EndpointConfig(null, true, "url", Optional.empty(), Optional.of(auth()), List.of(),
-                            Optional.empty(), List.of()));
-            assertThrows(NullPointerException.class,
-                    () -> new EndpointConfig("id", true, null, Optional.empty(), Optional.of(auth()), List.of(),
-                            Optional.empty(), List.of()));
+            assertThrows(NullPointerException.class, () -> endpointConfigWith(null, "url"));
+            assertThrows(NullPointerException.class, () -> endpointConfigWith("id", null));
+        }
+
+        /**
+         * Builds an otherwise-valid {@link EndpointConfig} so a mandatory-field test can vary
+         * exactly one component, keeping each {@code assertThrows} lambda to a single invocation.
+         */
+        private EndpointConfig endpointConfigWith(String id, String baseUrl) {
+            return new EndpointConfig(id, true, baseUrl, Optional.empty(), Optional.of(auth()), List.of(),
+                    Optional.empty(), List.of());
         }
 
         @Test
@@ -644,34 +653,47 @@ class ConfigModelContractTest {
         @Test
         void routeConfigRequiresIdAndMatch() {
             MatchConfig match = matchConfig();
-            assertThrows(NullPointerException.class, () -> new RouteConfig(null, Optional.empty(), Optional.empty(),
-                    match, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                    Optional.empty(), Optional.empty()));
-            assertThrows(NullPointerException.class, () -> new RouteConfig("id", Optional.empty(), Optional.empty(),
-                    null, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                    Optional.empty(), Optional.empty()));
+            assertThrows(NullPointerException.class, () -> routeConfigWith(null, match));
+            assertThrows(NullPointerException.class, () -> routeConfigWith("id", null));
+        }
+
+        /**
+         * Builds an otherwise-valid {@link RouteConfig} so a mandatory-field test can vary
+         * exactly one component, keeping each {@code assertThrows} lambda to a single invocation.
+         */
+        private RouteConfig routeConfigWith(String id, MatchConfig match) {
+            return new RouteConfig(id, Optional.empty(), Optional.empty(), match, Optional.empty(), Optional.empty(),
+                    Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         }
 
         @Test
         void resolvedRouteRequiresIdMatchAuthAndExactlyOneTerminalAction() {
-            assertThrows(NullPointerException.class, () -> new ResolvedRoute(null, Protocol.HTTP, Optional.empty(),
-                    matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true,
-                    Optional.of(resolvedUpstream()), Optional.empty(), null, null, null));
-            assertThrows(NullPointerException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(), null,
-                    auth(), List.of(), Optional.empty(), Optional.empty(), true, true, Optional.of(resolvedUpstream()),
-                    Optional.empty(), null, null, null));
-            assertThrows(NullPointerException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
-                    matchConfig(), null, List.of(), Optional.empty(), Optional.empty(), true, true,
-                    Optional.of(resolvedUpstream()), Optional.empty(), null, null, null));
-            assertThrows(IllegalArgumentException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
-                            matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true, Optional.empty(),
-                            Optional.empty(), null, null, null),
+            MatchConfig match = matchConfig();
+            AuthConfig auth = auth();
+            Optional<ResolvedUpstream> upstream = Optional.of(resolvedUpstream());
+            Optional<ResolvedUpstream> noUpstream = Optional.empty();
+            Optional<ResolvedAsset> noAsset = Optional.empty();
+            Optional<ResolvedAsset> asset = Optional.of(ResolvedAsset.directory("/srv", AccessLevel.PUBLIC));
+
+            assertThrows(NullPointerException.class, () -> resolvedRouteWith(null, match, auth, upstream, noAsset));
+            assertThrows(NullPointerException.class, () -> resolvedRouteWith("id", null, auth, upstream, noAsset));
+            assertThrows(NullPointerException.class, () -> resolvedRouteWith("id", match, null, upstream, noAsset));
+            assertThrows(IllegalArgumentException.class,
+                    () -> resolvedRouteWith("id", match, auth, noUpstream, noAsset),
                     "a route with neither an upstream nor an asset terminal action is rejected (XOR)");
-            assertThrows(IllegalArgumentException.class, () -> new ResolvedRoute("id", Protocol.HTTP, Optional.empty(),
-                            matchConfig(), auth(), List.of(), Optional.empty(), Optional.empty(), true, true,
-                            Optional.of(resolvedUpstream()), Optional.of(ResolvedAsset.directory("/srv", AccessLevel.PUBLIC)),
-                            null, null, null),
+            assertThrows(IllegalArgumentException.class,
+                    () -> resolvedRouteWith("id", match, auth, upstream, asset),
                     "a route with both an upstream and an asset terminal action is rejected (XOR)");
+        }
+
+        /**
+         * Builds an otherwise-valid {@link ResolvedRoute} so a mandatory-field or XOR test can vary
+         * exactly one component, keeping each {@code assertThrows} lambda to a single invocation.
+         */
+        private ResolvedRoute resolvedRouteWith(String id, MatchConfig match, AuthConfig auth,
+                Optional<ResolvedUpstream> upstream, Optional<ResolvedAsset> asset) {
+            return new ResolvedRoute(id, Protocol.HTTP, Optional.empty(), match, auth, List.of(), Optional.empty(),
+                    Optional.empty(), true, true, upstream, asset, null, null, null);
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -513,60 +513,24 @@ class ConfigValidatorTest {
             assertHasError(errors, "/forwarded/trusted_proxies", expectedDetail);
         }
 
-        @Test
+        /**
+         * Each entry fails CIDR parsing at a different point: no slash at all, a numeric prefix
+         * length outside the address width, a prefix length that is not a number, and an address
+         * part that is not an IP literal. All four must be reported identically.
+         */
+        @ParameterizedTest(name = "trusted_proxies entry \"{0}\" is rejected as malformed")
+        @ValueSource(strings = {"not-a-cidr", "10.0.0.0/33", "10.0.0.0/abc", "not-an-ip/24"})
         @DisplayName("Should reject a malformed trusted_proxies CIDR entry with file/pointer context")
-        void shouldRejectMalformedCidr() {
+        void shouldRejectMalformedCidr(String malformedCidr) {
             GatewayConfig gateway = validGateway()
                     .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("not-a-cidr")).build()))
+                            .trustedProxies(List.of(malformedCidr)).build()))
                     .build();
             EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
 
             List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
 
-            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: not-a-cidr");
-        }
-
-        @Test
-        @DisplayName("Should reject a trusted_proxies CIDR whose prefix length is out of range")
-        void shouldRejectOutOfRangePrefixLength() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("10.0.0.0/33")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: 10.0.0.0/33");
-        }
-
-        @Test
-        @DisplayName("Should reject a trusted_proxies CIDR whose prefix length is not numeric")
-        void shouldRejectNonNumericPrefixLength() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("10.0.0.0/abc")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: 10.0.0.0/abc");
-        }
-
-        @Test
-        @DisplayName("Should reject a trusted_proxies CIDR whose address part is not an IP literal")
-        void shouldRejectNonLiteralCidrAddress() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("not-an-ip/24")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: not-an-ip/24");
+            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: " + malformedCidr);
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 
 import de.cuioss.sheriff.gateway.config.RouteTableBuilder;
@@ -61,7 +62,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -485,58 +488,29 @@ class ConfigValidatorTest {
                     () -> "expected no violations for a millisecond-precision timeout, got: " + errors);
         }
 
-        @Test
-        @DisplayName("Should reject a single full-space IPv4 CIDR in forwarded.trusted_proxies")
-        void shouldRejectTrustAllCidr() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder().trustedProxies(List.of("0.0.0.0/0")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "entire IPv4 address space");
+        static Stream<Arguments> fullAddressSpaceTrustedProxies() {
+            return Stream.of(
+                    Arguments.of("a single full-space IPv4 CIDR", List.of("0.0.0.0/0"), "entire IPv4 address space"),
+                    Arguments.of("a single full-space IPv6 CIDR", List.of("::/0"), "entire IPv6 address space"),
+                    Arguments.of("a complementary /1 IPv4 pair", List.of("0.0.0.0/1", "128.0.0.0/1"),
+                            "entire IPv4 address space"),
+                    Arguments.of("a complementary /1 IPv6 pair", List.of("::/1", "8000::/1"),
+                            "entire IPv6 address space"));
         }
 
-        @Test
-        @DisplayName("Should reject a single full-space IPv6 CIDR in forwarded.trusted_proxies")
-        void shouldRejectTrustAllIpv6Cidr() {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("fullAddressSpaceTrustedProxies")
+        @DisplayName("Should reject forwarded.trusted_proxies entries that cover the whole address space")
+        void shouldRejectFullAddressSpaceTrustedProxies(String label, List<String> trustedProxies,
+                String expectedDetail) {
             GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder().trustedProxies(List.of("::/0")).build()))
+                    .forwarded(Optional.of(ForwardedConfig.builder().trustedProxies(trustedProxies).build()))
                     .build();
             EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
 
             List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
 
-            assertHasError(errors, "/forwarded/trusted_proxies", "entire IPv6 address space");
-        }
-
-        @Test
-        @DisplayName("Should reject a complementary /1 IPv4 pair that together cover the whole address space")
-        void shouldRejectComplementaryIpv4HalfPair() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("0.0.0.0/1", "128.0.0.0/1")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "entire IPv4 address space");
-        }
-
-        @Test
-        @DisplayName("Should reject a complementary /1 IPv6 pair that together cover the whole address space")
-        void shouldRejectComplementaryIpv6HalfPair() {
-            GatewayConfig gateway = validGateway()
-                    .forwarded(Optional.of(ForwardedConfig.builder()
-                            .trustedProxies(List.of("::/1", "8000::/1")).build()))
-                    .build();
-            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
-
-            assertHasError(errors, "/forwarded/trusted_proxies", "entire IPv6 address space");
+            assertHasError(errors, "/forwarded/trusted_proxies", expectedDetail);
         }
 
         @Test
@@ -1071,50 +1045,26 @@ class ConfigValidatorTest {
             assertHasError(errors, "/anchors/open", "is access: public and must not declare an auth block");
         }
 
-        @Test
-        @DisplayName("Rule authenticated→floor: Should reject an access: authenticated anchor declaring no auth floor at all")
-        void shouldRejectAuthenticatedAnchorWithNoAuthBlock() {
-            GatewayConfig gateway = gatewayWithAnchors(Map.of(
-                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, null)));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
-
-            assertHasError(errors, "/anchors/secure", "declares no non-'none' auth floor");
+        static Stream<Arguments> authenticatedAnchorsWithoutBackedFloor() {
+            return Stream.of(
+                    Arguments.of("no auth floor at all", null, "declares no non-'none' auth floor"),
+                    Arguments.of("an explicit 'none' floor", "none", "declares no non-'none' auth floor"),
+                    Arguments.of("a bearer floor with no token_validation issuer", "bearer",
+                            "access: authenticated bearer floor requires token_validation with at least one issuer"),
+                    Arguments.of("a session floor with no oidc block", "session",
+                            "access: authenticated session floor requires an oidc block"));
         }
 
-        @Test
-        @DisplayName("Rule authenticated→floor: Should reject an access: authenticated anchor whose floor is 'none'")
-        void shouldRejectAuthenticatedAnchorWithNoneFloor() {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("authenticatedAnchorsWithoutBackedFloor")
+        @DisplayName("Rules authenticated→floor and authenticated backing: Should reject an access: authenticated anchor without a backed auth floor")
+        void shouldRejectAuthenticatedAnchorWithoutBackedFloor(String label, String require, String expectedDetail) {
             GatewayConfig gateway = gatewayWithAnchors(Map.of(
-                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "none")));
+                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, require)));
 
             List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
 
-            assertHasError(errors, "/anchors/secure", "declares no non-'none' auth floor");
-        }
-
-        @Test
-        @DisplayName("Rule authenticated backing: Should reject an authenticated bearer floor with no token_validation issuer")
-        void shouldRejectAuthenticatedBearerFloorWithoutIssuer() {
-            GatewayConfig gateway = gatewayWithAnchors(Map.of(
-                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "bearer")));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
-
-            assertHasError(errors, "/anchors/secure",
-                    "access: authenticated bearer floor requires token_validation with at least one issuer");
-        }
-
-        @Test
-        @DisplayName("Rule authenticated backing: Should reject an authenticated session floor with no oidc block")
-        void shouldRejectAuthenticatedSessionFloorWithoutOidc() {
-            GatewayConfig gateway = gatewayWithAnchors(Map.of(
-                    "secure", matrixAnchor("secure", "/secure", AnchorType.PROXY, AccessLevel.AUTHENTICATED, "session")));
-
-            List<ConfigError> errors = validator.validate(gateway, List.of(), topologyWith());
-
-            assertHasError(errors, "/anchors/secure",
-                    "access: authenticated session floor requires an oidc block");
+            assertHasError(errors, "/anchors/secure", expectedDetail);
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -542,6 +542,34 @@ class ConfigValidatorTest {
         }
 
         @Test
+        @DisplayName("Should reject a trusted_proxies CIDR whose prefix length is not numeric")
+        void shouldRejectNonNumericPrefixLength() {
+            GatewayConfig gateway = validGateway()
+                    .forwarded(Optional.of(ForwardedConfig.builder()
+                            .trustedProxies(List.of("10.0.0.0/abc")).build()))
+                    .build();
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: 10.0.0.0/abc");
+        }
+
+        @Test
+        @DisplayName("Should reject a trusted_proxies CIDR whose address part is not an IP literal")
+        void shouldRejectNonLiteralCidrAddress() {
+            GatewayConfig gateway = validGateway()
+                    .forwarded(Optional.of(ForwardedConfig.builder()
+                            .trustedProxies(List.of("not-an-ip/24")).build()))
+                    .build();
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            assertHasError(errors, "/forwarded/trusted_proxies", "malformed trusted_proxies CIDR: not-an-ip/24");
+        }
+
+        @Test
         @DisplayName("Should boot-WARN a very broad but not total CIDR without failing the boot")
         void shouldWarnBroadButNotTotalCidr() {
             GatewayConfig gateway = validGateway()

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
@@ -197,8 +197,9 @@ class DispatchStageTest {
             };
 
             // Act — the stream is never subscribed (failure before send), so retry is allowed
+            var guard = retryGuard();
             GatewayException raised = assertThrows(GatewayException.class,
-                    () -> stage.guardedDispatch(retryGuard(), gate, HttpMethod.GET, bytesSent::get, () -> false,
+                    () -> stage.guardedDispatch(guard, gate, HttpMethod.GET, bytesSent::get, () -> false,
                             failing));
 
             // Assert — the safe idempotent+bodyless request was retried the full budget
@@ -221,8 +222,9 @@ class DispatchStageTest {
             };
 
             // Act
+            var guard = retryGuard();
             assertThrows(GatewayException.class,
-                    () -> stage.guardedDispatch(retryGuard(), gate, HttpMethod.POST, bytesSent::get, () -> false,
+                    () -> stage.guardedDispatch(guard, gate, HttpMethod.POST, bytesSent::get, () -> false,
                             failing));
 
             // Assert — a POST must never be re-sent, so the upstream is called exactly once
@@ -245,8 +247,9 @@ class DispatchStageTest {
             };
 
             // Act
+            var guard = retryGuard();
             assertThrows(GatewayException.class,
-                    () -> stage.guardedDispatch(retryGuard(), gate, HttpMethod.PUT, bytesSent::get, () -> false,
+                    () -> stage.guardedDispatch(guard, gate, HttpMethod.PUT, bytesSent::get, () -> false,
                             failing));
 
             // Assert — a streamed request cannot be replayed once a body byte has been sent
@@ -271,8 +274,9 @@ class DispatchStageTest {
             };
 
             // Act — idempotent GET, zero bytes sent, but the body stream is already subscribed
+            var guard = retryGuard();
             assertThrows(GatewayException.class,
-                    () -> stage.guardedDispatch(retryGuard(), gate, HttpMethod.GET, bytesSent::get, () -> true,
+                    () -> stage.guardedDispatch(guard, gate, HttpMethod.GET, bytesSent::get, () -> true,
                             failing));
 
             // Assert — reusing an already-subscribed one-shot body stream is refused, no re-send

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
@@ -17,6 +17,7 @@ package de.cuioss.sheriff.gateway.edge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Annotation;
@@ -178,6 +179,19 @@ class GatewayEdgePipelineTest {
         // Assert
         assertEquals(405, response.status());
         assertNotNull(response.headers().get("Allow"), "a 405 names the permitted verbs in the Allow header");
+    }
+
+    @Test
+    @DisplayName("rejects a verb outside the gateway's method model 405 before any stage runs")
+    void rejectsUnmodelledVerb() throws Exception {
+        // Act — TRACE is a valid HTTP verb the gateway deliberately does not model, so it is refused at
+        // the pipeline entry, before route selection ever runs
+        Response response = send(io.vertx.core.http.HttpMethod.TRACE, "/echo/orders", Map.of(), null);
+
+        // Assert
+        assertEquals(405, response.status());
+        assertNull(response.headers().get("X-Upstream-Echo"),
+                "an unmodelled verb must never reach the upstream");
     }
 
     @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapperTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssemblerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssemblerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapperTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/EventTypeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/EventTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/GatewayEventCounterTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/GatewayEventCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/TcpPeerGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/TcpPeerGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuardTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/FramingGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/FramingGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
@@ -135,8 +135,9 @@ class ThoroughChecksStageTest {
         PipelineRequest request = requestFor("/api/other", routeWithConfig(Optional.empty()));
 
         // Act
+        List<String> allowedPaths = List.of("/api/orders");
         GatewayException thrown = assertThrows(GatewayException.class,
-                () -> stage.process(request, List.of("/api/orders")));
+                () -> stage.process(request, allowedPaths));
 
         // Assert
         assertEquals(EventType.PATH_NOT_ALLOWED, thrown.getEventType());
@@ -159,8 +160,9 @@ class ThoroughChecksStageTest {
         PipelineRequest request = requestFor("/api/42", routeWithConfig(Optional.empty()));
 
         // Act
+        List<String> allowedPaths = List.of("/api/{id}/detail");
         GatewayException thrown = assertThrows(GatewayException.class,
-                () -> stage.process(request, List.of("/api/{id}/detail")));
+                () -> stage.process(request, allowedPaths));
 
         // Assert
         assertEquals(EventType.PATH_NOT_ALLOWED, thrown.getEventType());

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigFailFastTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigFailFastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetricsTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/RouteRuntimeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/RouteRuntimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriter.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverter.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkLogMessages.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6ResultPostProcessor.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6ResultPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/package-info.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * k6 benchmark post-processing for API Sheriff.
  * <p>

--- a/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriterTest.java
+++ b/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverterTest.java
+++ b/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoService.java
+++ b/integration-tests/src/main/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ApiSheriffIntegrationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ApiSheriffIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BaseIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ConfigLoadedIntegrationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ConfigLoadedIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DirectoryAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DirectoryAssetServingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ErrorContractIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ErrorContractIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GracefulShutdownIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GracefulShutdownIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GrpcProxyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GrpcProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MetricsIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PipelineVerbIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PipelineVerbIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WebSocketProxyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WebSocketProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoServiceTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,15 @@
     </issueManagement>
 
     <properties>
+        <!-- Project-owned pin, not an override: the resolved parent chain
+             (de.cuioss:cui-java-parent:1.5.4 -> de.cuioss:cui-java-bom:1.5.4) declares no
+             Quarkus version at all, so this property is the single source of truth for the
+             Quarkus platform. It feeds the io.quarkus:quarkus-bom import below and the
+             Quarkus build tooling, which is why the value has to be maintained here.
+             Changing it is a platform migration, never a routine version bump: the
+             quarkus-bom import is deliberately declared first so it wins the smallrye-config
+             convergence (see the token-sheriff-bom comment below), and cui-java-bom aligns
+             its JUnit Jupiter version to whatever the Quarkus BOM ships. -->
         <version.quarkus>3.37.3</version.quarkus>
         <version.token-sheriff>0.9.2</version.token-sheriff>
         <version.json-schema-validator>1.5.9</version.json-schema-validator>

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,35 @@
                             </activeRecipes>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <!--
+                            Pins the license header's copyright year to 2026.
+
+                            DO NOT DELETE when bumping cui-java-parent. The parent's
+                            pre-commit profile carries the comment "No <year> override:
+                            mycila license-maven-plugin defaults to the current year" and
+                            omits <year> on that basis. That comment is FALSE: mycila
+                            resolves ${year} from the project's <inceptionYear>, not from
+                            the system clock, and no <inceptionYear> is declared anywhere
+                            in this project or its parent chain (cui-java-parent ->
+                            cui-java-bom -> cui-parent-pom). With neither a <year> override
+                            nor an <inceptionYear>, the year does not track the current
+                            year; it regresses to the stale 2022 value, which is how
+                            every header in this repository came to read 2022.
+
+                            Only <year> is overridden here; owner (CUI-OpenSource-Software)
+                            and email (info@cuioss.de) continue to be inherited from the
+                            parent, since Maven merges child <properties> into the parent's
+                            plugin configuration rather than replacing the whole block.
+                        -->
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <configuration>
+                            <properties>
+                                <year>2026</year>
+                            </properties>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Summary

Drives the SonarCloud residual backlog to zero for every finding fixable within this branch, closes out the snapshot-deploy publication root-cause investigation, records the Quarkus-version pin rationale (and fixes a stale parent-POM reference in `CLAUDE.md`), and sweeps every Java license header's copyright year from 2022 to 2026.

## Changes

- **Deliverable 1 — snapshot-deploy publication root cause** (verification only, zero file change): confirmed the `integration-tests` and `benchmarks` modules both suppress publication via `skipPublishing` — the `central-publishing-maven-plugin`'s own user property — never `maven.deploy.skip`. The parent POM already sets `maven-deploy-plugin` `skip=true` for every module, so `maven.deploy.skip` was never a candidate switch; `skipPublishing` is the only correct one.
- **Deliverable 2 — Quarkus pin rationale + stale parent-POM fix** (`pom.xml`, `CLAUDE.md`): added an in-repo comment next to `version.quarkus` in `pom.xml` explaining why the property is a project-owned pin (the resolved `de.cuioss:cui-java-parent:1.5.4` chain declares no Quarkus version at all), and corrected `CLAUDE.md`'s stale "cui-java-parent:1.5.1" line to the actual resolved `1.5.4`.
- **Deliverable 3 — live SonarCloud backlog query**: queried `cuioss_API-Sheriff` and partitioned the 64 open issues into 34 live (real, code-fixable) and 30 stale ghost findings — all 30 under the deleted pre-rename `de.cuioss.sheriff.api.**` package tree, each reporting line 0.
- **Deliverable 4 — sweep the 34 live findings to zero**: fixed across
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java`,
  `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java`, and the corresponding test files (e.g. `ConfigValidatorTest.java`, `ConfigModelContractTest.java`, `TokenValidatorProducerTest.java`, `DispatchStageTest.java`, `ThoroughChecksStageTest.java`).
- **Deliverable 6 — license-header copyright-year sweep (2022 → 2026)**: applied across every Java source in `api-sheriff`, `integration-tests`, and `benchmarks`, plus a `pom.xml` comment recording why the *parent's* pre-commit profile comment ("no `<year>` override needed — mycila defaults to the current year") is inaccurate for this project: no `<inceptionYear>` is declared anywhere in this project or its parent chain, so mycila's `${year}` resolution regresses to a stale value (2022) rather than tracking the current year.

## Suppressions

Two `@SuppressWarnings("java:S6916")` (each paired with an in-code `// NOSONAR` rationale) were added:

- `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java:72`
- `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java:560`

Both sites are canonical-constructor / compact bodies whose invariant check switches on an enum constant. S6916 suggests replacing the `if` inside each `case` with a `when` guard, but a `when` guard can only attach to a *pattern* label, not an enum-*constant* label — `case DIRECTORY when ...` is a compile error (verified against `javac --release 25`). The suggested remedy is inapplicable at these sites, and restructuring to a type-pattern switch would rewrite the invariant check rather than address the finding.

## License-header file-count note

`git diff --stat` reports **168** Java files changed for the header-year sweep, not the **167** a naive `grep -rl` count over `*.java` would suggest. This is a false negative in the grep-based count, not a missed file: one of the 168 files is binary-classified by git's diff machinery (a CRLF/encoding artifact unrelated to header content), so a text-mode `grep -l` count silently skips it while `git diff --stat` still reports the change. Verification for this deliverable used `license:check` — the mycila plugin's own header-compliance verb — rather than a grep count; `license:check` inspects every file the plugin is configured against regardless of git's binary classification, so it is the stronger, authoritative signal here.

## Deferred (blocked on post-merge events — NOT in this PR)

Three of the plan's eight deliverables are deliberately excluded from this PR because each depends on state this PR itself has not yet produced:

- **Deliverable 5 — clear the 30 stale ghost findings** by forcing a fresh full SonarCloud analysis. Blocked on this PR's own merge: the ghost findings originate from the pre-rename package tree and only clear once a fresh full analysis runs against the post-merge `main`.
- **Deliverable 7 — adapt `ConfigLoader` for `json-schema-validator` 3.0.6** on PR #70's own branch (`dependabot/maven/com.networknt-json-schema-validator-3.0.6`), on a separate checkout outside this plan's branch and worktree. Sequenced after this PR merges, per the plan's constraint: land this PR first and rebase #70 on top, rather than racing the two.
- **Deliverable 8 — post-merge closure proof** (post-merge PROJECT gate status, final open-findings total, the deliverable-1 finding, and the #69/#70 dispositions). Depends on deliverables 5, 6, and 7 all landing, so it cannot be produced before this PR merges.

## Documentation

No doc-tree change was made, and none is warranted: nothing in this PR changes what an operator or contributor does differently. The `CLAUDE.md` edit is a one-line factual correction (the actual resolved parent-POM version), not a doc-layer description of new behavior; the `pom.xml` comments are in-code rationale for future maintainers touching that specific property/plugin configuration, not user- or developer-facing documentation. Per the project's three-layer documentation convention, this is stated explicitly rather than silently skipped.

## Test Plan

- [x] `verify` (full reactor) — passed, confirming the deliverable-1 close-out made no file change
- [x] `verify -Ppre-commit -pl api-sheriff -am` — passed with zero errors/warnings after the Sonar sweep (deliverable 4)
- [x] `verify -Ppre-commit` — passed with zero errors/warnings after the license-header sweep (deliverable 6)

---
Generated by plan-finalize skill
