### PR TITLE
docs(build): state the general executor form and drop bare ./mvnw examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Never hard-code Maven build tool commands (`mvn`, `./mvnw`) — always invoke Ma
 
 `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "<any maven goals & options>" [--project-dir <path>]`
 
-- `--command-args` accepts **any** Maven goals and options — profiles, `-pl`, `-Dtest=…`, system properties. Anything you would pass to `mvn` goes here.
+- `--command-args` accepts **any** Maven goals and options — profiles, `-pl`, `-Dtest=…`, system properties. Pass the goals/options **only**, never the `mvn`/`./mvnw` binary itself (the executor supplies the wrapper).
 - `--project-dir <path>` is the escape hatch to build a checkout **outside** the main tree — e.g. an ad-hoc worktree under `.plan/local/worktrees/` or in the scratchpad. It defaults to the project root; use it instead of `cd`-ing into a worktree and running `./mvnw` there.
 
 The entries below are common **examples, not a closed set** — any Maven invocation goes through this same `run --command-args`:
@@ -35,13 +35,13 @@ The entries below are common **examples, not a closed set** — any Maven invoca
 - Module tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl integration-tests -am"` — only on integration-tests
 - Integration tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-tests -am"` — only on integration-tests
 - Benchmark (benchmarks): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pbenchmark -pl benchmarks -am"` — only on benchmarks
-- Targeted test (single test / pattern): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest='ConfigLoaderTest'"`
-- Targeted test in an ad-hoc worktree: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest='ConfigLoaderTest'" --project-dir /path/to/worktree`
+- Targeted test (single test / pattern): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest=ConfigLoaderTest"`
+- Targeted test in an ad-hoc worktree: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest=ConfigLoaderTest" --project-dir /path/to/worktree`
 - Native executable: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "clean install -Pnative -pl api-sheriff -am -DskipTests"`
 - Use a 10-minute Bash timeout (600000ms) for build invocations
 - Analyze each build's TOON result: `status`, `errors[N]{file,line,message,category}`, `log_file`
 
-The production Docker image build is **not** a Maven invocation, so it does not go through the executor:
+The executor rule covers **Maven builds only**. Genuinely non-Maven tooling runs directly — the sole case here is the production Docker image build:
 
 ```bash
 docker build -f api-sheriff/src/main/docker/Dockerfile.native -t api-sheriff:latest api-sheriff/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,14 @@ Multi-module Maven project:
 
 ### Build Commands
 
-Never hard-code build tool commands (`mvn`, `./mvnw`) — invoke builds via the canonical executor commands below:
+Never hard-code Maven build tool commands (`mvn`, `./mvnw`) — always invoke Maven through the executor. The **general form** is:
+
+`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "<any maven goals & options>" [--project-dir <path>]`
+
+- `--command-args` accepts **any** Maven goals and options — profiles, `-pl`, `-Dtest=…`, system properties. Anything you would pass to `mvn` goes here.
+- `--project-dir <path>` is the escape hatch to build a checkout **outside** the main tree — e.g. an ad-hoc worktree under `.plan/local/worktrees/` or in the scratchpad. It defaults to the project root; use it instead of `cd`-ing into a worktree and running `./mvnw` there.
+
+The entries below are common **examples, not a closed set** — any Maven invocation goes through this same `run --command-args`:
 
 - Compile: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "compile"`
 - Quality gate: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`
@@ -28,16 +35,15 @@ Never hard-code build tool commands (`mvn`, `./mvnw`) — invoke builds via the 
 - Module tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl integration-tests -am"` — only on integration-tests
 - Integration tests (integration-tests): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-tests -am"` — only on integration-tests
 - Benchmark (benchmarks): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pbenchmark -pl benchmarks -am"` — only on benchmarks
+- Targeted test (single test / pattern): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest='ConfigLoaderTest'"`
+- Targeted test in an ad-hoc worktree: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl api-sheriff -Dtest='ConfigLoaderTest'" --project-dir /path/to/worktree`
+- Native executable: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "clean install -Pnative -pl api-sheriff -am -DskipTests"`
 - Use a 10-minute Bash timeout (600000ms) for build invocations
 - Analyze each build's TOON result: `status`, `errors[N]{file,line,message,category}`, `log_file`
 
-Special builds without a canonical command:
+The production Docker image build is **not** a Maven invocation, so it does not go through the executor:
 
 ```bash
-# Build native executable
-./mvnw clean install -Pnative -pl api-sheriff -am -DskipTests
-
-# Build production Docker image
 docker build -f api-sheriff/src/main/docker/Dockerfile.native -t api-sheriff:latest api-sheriff/
 ```
 


### PR DESCRIPTION
## Why

A running plan's agent ran `./mvnw -pl api-sheriff test -Dtest='ConfigL…'` directly in an ad-hoc worktree, against the "use the canonical executor" rule. Root-cause analysis: **not** a capability gap (the executor supports it) and **not** wholesale non-compliance (the agent used the executor everywhere else) — a **rule-clarity defect** in CLAUDE.md.

CLAUDE.md presented the executor as a *closed* set of nine presets and showed bare `./mvnw` for "special builds without a canonical command" — which teaches "no matching preset → raw `./mvnw` is fine." Neither a targeted `-Dtest=` run nor the `--project-dir` escape hatch was documented.

## What

- State the **general form**: `run --command-args "<any goals>" [--project-dir <path>]`.
- Document `--command-args` as accepting any Maven option, and `--project-dir` as the escape hatch for a checkout outside the main tree (ad-hoc worktree / scratchpad).
- Mark the preset list as **examples, not a closed set**.
- Add concrete **targeted-test**, **targeted-test-in-worktree**, and **native** commands as executor invocations.
- Keep only the Docker build raw, since it is not a Maven invocation (reframed as such).

Docs-only; no code or build behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)