### PR TITLE
chore(config): enable pr-agent in the review pipeline, drop retired gemini

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -103,7 +103,7 @@
           "lane": "minimal"
         },
         "plan-marshall:automatic-review": {
-          "enabled_bots": "coderabbit,sourcery,gemini",
+          "enabled_bots": "coderabbit,sourcery,pr-agent",
           "review_bot_buffer_seconds": 180,
           "review_completion_poll_timeout_seconds": 600,
           "re_review_on_loopback": false,


### PR DESCRIPTION
One-line follow-up to #104. The pilot added the reviewer workflow but left `enabled_bots` untouched, so PR-Agent reviews would have been **posted and never ingested** into the findings pipeline.

```
- "enabled_bots": "coderabbit,sourcery,gemini"
+ "enabled_bots": "coderabbit,sourcery,pr-agent"
```

Gemini goes in the same edit: its consumer tier was retired 2026-07-17, so that entry only made finalize wait for a bot that can never post. Net bot count is unchanged, so the wait budget doesn't grow. The `standards/gemini.md` registry doc stays, so a historical Gemini comment still classifies correctly.

Now matches plan-marshall and TokenSheriff.

Labelled `skip-bot-review` — no reviewer value in a one-line config change.
