### PR TITLE
chore(plan-marshall): enable orchestrator auto_emit and set parallelization_scope

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -160,7 +160,8 @@
     }
   },
   "orchestrator": {
-    "auto_emit": false
+    "auto_emit": true,
+    "parallelization_scope": 2
   },
   "build": {
     "queue": {


### PR DESCRIPTION
## What

Records the two orchestrator autonomy knobs the `api-sheriff-roadmap` epic now runs under, set by operator decision on 2026-07-28/29.

```diff
   "orchestrator": {
-    "auto_emit": false
+    "auto_emit": true,
+    "parallelization_scope": 2
   },
```

## Why

**`auto_emit: true`** — on every landing that frees a slot, the orchestrator auto-fills toward `parallelization_scope` and auto-stamps the `launched` transition, rather than waiting for a per-plan operator confirmation. What it does **not** change: the disjointness guard, the prep-readiness guard, the `N − R` slot count, and the emit≠running invariant — the `launched → running` start stays operator-owned under either value, and a colliding or unprepared plan is never emitted just to fill a slot.

**`parallelization_scope: 2`** — previously unset at the config default. The epic already carried `2` at the epic level (the value the `next` verb actually reads), so this changes no current behaviour; it makes the standing *"always aim for two parallel plans"* instruction durable rather than epic-local.

The knobs have been live for two plans already. PLAN-07B and PLAN-32 ran concurrently under them and produced zero rebase conflicts, and the post-landing auto-fill correctly skipped two blocked candidates to emit PLAN-31A.

## Scope

Configuration only. No production code, no tests, no build behaviour. The file was modified in the working tree while PLAN-07B was in flight and is landed here as its own change rather than folded into an unrelated plan's PR.

## Review

Labelled `skip-bot-review` per operator instruction — a two-line config change with no reviewable surface.
