### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -123,6 +123,10 @@
         "default:lessons-capture": {
           "lane": "minimal"
         },
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2,
+          "lane": "minimal"
+        },
         "default:adr-propose": {
           "lane": "off"
         },
@@ -136,10 +140,6 @@
           "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
           "pre_merge_comment_barrier": "fail_into_loopback",
-          "lane": "minimal"
-        },
-        "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2,
           "lane": "minimal"
         },
         "default:record-metrics": {
@@ -158,6 +158,9 @@
         "post-run-review": "level-4"
       }
     }
+  },
+  "orchestrator": {
+    "auto_emit": false
   },
   "build": {
     "queue": {
@@ -299,7 +302,7 @@
       "plugin_cache_keep_versions": 5,
       "plugin_cache_keep_days": 3
     },
-    "provisioned_version": "0.1.1195",
-    "config_seed_fingerprint": "9a1bd104"
+    "provisioned_version": "0.1.1219",
+    "config_seed_fingerprint": "4e859c03"
   }
 }


### PR DESCRIPTION
## Summary

Post-upgrade reconciliation of `.plan/marshal.json` after refreshing plan-marshall from `0.1.1195` to `0.1.1219`.

Produced by `/marshall-steward upgrade` (consumer project), Stage 2 — reconcile-config:

- `sync-defaults` back-filled two missing default keys: `orchestrator` and `orchestrator.auto_emit`
- `steps-sort` restored `plan.phase-6-finalize.steps` to canonical frontmatter order (`finalize-step-preference-emitter` ahead of `adr-propose`; `record-metrics` after `branch-cleanup`)

No functional project code is touched — this is plan-marshall configuration state only.

## Verification

Stage 3 (verify) preflight is clean:

```
executor_action: fresh
marshal_status:  fresh
installed_version / executor_version / marshal_version: 0.1.1219
```

`build.map` drift check reported `in_sync: true` — no re-seed needed.

Labelled `skip-bot-review`: no reviewable source change.
