### PR TITLE
fix(it): tamper the decoded GCM tag, not a base64 padding bit

### DIFF
--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieStatelessnessIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieStatelessnessIT.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.restassured.response.Response;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -154,14 +155,22 @@ class BffCookieStatelessnessIT {
     }
 
     /**
-     * Flips the final character of the sealed value, which sits inside the authentication tag.
+     * Flips a bit inside the trailing 16-byte GCM authentication tag.
+     * <p>
+     * The mutation is applied to the <em>decoded</em> bytes rather than to the final base64url
+     * character, because editing that character is not reliably a mutation at all: when the sealed
+     * length is not a multiple of three, the final character carries 2 or 4 unused padding bits that
+     * {@link Base64#getUrlDecoder()} discards without validating. Flipping only those bits — which is
+     * what {@code 'A' -> 'B'} does — re-decodes to the identical ciphertext and tag, so the peer
+     * unseals it successfully and answers 200. Mutating a decoded tag byte is unambiguous.
      *
      * @param sealed the sealed cookie value
      * @return the tampered value, still in the base64url alphabet
      */
     private static String tamper(String sealed) {
         assertNotNull(sealed, "the login must establish a sealed session cookie");
-        char last = sealed.charAt(sealed.length() - 1);
-        return sealed.substring(0, sealed.length() - 1) + (last == 'A' ? 'B' : 'A');
+        byte[] raw = Base64.getUrlDecoder().decode(sealed);
+        raw[raw.length - 1] ^= 0x01;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
     }
 }


### PR DESCRIPTION
## Problem

`BffCookieStatelessnessIT.thePeerRefusesACookieItCannotUnseal` failed **post-merge on `main`** (`341ab9e`, run [30334562679](https://github.com/cuioss/API-Sheriff/actions/runs/30334562679)):

```
BffCookieStatelessnessIT.thePeerRefusesACookieItCannotUnseal:138 1 expectation failed.
Expected status code <401> but was <200>.
```

This is a defect in the test, **not** in the gateway. The peer was right to answer 200.

## Root cause

The test broke the sealed cookie's authentication tag by flipping the final base64url character:

```java
char last = sealed.charAt(sealed.length() - 1);
return sealed.substring(0, sealed.length() - 1) + (last == 'A' ? 'B' : 'A');
```

That is not reliably a mutation. The sealed payload is `version(1) || key-id(1) || nonce(12) || ciphertext || tag(16)`. When its byte length is not a multiple of three, the final base64url character carries 2 or 4 **unused padding bits**, and `Base64.getUrlDecoder()` discards them without validating. `'A'` (`0b000000`) → `'B'` (`0b000001`) flips only the lowest bit — a padding bit in that case — so the value re-decodes to the **identical** ciphertext and tag. The GCM tag still authenticates, the peer unseals the session correctly, and the route returns 200.

Verified directly:

```
len(bytes)=32 len%3=2
encoded  = AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHgA
tampered = AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHgB   (last 'A' -> 'B')
decodes to IDENTICAL bytes? true
```

The no-op requires the last character to be `'A'` **and** the sealed length to be a non-multiple of 3 — roughly 4% of runs, since the ciphertext length tracks the JWT size and varies per login. That is why the suite passed on the PR head (`ba3edbc`) and failed on `main` shortly after.

## Fix

Mutate a byte of the **decoded** 16-byte GCM tag instead:

```java
byte[] raw = Base64.getUrlDecoder().decode(sealed);
raw[raw.length - 1] ^= 0x01;
return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
```

Always a real tag mutation, so the probabilistic branch is gone entirely. The Javadoc records the padding-bit trap so the original shape is not reintroduced.

## Verification

- `verify -Ppre-commit` green
- `test-compile -pl integration-tests -am` green
- Integration Tests on this PR are the authoritative check — the same job that caught the failure

## Not in scope

`Performance Benchmark` is also red on `main`, but it is **pre-existing and unrelated**: the same `run-k6-passthrough-relay-benchmark` `checks, http_req_failed` threshold crossing (exit 99) fails on PR #119 (a workflow-version bump) and on #117 / #116 before it. `benchmarks/**` is another plan's surface; reported, not touched here.

## Note

Supersedes #120, which was closed unmerged. Same commit, no code change — reopened so the review bots get a clean run after both CodeRabbit and Sourcery hit account rate limits on the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G99PK9iS9vgHvttFZ7ueir