### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -302,7 +302,7 @@
       "plugin_cache_keep_versions": 5,
       "plugin_cache_keep_days": 3
     },
-    "provisioned_version": "0.1.1228",
-    "config_seed_fingerprint": "4e859c03"
+    "provisioned_version": "0.1.1240",
+    "config_seed_fingerprint": "120d376a"
   }
 }


### PR DESCRIPTION
## Summary

Post-upgrade reconciliation of `.plan/marshal.json` after refreshing plan-marshall from `0.1.1228` to `0.1.1240`.

Produced by `/marshall-steward upgrade` (consumer project):

- `system.provisioned_version` refreshed `0.1.1228` → `0.1.1240`
- `system.config_seed_fingerprint` refreshed `4e859c03` → `120d376a`

No functional project code is touched — this is plan-marshall configuration state only.

## Upgrade run details

- Stage 1 — plugin cache freshness `fresh` (cache 0.1.1240 == marketplace manifest 0.1.1240); executor regenerated from the 0.1.1240 cache generator (140 scripts); retention sweep swept 60 version dirs across 10 bundles, 0 removable (keep_versions=5, keep_days=3)
- Stage 2 — `sync-defaults` added 0 keys (stamps re-written); `steps-sort` reported no reorder (18 steps); `build.map` drift `in_sync: true`

## Verification

Stage 3 (verify) preflight is clean:

```
executor_action: fresh
marshal_status:  fresh
installed_version / executor_version / marshal_version: 0.1.1240
```

Labelled `skip-bot-review`: no reviewable source change.
