### PR TITLE
chore(steward): land steward-maintained artifacts

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -82,10 +82,10 @@
         },
         "default:pre-submission-self-review": {
           "drop_review_on_scope_gate": false,
-          "lane": "auto"
+          "lane": "standard"
         },
         "default:finalize-step-simplify": {
-          "lane": "auto"
+          "lane": "standard"
         },
         "default:finalize-step-security-audit": {
           "lane": "full"
@@ -111,7 +111,7 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "lane": "auto",
+          "lane": "standard",
           "required_bots": "coderabbit,pr-agent",
           "optional_bots": "sourcery",
           "bot_lists_provenance": "answered"
@@ -120,7 +120,7 @@
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
           "ce_wait_timeout_seconds": 600,
-          "lane": "auto"
+          "lane": "standard"
         },
         "default:lessons-capture": {
           "lane": "minimal"
@@ -306,7 +306,7 @@
       "plugin_cache_keep_days": 3,
       "no_plan_body_days": 7
     },
-    "provisioned_version": "0.1.1274",
+    "provisioned_version": "0.1.1275",
     "config_seed_fingerprint": "59c217c3"
   }
 }


### PR DESCRIPTION
## Summary

Steward `upgrade` reconciliation landing for `.plan/marshal.json`.

- `system.provisioned_version` re-stamped `0.1.1274` → `0.1.1275` (plugin cache and executor are both at `0.1.1275`).
- Operator lane changes: `default:pre-submission-self-review`, `default:finalize-step-simplify`, `plan-marshall:automatic-review` and `default:sonar-roundtrip` move from lane `auto` to lane `standard`.

## Upgrade run (consumer kind)

| Stage | Result |
|-------|--------|
| 1 — regenerate-targets | cache freshness `fresh` (0.1.1275 == manifest); executor regenerated (141 scripts); retention sweep kept 150 dirs, removed 0 |
| 2 — reconcile-config | `sync-defaults` added 0 keys; `steps-sort` already ordered; `migrate-bot-lists` no-op (`required_bots=coderabbit,pr-agent`, `optional_bots=sourcery`); `build.map` in sync |
| 3 — verify | `generate_executor preflight`: executor `fresh`, marshal `fresh` |
| 4 — land | this PR |

No source or build changes — configuration only.

## Review

Labelled `skip-bot-review`: CodeRabbit and PR-Agent are suppressed; Sourcery only skips if the repo's `.sourcery.yaml` opts in via `github.ignore_labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wKFHVFnztc6YUAwmpXbWs
