### PR TITLE
chore(steward): enable phase-6-finalize loop_back_without_asking

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -70,7 +70,7 @@
     "phase-6-finalize": {
       "max_iterations": 3,
       "finalize_without_asking": true,
-      "loop_back_without_asking": false,
+      "loop_back_without_asking": true,
       "checks_wait_timeout_seconds": 600,
       "steps": {
         "default:finalize-step-sync-baseline": {


### PR DESCRIPTION
## Summary

Follow-up to #136, same steward landing session.

`plan.phase-6-finalize.loop_back_without_asking` flipped `false` → `true`, so the finalize phase may loop back into earlier phases without an operator prompt — matching the already-enabled `finalize_without_asking`.

Configuration only; one line in `.plan/marshal.json`.

## Review

Labelled `skip-bot-review`: CodeRabbit and PR-Agent are suppressed; Sourcery only skips if the repo's `.sourcery.yaml` opts in via `github.ignore_labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wKFHVFnztc6YUAwmpXbWs
