### PR TITLE
chore(steward): reconcile marshal.json for plan-marshall 0.1.1261

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -103,7 +103,6 @@
           "lane": "minimal"
         },
         "plan-marshall:automatic-review": {
-          "enabled_bots": "coderabbit,sourcery,pr-agent",
           "review_bot_buffer_seconds": 180,
           "review_completion_poll_timeout_seconds": 600,
           "re_review_on_loopback": false,
@@ -112,7 +111,10 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "lane": "auto"
+          "lane": "auto",
+          "required_bots": "coderabbit,pr-agent",
+          "optional_bots": "sourcery",
+          "bot_lists_provenance": "answered"
         },
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
@@ -303,7 +305,7 @@
       "plugin_cache_keep_versions": 5,
       "plugin_cache_keep_days": 3
     },
-    "provisioned_version": "0.1.1246",
-    "config_seed_fingerprint": "120d376a"
+    "provisioned_version": "0.1.1261",
+    "config_seed_fingerprint": "ccb21c71"
   }
 }


### PR DESCRIPTION
## Summary

Post-upgrade reconciliation of `.plan/marshal.json` produced by `/marshall-steward upgrade` against plan-marshall **0.1.1261** (consumer project kind).

## Changes

- **Bot participation split** — the retired `enabled_bots` knob on `plan-marshall:automatic-review` is replaced by the `required_bots` / `optional_bots` pair:
  - `required_bots: coderabbit,pr-agent` — silence from either blocks the merge gate.
  - `optional_bots: sourcery` — ingested and reported, never gating.
  - `bot_lists_provenance: answered` — records the deliberate operator decision so a future steward entry does not re-ask.
- **Provisioning stamps** — `system.provisioned_version` re-stamped `0.1.1246` → `0.1.1261`, with a refreshed `config_seed_fingerprint`.

## Verification

| Stage | Result |
|-------|--------|
| Plugin-cache freshness | `fresh` (cache 0.1.1261 == marketplace manifest 0.1.1261) |
| Executor regeneration | 141 scripts discovered, executor written |
| Cache-retention sweep | 150 version dirs swept, 0 removable (keep_versions=5, keep_days=3) |
| `build.map` drift | `in_sync: true` |
| Executor / config preflight | `executor_action: fresh`, `marshal_status: fresh` |

No source or build changes — plan-marshall configuration state only. Labelled `skip-bot-review` (suppresses CodeRabbit and PR-Agent; Sourcery is unaffected, as this repo's `.sourcery.yaml` does not opt into `github.ignore_labels`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX5wDYSTCPQK6VptmWibza
