### PR TITLE
chore(ci): opt in to the PR-Agent third reviewer (pilot)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -27,5 +27,10 @@ permissions:
 
 jobs:
   review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@83b3ab36e40dedbeda0ee74ac71876183b70b649 # v0.15.2
-    secrets: inherit
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@ab447694b019d30edc56f2ff7c5100ba731ca590 # v0.15.3
+    # Map only what the reviewer needs. `secrets: inherit` would hand it every secret this
+    # repo can see (GPG keys, Sonatype credentials, SONAR_TOKEN, …) for no reason; these two
+    # are the whole requirement, because Vertex AI is reached keylessly.
+    secrets:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
+      REVIEW_APP_PRIVATE_KEY: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -24,5 +24,5 @@ permissions:
 
 jobs:
   review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@830c2dd2ffe4850be37c5faa0a0d112713dfd7e3 # v0.14.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@19d5894332b91eb52396659568933c4a751346a4 # v0.14.1
     secrets: inherit

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@0f9c794859ef77d2780f10a27054b45b3dd98d71 # v0.15.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@b07a4047beb44dd11a9d6e11ab3cf1963aa4a010 # v0.15.1
     secrets: inherit

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,28 @@
+# Third automated PR reviewer (PR-Agent on Google Gemini), beside CodeRabbit and Sourcery.
+#
+# All review tuning is central in cuioss/pr-agent-settings (.pr_agent.toml) — nothing is
+# configured here. The org skip rules (dependabot[bot], cuioss-release-bot[bot], the
+# skip-bot-review label, fork PRs) are enforced by the reusable workflow's job-level `if:`
+# guard, because PR-Agent's own ignore_pr_* settings are inert in GitHub Action mode.
+#
+# See https://github.com/cuioss/pr-agent-settings/blob/main/README.adoc
+
+name: PR Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  # On-demand commands (/review, /ask, /improve, /help). Also how a re-review is requested
+  # after pushing fixes — there is deliberately no automatic re-review on every push.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@830c2dd2ffe4850be37c5faa0a0d112713dfd7e3 # v0.14.0
+    secrets: inherit

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@b07a4047beb44dd11a9d6e11ab3cf1963aa4a010 # v0.15.1
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@83b3ab36e40dedbeda0ee74ac71876183b70b649 # v0.15.2
     secrets: inherit

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,8 +21,11 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  # Required: mints the OIDC token Workload Identity Federation exchanges for the short-lived
+  # GCP credentials the reviewer uses to reach Gemini on Vertex AI.
+  id-token: write
 
 jobs:
   review:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@19d5894332b91eb52396659568933c4a751346a4 # v0.14.1
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-pr-agent-review.yml@0f9c794859ef77d2780f10a27054b45b3dd98d71 # v0.15.0
     secrets: inherit


### PR DESCRIPTION
Adds the caller for `cuioss-organization`'s `reusable-pr-agent-review.yml` (v0.14.0), making this the Java/Maven half of the pilot for the org's **third** automated reviewer — open-source [PR-Agent](https://github.com/The-PR-Agent/pr-agent) on Google Gemini, beside CodeRabbit and Sourcery. Nothing is replaced.

Nothing is configured here by design:

- Review tuning is central in [cuioss/pr-agent-settings](https://github.com/cuioss/pr-agent-settings) (`.pr_agent.toml`), merged beneath any repo-local config and re-read every run.
- The org skip rules — `dependabot[bot]`, `cuioss-release-bot[bot]`, the `skip-bot-review` label, and fork PRs — live in the reusable workflow's job-level `if:` guard, because PR-Agent's own `ignore_pr_*` settings are read only by its webhook servers and are inert in GitHub Action mode.
- Only `/review` runs automatically. `/describe` and `/improve` are off.

The reviewer is security-weighted (`require_security_review`, security-focused extra instructions), filling the gap left by the retired consumer tier of Gemini Code Assist. This repo is in the pilot because it exercises a different language and footprint from plan-marshall, and its `claude.yml` gives a side-by-side reviewer comparison.

**This PR is a live test:** `pull_request` workflows run from the head branch, so the reviewer should post one comment from `cuioss-review-bot[bot]` headed `## PR Reviewer Guide 🔍`.
