### PR TITLE
fix(benchmarks): drop the leftover bash tail in the coverage step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -160,23 +160,6 @@ jobs:
             --benchmark-outcome "${BENCHMARK_OUTCOME}" \
             --summary-file "$GITHUB_STEP_SUMMARY"
 
-          # When Maven failed, the DID NOT RUN rows above and the Maven error are almost always the
-          # same event, but nothing on the page says so — a reader is left to infer the causal link.
-          # State it. This path never exits non-zero: the benchmark step's own failure already fails
-          # the job, and duplicating that here would only bury the real error.
-          if [ "${BENCHMARK_OUTCOME}" != "success" ]; then
-            {
-              echo
-              if [ "${missing}" -gt 0 ]; then
-                echo "> **Maven failed and the suite was TRUNCATED**: goals ${missing_names} produced no summary because the run aborted before reaching them. The DID NOT RUN rows above are a consequence of that failure, not ${missing} independent problems — fix the reported Maven error first, then re-read this table."
-              else
-                echo "> **Maven failed AFTER every expected goal produced a summary.** No goal was lost to truncation, so the failure lies outside goal execution (post-processing, the baseline comparison, or container teardown). The results above are complete and usable."
-              fi
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          echo "Benchmark coverage: ${missing} expected summary document(s) absent (benchmark step outcome: ${BENCHMARK_OUTCOME})."
-
       - name: Assemble benchmark artifacts for deployment
         run: |
           python3 benchmarks/scripts/benchmark-pages.py assemble \


### PR DESCRIPTION
## Intent

Follow-up to #131. Removes a leftover fragment of the bash implementation that the
manifest-driven coverage step replaced.

## What happened

#131 switched the "Summarise benchmark coverage" step to call
`benchmark-manifest.py summarise`, but the replacement missed a trailing block: a
truncation-narrative `if` and a final `echo`, both still referencing `${missing}` and
`${missing_names}`, which the deleted bash had defined.

The first post-merge Performance Benchmark run surfaced it — two verdict lines, the
second with an empty count:

```
Benchmark coverage: 0 of 12 expected summary document(s) absent (benchmark step outcome: success).
Benchmark coverage:  expected summary document(s) absent (benchmark step outcome: success).
```

## Why it is not just cosmetic

The duplicate line is harmless. The truncation block is not.

The step runs under `shell: /usr/bin/bash -e`, and `[ "${missing}" -gt 0 ]` with an
unset operand is a syntax error. So on a **failed** benchmark run the step would abort
rather than print the truncation narrative — precisely the case that narrative exists
to explain. That path had not executed yet, because the run that exposed the leftover
succeeded.

## Why a pure deletion

`summarise` already emits the same narrative in both branches (truncated, and
"failed after every goal produced a summary"), so nothing is lost by removing the bash
copy. Keeping it would also re-create the two-implementations-of-one-contract problem
that motivated calling `summarise` in the first place.

## Verification

Quality gate green. The step's own behaviour only exercises in a post-merge
Performance Benchmark run; the `summarise` code path this defers to was verified in
#131 across all three exit semantics (complete coverage, missing document, absent
manifest) and is unchanged here.

`skip-bot-review` applied: a 17-line dead-code deletion with no reachable behaviour
change on the success path.
