### PR TITLE
fix(gateway): carve out Authorization from strict header-value cap

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -32,7 +32,7 @@
       "revalidation": "auto"
     },
     "phase-3-outline": {
-      "plan_without_asking": false,
+      "plan_without_asking": true,
       "q_gate_validation": "once",
       "effort": "level-5"
     },
@@ -63,8 +63,8 @@
         "default:verify:coverage": {}
       },
       "effort": {
-        "default": "level-4",
-        "verification-feedback": "level-4"
+        "default": "level-5",
+        "verification-feedback": "level-5"
       }
     },
     "phase-6-finalize": {
@@ -155,8 +155,8 @@
         }
       },
       "effort": {
-        "default": "level-3",
-        "verification-feedback": "level-5",
+        "default": "level-5",
+        "verification-feedback": "level-6",
         "post-run-review": "level-4"
       }
     }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityConfigurations.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityConfigurations.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.config.model;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.config.SecurityConfigurationBuilder;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * The single seeding seam for the cui-http {@link SecurityConfiguration}: the one place in this
+ * project that enumerates the record's component set when copying a policy.
+ * <p>
+ * <strong>Why a shared class rather than a private helper.</strong> {@link SecurityConfiguration#builder()}
+ * starts from {@code defaults()} — the dropped {@code default} preset — so a caller that overrides one
+ * dimension and omits the rest silently reverts every other dimension to that policy. Overriding a
+ * single dimension safely therefore requires copying <em>all</em> components first. That copy is
+ * needed in two packages: the {@code edge} package resolves a route's declared
+ * {@code security_filter} limits and the two pre-route header-value carve-outs, and the
+ * {@code pipeline} package derives the matching post-route carve-outs from the route's own policy. A
+ * second, hand-written component list is exactly the defect class this seam exists to prevent — an
+ * omitted component is invisible at the call site and shows up only as a validator that quietly
+ * stopped applying.
+ * <p>
+ * Framework-agnostic (ADR-0005): the class touches the cui-http configuration API only.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@UtilityClass
+public class SecurityConfigurations {
+
+    /**
+     * Returns a {@link SecurityConfigurationBuilder} carrying every component of {@code preset}, so a
+     * caller overriding one dimension leaves the other twenty-three on the preset's values. Copies the
+     * record's full component set deliberately: an omitted component would silently fall back to the
+     * {@code defaults()} policy the builder starts from.
+     *
+     * @param preset the policy every component is copied from; never {@code null}
+     * @return a builder pre-loaded with {@code preset}'s complete component set
+     */
+    public static SecurityConfigurationBuilder builderSeededFrom(SecurityConfiguration preset) {
+        return SecurityConfiguration.builder()
+                .maxPathLength(preset.maxPathLength())
+                .allowDoubleEncoding(preset.allowDoubleEncoding())
+                .maxParameterNameLength(preset.maxParameterNameLength())
+                .maxParameterValueLength(preset.maxParameterValueLength())
+                .maxHeaderNameLength(preset.maxHeaderNameLength())
+                .maxHeaderValueLength(preset.maxHeaderValueLength())
+                .maxCookieNameLength(preset.maxCookieNameLength())
+                .maxCookieValueLength(preset.maxCookieValueLength())
+                .maxBodySize(preset.maxBodySize())
+                .allowNullBytes(preset.allowNullBytes())
+                .allowControlCharacters(preset.allowControlCharacters())
+                .allowExtendedAscii(preset.allowExtendedAscii())
+                .normalizeUnicode(preset.normalizeUnicode())
+                .caseSensitiveComparison(preset.caseSensitiveComparison())
+                .failOnSuspiciousPatterns(preset.failOnSuspiciousPatterns())
+                .requireSecureCookies(preset.requireSecureCookies())
+                .requireHttpOnlyCookies(preset.requireHttpOnlyCookies())
+                .maxParameterCount(preset.maxParameterCount())
+                .maxHeaderCount(preset.maxHeaderCount())
+                .maxCookieCount(preset.maxCookieCount())
+                .allowedHeaderNames(preset.allowedHeaderNames())
+                .blockedHeaderNames(preset.blockedHeaderNames())
+                .allowedContentTypes(preset.allowedContentTypes())
+                .blockedContentTypes(preset.blockedContentTypes());
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
@@ -52,7 +52,7 @@ import java.util.Optional;
  * @since 1.0
  */
 public record SecurityDefaultsConfig(Optional<String> profile,
-        Optional<Integer> maxAuthorizationHeaderValueLength) {
+Optional<Integer> maxAuthorizationHeaderValueLength) {
 
     /**
      * The {@code Authorization} header-value cap an omitted

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
@@ -32,18 +32,58 @@ import java.util.Optional;
  * {@code security_filter} — or one whose block omits {@code profile} — therefore inherits the value
  * carried here, and an entirely omitted {@code security_defaults} block resolves to
  * {@link SecurityProfile#DEFAULT_PROFILE}.
+ * <p>
+ * <strong>{@code max_authorization_header_value_length}.</strong> The budget backing the pre-route
+ * {@code Authorization} header-value carve-out. A bearer token is routinely larger than the resolved
+ * preset's {@code maxHeaderValueLength} — a Keycloak access token plus the {@code Bearer } prefix
+ * measures ~1028 characters against the {@code strict} preset's 1024 — so without a raised cap the
+ * non-skippable pre-route floor rejects every bearer request {@code 400} before route selection, and
+ * stage-4 bearer validation never runs. The value is operator-declared rather than a fixed constant
+ * because the right budget is a property of the deployment's identity provider, not of the gateway.
+ * It is boot-validated: a declared value below the resolved baseline {@code maxHeaderValueLength}
+ * would make the "carve-out" a tightening in disguise and is refused.
  *
  * @param profile the baseline security-filter profile, empty when omitted
+ * @param maxAuthorizationHeaderValueLength the {@code Authorization} header-value cap, empty when
+ *                                          omitted — resolve it through
+ *                                          {@link #effectiveMaxAuthorizationHeaderValueLength()}
+ *                                          rather than reading this component directly
  * @author API Sheriff Team
  * @since 1.0
  */
-public record SecurityDefaultsConfig(Optional<String> profile) {
+public record SecurityDefaultsConfig(Optional<String> profile,
+        Optional<Integer> maxAuthorizationHeaderValueLength) {
 
     /**
-     * Canonical constructor normalizing an absent {@code profile} to
-     * {@link Optional#empty()}.
+     * The {@code Authorization} header-value cap an omitted
+     * {@code max_authorization_header_value_length} resolves to.
+     * <p>
+     * The number is the {@code lenient} preset's own {@code maxHeaderValueLength}, chosen so the
+     * carve-out never admits a header value the loosest <em>shipped</em> profile would itself reject
+     * — the relaxation stays inside the product's existing envelope rather than inventing a wider
+     * one. It also sits comfortably inside the gateway's 16 KiB inbound header-block transport
+     * bound, so a value that clears this cap can still actually arrive; a larger default would
+     * promise headroom the transport never delivers. It remains a bounded cap, never an exemption.
+     */
+    public static final int DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH = 8192;
+
+    /**
+     * Canonical constructor normalizing an absent {@code profile} or
+     * {@code maxAuthorizationHeaderValueLength} to {@link Optional#empty()}.
      */
     public SecurityDefaultsConfig {
         profile = Objects.requireNonNullElse(profile, Optional.empty());
+        maxAuthorizationHeaderValueLength =
+                Objects.requireNonNullElse(maxAuthorizationHeaderValueLength, Optional.empty());
+    }
+
+    /**
+     * Resolves the {@code Authorization} header-value cap actually enforced at the pre-route floor.
+     *
+     * @return the declared {@code max_authorization_header_value_length}, or
+     *         {@link #DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH} when the key is omitted
+     */
+    public int effectiveMaxAuthorizationHeaderValueLength() {
+        return maxAuthorizationHeaderValueLength.orElse(DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH);
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
@@ -48,6 +48,7 @@ import de.cuioss.sheriff.gateway.config.model.Protocol;
 import de.cuioss.sheriff.gateway.config.model.ResolvedTopology;
 import de.cuioss.sheriff.gateway.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.gateway.config.model.RouteConfig;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityFilterConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityHeadersConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
@@ -125,6 +126,8 @@ public final class ConfigValidator {
     private static final String OIDC_LOGIN_PATH_POINTER = "/oidc/login/path";
     private static final String OIDC_SESSION_MAX_SESSIONS_POINTER = "/oidc/session/max_sessions";
     private static final String OIDC_SESSION_MAX_COOKIE_SIZE_POINTER = "/oidc/session/max_cookie_size";
+    private static final String SECURITY_DEFAULTS_AUTHORIZATION_POINTER =
+            "/security_defaults/max_authorization_header_value_length";
 
     private static final List<ValidationRule> DEFAULT_RULES = List.of(
             (gateway, endpoints, topology, errors) -> validateVersion(gateway, errors),
@@ -152,7 +155,8 @@ public final class ConfigValidator {
             (gateway, endpoints, topology, errors) -> validatePassthroughHostCollision(gateway, endpoints, errors),
             (gateway, endpoints, topology, errors) -> validatePassthroughAliasResolvable(gateway, topology, errors),
             (gateway, endpoints, topology, errors) -> validateWebSocketConfig(gateway, endpoints, errors),
-            (gateway, endpoints, topology, errors) -> validateEdgeHardening(gateway, errors));
+            (gateway, endpoints, topology, errors) -> validateEdgeHardening(gateway, errors),
+            (gateway, endpoints, topology, errors) -> validateAuthorizationHeaderValueLength(gateway, errors));
 
     private final List<ValidationRule> rules;
 
@@ -222,6 +226,51 @@ public final class ConfigValidator {
                                 + "sub-budget of the admission pool and could never bind"));
             }
         });
+    }
+
+    /**
+     * Bounds the operator-declared {@code Authorization} header-value carve-out: a
+     * <em>declared</em> {@code security_defaults.max_authorization_header_value_length} must not fall
+     * below the resolved gateway-wide baseline {@code maxHeaderValueLength}.
+     * <p>
+     * The key exists to <em>raise</em> the non-skippable pre-route floor's header-value cap for
+     * {@code Authorization} values alone (ADR-0019), because a bearer token plus its {@code Bearer }
+     * prefix routinely exceeds the {@code strict} preset's cap and would otherwise be rejected before
+     * route selection. A value below the baseline is therefore not a carve-out at all but a per-header
+     * <em>tightening</em> expressed in the wrong place — tightening belongs on
+     * {@code security_defaults.profile} or on a route's {@code security_filter} — and it would
+     * silently make {@code Authorization} the single most-restricted header while reading like a
+     * relaxation key. That is always a misconfiguration rather than a deliberate posture, the same
+     * shape {@link #validateEdgeHardening} applies to the admission budget.
+     * <p>
+     * The comparison is genuinely cross-cutting and cannot move into the bundled JSON Schema: the
+     * baseline is the <em>resolved</em> profile's preset limit, which the schema cannot see. The
+     * schema owns the value range ({@code integer}, {@code minimum: 1}) alone. The baseline is
+     * resolved through the same {@link RouteTableBuilder#globalProfile} plus
+     * {@link SecurityProfile#limitsProfile} chain the edge performs, so the boot refusal and the
+     * runtime cap can never disagree.
+     * <p>
+     * An omitted key is never refused — it resolves to
+     * {@link SecurityDefaultsConfig#DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH}. No upper bound is
+     * enforced here: the gateway's 16 KiB inbound header-block transport limit already caps what can
+     * arrive, and it is owned by the edge layer — restating it as a second constant in this
+     * framework-agnostic class (ADR-0005) would fork the value.
+     */
+    private static void validateAuthorizationHeaderValueLength(GatewayConfig gateway, List<ConfigError> errors) {
+        gateway.securityDefaults()
+                .flatMap(SecurityDefaultsConfig::maxAuthorizationHeaderValueLength)
+                .ifPresent(declared -> {
+                    SecurityProfile global = RouteTableBuilder.globalProfile(gateway);
+                    int baseline = SecurityProfile.limitsProfile(global, global).preset().maxHeaderValueLength();
+                    if (declared < baseline) {
+                        errors.add(new ConfigError(GATEWAY_FILE, SECURITY_DEFAULTS_AUTHORIZATION_POINTER,
+                                ("max_authorization_header_value_length %d is below the resolved baseline "
+                                        + "max_header_value_length %d; the key raises the pre-route cap for "
+                                        + "Authorization values only and can never lower it — tighten through "
+                                        + "security_defaults.profile or a route security_filter instead")
+                                        .formatted(declared, baseline)));
+                    }
+                });
     }
 
     private static void validateEndpointIdUniqueness(List<EndpointConfig> endpoints, List<ConfigError> errors) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
@@ -237,11 +237,20 @@ public final class ConfigValidator {
      * {@code Authorization} values alone (ADR-0019), because a bearer token plus its {@code Bearer }
      * prefix routinely exceeds the {@code strict} preset's cap and would otherwise be rejected before
      * route selection. A value below the baseline is therefore not a carve-out at all but a per-header
-     * <em>tightening</em> expressed in the wrong place — tightening belongs on
-     * {@code security_defaults.profile} or on a route's {@code security_filter} — and it would
+     * <em>tightening</em> expressed through the one key that cannot express one, and it would
      * silently make {@code Authorization} the single most-restricted header while reading like a
      * relaxation key. That is always a misconfiguration rather than a deliberate posture, the same
      * shape {@link #validateEdgeHardening} applies to the admission budget.
+     * <p>
+     * The refusal deliberately offers no downward path, because none exists: neither remedy an
+     * operator might reach for can lower an {@code Authorization} value cap. A route's
+     * {@code security_filter} cannot, since
+     * {@code ThoroughChecksStage.carveOutConfigurationFor} floors the effective cap back up to
+     * {@code max(routeConfig.maxHeaderValueLength(), budget)} for the carved-out header name; and
+     * {@code security_defaults.profile} cannot either, since the budget resolves through
+     * {@link SecurityDefaultsConfig#effectiveMaxAuthorizationHeaderValueLength()} — the declared key
+     * or the fixed {@link SecurityDefaultsConfig#DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH} —
+     * and does not track the profile at all. Both govern general header values instead.
      * <p>
      * The comparison is genuinely cross-cutting and cannot move into the bundled JSON Schema: the
      * baseline is the <em>resolved</em> profile's preset limit, which the schema cannot see. The
@@ -266,8 +275,10 @@ public final class ConfigValidator {
                         errors.add(new ConfigError(GATEWAY_FILE, SECURITY_DEFAULTS_AUTHORIZATION_POINTER,
                                 ("max_authorization_header_value_length %d is below the resolved baseline "
                                         + "max_header_value_length %d; the key raises the pre-route cap for "
-                                        + "Authorization values only and can never lower it — tighten through "
-                                        + "security_defaults.profile or a route security_filter instead")
+                                        + "Authorization values only and can never lower it — declare at least "
+                                        + "the baseline here, as security_defaults.profile and a route "
+                                        + "security_filter bound general header values rather than the "
+                                        + "Authorization carve-out")
                                         .formatted(declared, baseline)));
                     }
                 });

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -59,6 +59,7 @@ import de.cuioss.sheriff.gateway.config.model.Protocol;
 import de.cuioss.sheriff.gateway.config.model.ResolvedAsset;
 import de.cuioss.sheriff.gateway.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.gateway.config.model.RouteTable;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityFilterConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
 import de.cuioss.sheriff.gateway.config.model.TlsConfig;
@@ -318,7 +319,8 @@ public class GatewayEdgeRoute {
         this.reservedPathRegistry = ReservedPathRegistry.from(gatewayConfig.oidc());
         this.securityHeadersStage = new SecurityHeadersStage(gatewayConfig.securityHeaders());
         this.basicChecksStage = new BasicChecksStage(defaultConfiguration, securityEventCounter,
-                cookieHeaderConfigurationFor(gatewayConfig, bffRuntime));
+                cookieHeaderConfigurationFor(gatewayConfig, bffRuntime, defaultConfiguration),
+                authorizationHeaderConfigurationFor(gatewayConfig, defaultConfiguration));
         this.canonicalPathGuard = new CanonicalPathGuard();
         this.framingGate = new FramingGate();
         this.passthroughHostGuardStage = new PassthroughHostGuardStage(
@@ -1215,18 +1217,19 @@ public class GatewayEdgeRoute {
      * {@code null} for every gateway that is not an active cookie-mode BFF.
      * <p>
      * <strong>Why this exists.</strong> Stage 1 validates every inbound header value against the
-     * cui-http default {@code maxHeaderValueLength} of 2048 characters, while a cookie-mode BFF's
-     * sealed session cookie is designed to a multi-kilobyte budget. Encoded as two independent
-     * constants, the two limits contradicted each other inside the same product: every request
-     * carrying a live sealed cookie was rejected {@code 400} at the edge before any BFF logic ran.
-     * The single declared budget ({@code oidc.session.max_cookie_size}, defaulting to
+     * resolved baseline {@code maxHeaderValueLength} — whatever {@code security_defaults.profile}
+     * resolves to, 1024 characters under {@code strict} and 8192 under {@code lenient} — while a
+     * cookie-mode BFF's sealed session cookie is designed to a multi-kilobyte budget. Encoded as two
+     * independent constants, the two limits contradicted each other inside the same product: every
+     * request carrying a live sealed cookie was rejected {@code 400} at the edge before any BFF logic
+     * ran. The single declared budget ({@code oidc.session.max_cookie_size}, defaulting to
      * {@link SealedSessionCookieCodec#DEFAULT_COOKIE_VALUE_BUDGET}) now drives BOTH ends of the round
      * trip — the codec's seal-time budget and this pre-route cap.
      * <p>
      * <strong>The relaxation is scoped twice.</strong> By MODE: a bearer-only or server-mode gateway
-     * gets {@code null} and keeps the 2048 default on every header, exactly as before. By HEADER:
+     * gets {@code null} and keeps the resolved baseline on every header, exactly as before. By HEADER:
      * within a cookie-mode gateway the raised cap applies to the {@code Cookie} / {@code Set-Cookie}
-     * values only — {@link BasicChecksStage} keeps the default policy for every other header, and
+     * values only — {@link BasicChecksStage} keeps the baseline policy for every other header, and
      * every non-length validator (null-byte, control-character, injection-pattern) still applies to
      * the cookie value. It remains a deliberate relaxation of an inbound hardening control, held as
      * narrow as the pre-route position allows.
@@ -1235,9 +1238,21 @@ public class GatewayEdgeRoute {
      * runs BEFORE route selection and this bean holds the whole route table, so no anchor exists at
      * that point. The configuration key lives on the global {@code oidc.session} block for exactly
      * that reason; its placement must not be read as per-anchor enforcement.
+     * <p>
+     * Package-private rather than private so the seeding is asserted directly by
+     * {@code GatewayEdgeRouteTest} instead of only through a booted edge, matching the precedent
+     * {@link #securityPostureFor} sets.
+     *
+     * @param gatewayConfig the bound gateway document supplying the cookie budget
+     * @param bffRuntime    the BFF runtime whose active-cookie-mode state gates the carve-out
+     * @param baseline      the gateway's resolved baseline configuration the returned policy is
+     *                      seeded from, so it differs from the baseline in
+     *                      {@code maxHeaderValueLength} and nothing else
+     * @return the {@code Cookie} / {@code Set-Cookie} value policy, or {@code null} for a gateway
+     *         that is not an active cookie-mode BFF
      */
-    private static @Nullable SecurityConfiguration cookieHeaderConfigurationFor(GatewayConfig gatewayConfig,
-            BffRuntime bffRuntime) {
+    static @Nullable SecurityConfiguration cookieHeaderConfigurationFor(GatewayConfig gatewayConfig,
+            BffRuntime bffRuntime, SecurityConfiguration baseline) {
         Optional<OidcConfig.Session> session = gatewayConfig.oidc().flatMap(OidcConfig::session);
         // The SHARED cookie-mode predicate on the config model — never a locally-declared constant
         // compared here. A private constant plus a local comparison is what let this cap relax for a
@@ -1248,10 +1263,53 @@ public class GatewayEdgeRoute {
         }
         int budget = session.flatMap(OidcConfig.Session::maxCookieSize)
                 .orElse(SealedSessionCookieCodec.DEFAULT_COOKIE_VALUE_BUDGET);
-        // SecurityConfiguration.builder() with no overrides IS SecurityConfiguration.defaults(), so
-        // this differs from the gateway default in maxHeaderValueLength and nothing else.
-        return SecurityConfiguration.builder()
+        // Seeded component-by-component from the RESOLVED baseline, so this differs from it in
+        // maxHeaderValueLength and nothing else — which is what makes ADR-0019's "only the length cap
+        // changes" bound structurally true. Seeding from SecurityConfiguration.builder() instead (its
+        // defaults being the dropped `default` preset) silently relaxed failOnSuspiciousPatterns,
+        // allowExtendedAscii and caseSensitiveComparison for cookie values on a strict gateway.
+        return builderSeededFrom(baseline)
                 .maxHeaderValueLength(budget + COOKIE_HEADER_OVERHEAD_BYTES)
+                .build();
+    }
+
+    /**
+     * Derives the pre-route {@code Authorization} header-value policy from the gateway document.
+     * <p>
+     * <strong>Why this exists.</strong> A bearer token plus its {@code Bearer } prefix routinely
+     * exceeds the resolved baseline {@code maxHeaderValueLength} — a Keycloak access token measures
+     * above the {@code strict} preset's 1024-character cap — so without a raised cap Stage 1, the
+     * non-skippable pre-route floor, rejects every bearer request {@code 400} before route selection
+     * and bearer validation never runs at all.
+     * <p>
+     * <strong>The relaxation is scoped, but unconditionally present.</strong> By HEADER: the raised
+     * cap reaches {@code Authorization} values only. By VALIDATOR: the returned configuration is
+     * seeded from {@code baseline} and overrides {@code maxHeaderValueLength} alone, so every
+     * non-length validator still applies. Unlike the cookie carve-out there is no MODE axis — every
+     * gateway is bearer-capable, so this policy is always built and never {@code null}. That axis is
+     * genuinely weaker than the cookie carve-out's, not equivalent to it.
+     * <p>
+     * The budget comes from the operator-declared {@code security_defaults.max_authorization_header_value_length},
+     * defaulting to {@link SecurityDefaultsConfig#DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH}. It
+     * sits on the gateway-wide {@code security_defaults} block because Stage 1 runs before route
+     * selection, so no anchor exists at that point; a declared value below the resolved baseline is
+     * refused at boot by {@code ConfigValidator}.
+     * <p>
+     * Package-private for the same reason as {@link #cookieHeaderConfigurationFor}.
+     *
+     * @param gatewayConfig the bound gateway document supplying the declared budget
+     * @param baseline      the gateway's resolved baseline configuration the returned policy is
+     *                      seeded from
+     * @return the {@code Authorization} value policy, differing from {@code baseline} in
+     *         {@code maxHeaderValueLength} alone
+     */
+    static SecurityConfiguration authorizationHeaderConfigurationFor(GatewayConfig gatewayConfig,
+            SecurityConfiguration baseline) {
+        int budget = gatewayConfig.securityDefaults()
+                .map(SecurityDefaultsConfig::effectiveMaxAuthorizationHeaderValueLength)
+                .orElse(SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH);
+        return builderSeededFrom(baseline)
+                .maxHeaderValueLength(budget)
                 .build();
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -1247,6 +1247,19 @@ public class GatewayEdgeRoute {
      * injection-pattern) still applies to the cookie value. It remains a deliberate relaxation of an
      * inbound hardening control, held as narrow as the pre-route position allows.
      * <p>
+     * <strong>The cap is {@code max}-bounded, so the carve-out can only ever ADMIT MORE length.</strong>
+     * The effective cap is {@code max(baseline.maxHeaderValueLength(), budget + }{@value #COOKIE_HEADER_OVERHEAD_BYTES}{@code )}.
+     * Setting it outright from the budget made the carve-out LOWER the cap on a {@code lenient}
+     * gateway: the shipped default budget
+     * ({@link SealedSessionCookieCodec#DEFAULT_COOKIE_VALUE_BUDGET}, 4096) plus the overhead is 4608,
+     * below that profile's 8192 baseline, so a cookie-mode BFF rejected {@code 400} every request
+     * whose {@code Cookie} value sat between the two — while every OTHER header on the same gateway
+     * was admitted to 8192. No operator misconfiguration was required. The {@code max} restores
+     * ADR-0019's stated bound, "the direction of change is admit-more-length-only", and matches the
+     * two sibling sites: {@code ThoroughChecksStage.carveOutConfigurationFor} caps at
+     * {@code max(routeCap, budget)} post-route, and {@code ConfigValidator} refuses a below-baseline
+     * {@code Authorization} budget outright at boot.
+     * <p>
      * The returned policy is handed to {@link ThoroughChecksStage} as well as to
      * {@link BasicChecksStage}: the post-route stage re-validates every header under the ROUTE's
      * configuration whenever that configuration diverges from the baseline, so it needs the same
@@ -1283,13 +1296,18 @@ public class GatewayEdgeRoute {
         }
         int budget = session.flatMap(OidcConfig.Session::maxCookieSize)
                 .orElse(SealedSessionCookieCodec.DEFAULT_COOKIE_VALUE_BUDGET);
+        // max(), not an outright set: a carve-out may only ever ADMIT MORE length. The default budget
+        // plus the overhead is 4608, which sits BELOW the lenient profile's 8192 baseline, so setting
+        // the cap outright turned this carve-out into a per-header TIGHTENING on every shipped-default
+        // lenient cookie-mode gateway. Same bound as ThoroughChecksStage.carveOutConfigurationFor.
+        int cap = Math.max(baseline.maxHeaderValueLength(), budget + COOKIE_HEADER_OVERHEAD_BYTES);
         // Seeded component-by-component from the RESOLVED baseline, so this differs from it in
         // maxHeaderValueLength and nothing else — which is what makes ADR-0019's "only the length cap
         // changes" bound structurally true. Seeding from SecurityConfiguration.builder() instead (its
         // defaults being the dropped `default` preset) silently relaxed failOnSuspiciousPatterns,
         // allowExtendedAscii and caseSensitiveComparison for cookie values on a strict gateway.
         return SecurityConfigurations.builderSeededFrom(baseline)
-                .maxHeaderValueLength(budget + COOKIE_HEADER_OVERHEAD_BYTES)
+                .maxHeaderValueLength(cap)
                 .build();
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -59,6 +59,7 @@ import de.cuioss.sheriff.gateway.config.model.Protocol;
 import de.cuioss.sheriff.gateway.config.model.ResolvedAsset;
 import de.cuioss.sheriff.gateway.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.gateway.config.model.RouteTable;
+import de.cuioss.sheriff.gateway.config.model.SecurityConfigurations;
 import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityFilterConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
@@ -318,16 +319,25 @@ public class GatewayEdgeRoute {
         // ThoroughChecksStage, so a reserved path never reaches it (ADR-0019, amended).
         this.reservedPathRegistry = ReservedPathRegistry.from(gatewayConfig.oidc());
         this.securityHeadersStage = new SecurityHeadersStage(gatewayConfig.securityHeaders());
+        // Both header-value carve-outs are resolved ONCE and handed to BOTH stages that measure a
+        // header value. Stage 3 re-validates every header under the ROUTE's configuration whenever
+        // that configuration diverges from the baseline, so without the same two policies it would
+        // undo the carve-outs one stage later — and it runs before the authentication stage, so an
+        // Authorization value is still present when it does.
+        SecurityConfiguration cookieHeaderConfiguration =
+                cookieHeaderConfigurationFor(gatewayConfig, bffRuntime, defaultConfiguration);
+        SecurityConfiguration authorizationHeaderConfiguration =
+                authorizationHeaderConfigurationFor(gatewayConfig, defaultConfiguration);
         this.basicChecksStage = new BasicChecksStage(defaultConfiguration, securityEventCounter,
-                cookieHeaderConfigurationFor(gatewayConfig, bffRuntime, defaultConfiguration),
-                authorizationHeaderConfigurationFor(gatewayConfig, defaultConfiguration));
+                cookieHeaderConfiguration, authorizationHeaderConfiguration);
         this.canonicalPathGuard = new CanonicalPathGuard();
         this.framingGate = new FramingGate();
         this.passthroughHostGuardStage = new PassthroughHostGuardStage(
                 gatewayConfig.tls().map(TlsConfig::passthroughSni).map(Map::keySet).orElse(Set.of()));
         this.routeSelectionStage = new RouteSelectionStage(routes);
         this.verbGateStage = new VerbGateStage();
-        this.thoroughChecksStage = new ThoroughChecksStage(defaultConfiguration, securityEventCounter);
+        this.thoroughChecksStage = new ThoroughChecksStage(defaultConfiguration, securityEventCounter,
+                cookieHeaderConfiguration, authorizationHeaderConfiguration);
         // A server-mode BFF wires the session-aware AuthenticationStage so a require:session route is
         // served through the SessionAuthenticationStage (D4) rather than failing at request time; a
         // bearer-only gateway keeps the no-session constructor unchanged.
@@ -1237,6 +1247,13 @@ public class GatewayEdgeRoute {
      * injection-pattern) still applies to the cookie value. It remains a deliberate relaxation of an
      * inbound hardening control, held as narrow as the pre-route position allows.
      * <p>
+     * The returned policy is handed to {@link ThoroughChecksStage} as well as to
+     * {@link BasicChecksStage}: the post-route stage re-validates every header under the ROUTE's
+     * configuration whenever that configuration diverges from the baseline, so it needs the same
+     * budget or it would undo this carve-out one stage later. Only the policy's
+     * {@code maxHeaderValueLength} is read there, as the budget; the remaining dimensions applied
+     * post-route come from the route's own configuration.
+     * <p>
      * <strong>Recorded constraint — enforcement is gateway-wide, not per-anchor.</strong> Stage 1
      * runs BEFORE route selection and this bean holds the whole route table, so no anchor exists at
      * that point. The configuration key lives on the global {@code oidc.session} block for exactly
@@ -1271,7 +1288,7 @@ public class GatewayEdgeRoute {
         // changes" bound structurally true. Seeding from SecurityConfiguration.builder() instead (its
         // defaults being the dropped `default` preset) silently relaxed failOnSuspiciousPatterns,
         // allowExtendedAscii and caseSensitiveComparison for cookie values on a strict gateway.
-        return builderSeededFrom(baseline)
+        return SecurityConfigurations.builderSeededFrom(baseline)
                 .maxHeaderValueLength(budget + COOKIE_HEADER_OVERHEAD_BYTES)
                 .build();
     }
@@ -1292,6 +1309,12 @@ public class GatewayEdgeRoute {
      * gateway is bearer-capable, so this policy is always built and never {@code null}. That axis is
      * genuinely weaker than the cookie carve-out's, not equivalent to it.
      * <p>
+     * As with the cookie carve-out, the returned policy is handed to {@link ThoroughChecksStage} as
+     * well as to {@link BasicChecksStage}, so the raised cap survives the post-route re-run a route
+     * with a divergent {@code security_filter} triggers — a route declaring nothing more than a
+     * raised {@code max_body_bytes} already diverges. Without that, the floor would admit a bearer
+     * token and the very next stage would reject it, still ahead of bearer validation.
+     * <p>
      * The budget comes from the operator-declared {@code security_defaults.max_authorization_header_value_length},
      * defaulting to {@link SecurityDefaultsConfig#DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH}. It
      * sits on the gateway-wide {@code security_defaults} block because Stage 1 runs before route
@@ -1311,7 +1334,7 @@ public class GatewayEdgeRoute {
         int budget = gatewayConfig.securityDefaults()
                 .map(SecurityDefaultsConfig::effectiveMaxAuthorizationHeaderValueLength)
                 .orElse(SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH);
-        return builderSeededFrom(baseline)
+        return SecurityConfigurations.builderSeededFrom(baseline)
                 .maxHeaderValueLength(budget)
                 .build();
     }
@@ -1349,11 +1372,12 @@ public class GatewayEdgeRoute {
      * builder is seeded component-by-component from {@code preset} because the cui-http
      * {@link SecurityConfiguration} exposes no preset-seeded builder — {@link SecurityConfiguration#builder()}
      * starts from {@code defaults()}, so seeding explicitly is the only way an undeclared dimension
-     * keeps the preset's value instead of silently reverting to the default policy.
+     * keeps the preset's value instead of silently reverting to the default policy. The component
+     * list lives once, in {@link SecurityConfigurations#builderSeededFrom(SecurityConfiguration)}.
      */
     private static SecurityConfiguration applyDeclaredLimits(SecurityConfiguration preset,
             SecurityFilterConfig filter) {
-        SecurityConfigurationBuilder builder = builderSeededFrom(preset);
+        SecurityConfigurationBuilder builder = SecurityConfigurations.builderSeededFrom(preset);
         filter.maxBodyBytes().ifPresent(value -> builder.maxBodySize(value.longValue()));
         filter.maxQueryParams().ifPresent(builder::maxParameterCount);
         filter.maxHeaderCount().ifPresent(builder::maxHeaderCount);
@@ -1369,40 +1393,6 @@ public class GatewayEdgeRoute {
             builder.allowedContentTypes(Set.copyOf(filter.allowedContentTypes()));
         }
         return builder.build();
-    }
-
-    /**
-     * Returns a {@link SecurityConfigurationBuilder} carrying every component of {@code preset}, so
-     * a caller overriding one dimension leaves the other twenty-three on the preset's values. Copies
-     * the record's full component set deliberately: an omitted component would silently fall back to
-     * the {@code defaults()} policy the builder starts from.
-     */
-    private static SecurityConfigurationBuilder builderSeededFrom(SecurityConfiguration preset) {
-        return SecurityConfiguration.builder()
-                .maxPathLength(preset.maxPathLength())
-                .allowDoubleEncoding(preset.allowDoubleEncoding())
-                .maxParameterNameLength(preset.maxParameterNameLength())
-                .maxParameterValueLength(preset.maxParameterValueLength())
-                .maxHeaderNameLength(preset.maxHeaderNameLength())
-                .maxHeaderValueLength(preset.maxHeaderValueLength())
-                .maxCookieNameLength(preset.maxCookieNameLength())
-                .maxCookieValueLength(preset.maxCookieValueLength())
-                .maxBodySize(preset.maxBodySize())
-                .allowNullBytes(preset.allowNullBytes())
-                .allowControlCharacters(preset.allowControlCharacters())
-                .allowExtendedAscii(preset.allowExtendedAscii())
-                .normalizeUnicode(preset.normalizeUnicode())
-                .caseSensitiveComparison(preset.caseSensitiveComparison())
-                .failOnSuspiciousPatterns(preset.failOnSuspiciousPatterns())
-                .requireSecureCookies(preset.requireSecureCookies())
-                .requireHttpOnlyCookies(preset.requireHttpOnlyCookies())
-                .maxParameterCount(preset.maxParameterCount())
-                .maxHeaderCount(preset.maxHeaderCount())
-                .maxCookieCount(preset.maxCookieCount())
-                .allowedHeaderNames(preset.allowedHeaderNames())
-                .blockedHeaderNames(preset.blockedHeaderNames())
-                .allowedContentTypes(preset.allowedContentTypes())
-                .blockedContentTypes(preset.blockedContentTypes());
     }
 
     /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -1227,12 +1227,15 @@ public class GatewayEdgeRoute {
      * trip — the codec's seal-time budget and this pre-route cap.
      * <p>
      * <strong>The relaxation is scoped twice.</strong> By MODE: a bearer-only or server-mode gateway
-     * gets {@code null} and keeps the resolved baseline on every header, exactly as before. By HEADER:
-     * within a cookie-mode gateway the raised cap applies to the {@code Cookie} / {@code Set-Cookie}
-     * values only — {@link BasicChecksStage} keeps the baseline policy for every other header, and
-     * every non-length validator (null-byte, control-character, injection-pattern) still applies to
-     * the cookie value. It remains a deliberate relaxation of an inbound hardening control, held as
-     * narrow as the pre-route position allows.
+     * gets {@code null}, so no cookie carve-out exists there and its {@code Cookie} /
+     * {@code Set-Cookie} values are measured at the resolved baseline like any other header. By
+     * HEADER: within a cookie-mode gateway the raised cap reaches the {@code Cookie} /
+     * {@code Set-Cookie} values only. {@link BasicChecksStage} selects the value pipeline on the
+     * header NAME across three branches — an {@code Authorization} value takes the separate,
+     * unconditional carve-out of {@link #authorizationHeaderConfigurationFor}, and every OTHER header
+     * keeps the resolved baseline policy. Every non-length validator (null-byte, control-character,
+     * injection-pattern) still applies to the cookie value. It remains a deliberate relaxation of an
+     * inbound hardening control, held as narrow as the pre-route position allows.
      * <p>
      * <strong>Recorded constraint — enforcement is gateway-wide, not per-anchor.</strong> Stage 1
      * runs BEFORE route selection and this bean holds the whole route table, so no anchor exists at

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
@@ -61,8 +61,9 @@ import org.jspecify.annotations.Nullable;
  *   <li><strong>{@code Cookie} / {@code Set-Cookie}</strong> — a cookie-mode BFF's sealed session
  *       cookie is designed to a multi-kilobyte budget the resolved baseline would reject at the edge
  *       on every authenticated request. The OPTIONAL {@code cookieHeaderConfiguration} supplies the
- *       raised cap; a bearer-only or server-mode gateway passes {@code null} and keeps the resolved
- *       baseline on every header, byte-for-byte unaffected. Its budget key is
+ *       raised cap; a bearer-only or server-mode gateway passes {@code null}, so no cookie carve-out
+ *       exists there and its {@code Cookie} / {@code Set-Cookie} values are measured at the resolved
+ *       baseline like any other header. Its budget key is
  *       {@code oidc.session.max_cookie_size}.</li>
  *   <li><strong>{@code Authorization}</strong> — a bearer token plus its {@code Bearer } prefix
  *       routinely exceeds the {@code strict} baseline, which would reject every bearer request here,

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
@@ -85,6 +85,12 @@ import org.jspecify.annotations.Nullable;
  * BEFORE route selection, so no anchor is resolved yet. Both configuration keys sit on global blocks
  * ({@code oidc.session} and {@code security_defaults}) for exactly that reason — their placement must
  * not be read as per-anchor enforcement.
+ * <p>
+ * <strong>Both carve-outs are honoured post-route too.</strong> They are declared here, but this is
+ * not the only stage that measures a header value: {@link ThoroughChecksStage} re-validates every
+ * header under the ROUTE's configuration whenever that configuration diverges from the gateway
+ * baseline, and it repeats this same three-way dispatch so neither carve-out is undone one stage
+ * later. See that class for the {@code max}-bounded per-route cap.
  *
  * @author API Sheriff Team
  * @since 1.0

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
@@ -53,19 +53,37 @@ import org.jspecify.annotations.Nullable;
  * terminates in {@code handleReservedPath} before route selection and therefore never reaches the
  * parameter pipeline at all — so this stage no longer takes a reserved-path predicate.
  * <p>
- * <strong>The cookie-mode header-value carve-out.</strong> A cookie-mode BFF's sealed session cookie
- * is designed to a multi-kilobyte budget, which the default 2048-character header-value cap would
- * reject at the edge on every authenticated request. The stage therefore accepts an OPTIONAL
- * {@code cookieHeaderConfiguration} whose only difference from the default policy is a raised
- * {@code maxHeaderValueLength}, and applies it to the {@code Cookie} / {@code Set-Cookie} header
- * values ONLY — every other header keeps the default cap, and every other validator in the pipeline
- * (null-byte, control-character, injection-pattern) applies to the cookie header unchanged. A
- * bearer-only or server-mode gateway passes {@code null} and is byte-for-byte unaffected.
+ * <strong>Two header-value carve-outs.</strong> The cap every header value is measured against is the
+ * <em>resolved baseline</em> — whatever {@code security_defaults.profile} resolves to, 1024 characters
+ * under {@code strict} and 8192 under {@code lenient} — never a fixed absolute. Two header names are
+ * carved out of it, each by a dedicated value pipeline selected on the header NAME:
+ * <ul>
+ *   <li><strong>{@code Cookie} / {@code Set-Cookie}</strong> — a cookie-mode BFF's sealed session
+ *       cookie is designed to a multi-kilobyte budget the resolved baseline would reject at the edge
+ *       on every authenticated request. The OPTIONAL {@code cookieHeaderConfiguration} supplies the
+ *       raised cap; a bearer-only or server-mode gateway passes {@code null} and keeps the resolved
+ *       baseline on every header, byte-for-byte unaffected. Its budget key is
+ *       {@code oidc.session.max_cookie_size}.</li>
+ *   <li><strong>{@code Authorization}</strong> — a bearer token plus its {@code Bearer } prefix
+ *       routinely exceeds the {@code strict} baseline, which would reject every bearer request here,
+ *       before route selection and before bearer validation ever runs. Unlike the cookie carve-out
+ *       this configuration is <em>unconditional and non-null</em>: a bearer-capable gateway is every
+ *       gateway, so there is no mode that switches it off. Its budget key is
+ *       {@code security_defaults.max_authorization_header_value_length}.</li>
+ * </ul>
+ * Both carve-outs are bounded on the same three axes ADR-0019 states. <em>By header</em>: the raised
+ * cap reaches those header names only — every other header is measured at the resolved baseline.
+ * <em>By validator</em>: each carve-out configuration is seeded from the resolved baseline and differs
+ * from it in {@code maxHeaderValueLength} alone, so every non-length validator (null-byte,
+ * control-character, extended-ASCII, injection-pattern) still applies to the carved-out value exactly
+ * as to any other. <em>By deployment</em>: the cookie carve-out exists only in an active cookie-mode
+ * BFF, while the {@code Authorization} carve-out is unconditional — a genuinely weaker axis, not a
+ * parallel one.
  * <p>
- * The relaxation is necessarily <strong>gateway-wide, not per-anchor</strong>: this stage runs
- * BEFORE route selection, so no anchor is resolved yet. The configuration key that supplies the
- * budget ({@code oidc.session.max_cookie_size}) sits on the global session block for exactly that
- * reason — its placement must not be read as per-anchor enforcement.
+ * Both relaxations are necessarily <strong>gateway-wide, not per-anchor</strong>: this stage runs
+ * BEFORE route selection, so no anchor is resolved yet. Both configuration keys sit on global blocks
+ * ({@code oidc.session} and {@code security_defaults}) for exactly that reason — their placement must
+ * not be read as per-anchor enforcement.
  *
  * @author API Sheriff Team
  * @since 1.0
@@ -74,10 +92,12 @@ public final class BasicChecksStage {
 
     private static final String COOKIE_HEADER = "cookie";
     private static final String SET_COOKIE_HEADER = "set-cookie";
+    private static final String AUTHORIZATION_HEADER = "authorization";
 
     private final SecurityConfiguration configuration;
     private final PipelineFactory.PipelineSet pipelines;
     private final HttpSecurityValidator cookieHeaderValuePipeline;
+    private final HttpSecurityValidator authorizationHeaderValuePipeline;
 
     /**
      * @param configuration      the gateway's resolved baseline inbound validation policy
@@ -86,16 +106,24 @@ public final class BasicChecksStage {
      *                           header VALUES only, or {@code null} to validate them under
      *                           {@code configuration} like every other header. Supplied only by a
      *                           cookie-mode BFF gateway, whose sealed session cookie exceeds the
-     *                           default header-value cap
+     *                           resolved baseline header-value cap
+     * @param authorizationHeaderConfiguration the policy applied to {@code Authorization} header
+     *                           VALUES only. Unconditional and never {@code null}: every gateway is
+     *                           bearer-capable, so unlike the cookie carve-out there is no mode that
+     *                           switches it off
      */
     public BasicChecksStage(SecurityConfiguration configuration, SecurityEventCounter eventCounter,
-            @Nullable SecurityConfiguration cookieHeaderConfiguration) {
+            @Nullable SecurityConfiguration cookieHeaderConfiguration,
+            SecurityConfiguration authorizationHeaderConfiguration) {
         this.configuration = Objects.requireNonNull(configuration, "configuration");
         SecurityEventCounter counter = Objects.requireNonNull(eventCounter, "eventCounter");
+        Objects.requireNonNull(authorizationHeaderConfiguration, "authorizationHeaderConfiguration");
         this.pipelines = PipelineFactory.createCommonPipelines(configuration, counter);
         this.cookieHeaderValuePipeline = cookieHeaderConfiguration == null
                 ? this.pipelines.headerValuePipeline()
                 : PipelineFactory.createHeaderValuePipeline(cookieHeaderConfiguration, counter);
+        this.authorizationHeaderValuePipeline =
+                PipelineFactory.createHeaderValuePipeline(authorizationHeaderConfiguration, counter);
     }
 
     /**
@@ -139,11 +167,10 @@ public final class BasicChecksStage {
             for (Map.Entry<String, List<String>> header : headers.entrySet()) {
                 String name = header.getKey();
                 pipelines.headerNamePipeline().validate(name);
-                // The header NAME is already in hand here — that is the seam the cookie-mode
-                // carve-out hangs off. Only Cookie / Set-Cookie values may use the raised cap.
-                HttpSecurityValidator valuePipeline = isCookieHeader(name)
-                        ? cookieHeaderValuePipeline
-                        : pipelines.headerValuePipeline();
+                // The header NAME is already in hand here — that is the seam both carve-outs hang
+                // off. Only Authorization and Cookie / Set-Cookie values may use a raised cap;
+                // every other header falls through to the resolved baseline pipeline.
+                HttpSecurityValidator valuePipeline = valuePipelineFor(name);
                 for (String value : header.getValue()) {
                     valuePipeline.validate(value);
                 }
@@ -151,6 +178,25 @@ public final class BasicChecksStage {
         } catch (UrlSecurityException violation) {
             throw rejected(violation);
         }
+    }
+
+    /**
+     * The three-way header-name dispatch: {@code Authorization} and {@code Cookie} / {@code Set-Cookie}
+     * each resolve to their own carve-out pipeline, everything else to the resolved baseline. The two
+     * carve-out names are disjoint, so the order of the branches carries no precedence decision.
+     */
+    private HttpSecurityValidator valuePipelineFor(String name) {
+        if (isAuthorizationHeader(name)) {
+            return authorizationHeaderValuePipeline;
+        }
+        if (isCookieHeader(name)) {
+            return cookieHeaderValuePipeline;
+        }
+        return pipelines.headerValuePipeline();
+    }
+
+    private static boolean isAuthorizationHeader(String name) {
+        return AUTHORIZATION_HEADER.equalsIgnoreCase(name);
     }
 
     private static boolean isCookieHeader(String name) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
@@ -23,12 +23,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
 import de.cuioss.http.security.exceptions.UrlSecurityException;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.http.security.pipeline.PipelineFactory;
+import de.cuioss.sheriff.gateway.config.model.SecurityConfigurations;
 import de.cuioss.sheriff.gateway.events.EventType;
 import de.cuioss.sheriff.gateway.events.GatewayException;
 import de.cuioss.sheriff.gateway.routing.RouteRuntime;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Stage 3 — per-route thorough checks, run after the verb gate on the selected route. The stage is
@@ -61,8 +65,30 @@ import de.cuioss.sheriff.gateway.routing.RouteRuntime;
  *       pipelines are re-run under it; a route whose config equals the default is skipped (stage 1
  *       already covered it). Per-config pipeline sets are cached so shared route shapes reuse one set.
  *       The parameter loop is deliberately NOT re-run here — that would duplicate the validation
- *       above on the hot path.</li>
+ *       above on the hot path. The re-run honours the SAME two header-value carve-outs the pre-route
+ *       floor grants — see below.</li>
  * </ul>
+ * <p>
+ * <strong>The two header-value carve-outs survive the re-run.</strong> {@code BasicChecksStage}
+ * dispatches on the header NAME across three branches so an {@code Authorization} value and a
+ * {@code Cookie} / {@code Set-Cookie} value are each measured against a raised cap. This stage
+ * re-validates every header value under the ROUTE's configuration, so without the same dispatch it
+ * would silently undo both carve-outs one stage later — and it runs BEFORE the authentication stage,
+ * so an {@code Authorization} value is still present and unmodified when it does. The concrete
+ * regression: on a {@code strict} gateway a route declaring nothing but a raised
+ * {@code max_body_bytes} diverges from the baseline, which triggers the re-run, which then rejected a
+ * bearer token {@code 400} before bearer validation ever ran. This stage therefore repeats the
+ * three-way dispatch, seeding each carve-out from the ROUTE's own configuration — never from the
+ * gateway baseline — via {@link #carveOutConfigurationFor(SecurityConfiguration, int)}.
+ * <p>
+ * The carve-out cap is {@code max(routeConfig.maxHeaderValueLength(), budget)}, and the {@code max}
+ * is load-bearing in both directions: a route that legitimately RAISES its own header-value cap above
+ * the carve-out budget keeps its higher cap, while a route sitting at or below the baseline still
+ * admits the carved-out header up to the budget. The carve-out never LOWERS a route's own cap, and it
+ * changes {@code maxHeaderValueLength} alone — every other validator (null-byte, control-character,
+ * extended-ASCII, injection-pattern, case-sensitivity) stays on the ROUTE's setting for the carved-out
+ * headers, exactly as for every other header. The direction of change is admit-more-length-only, for
+ * exactly two header names.
  * <p>
  * <strong>The closed list of what {@code none} turns off is exactly those two items</strong> — the
  * relocated url-parameter name/value validation and the pipeline re-run. Everything else keeps
@@ -79,18 +105,40 @@ public final class ThoroughChecksStage {
 
     private static final String SEGMENT_WILDCARD_PREFIX = "{";
     private static final String SEGMENT_WILDCARD_SUFFIX = "}";
+    private static final String COOKIE_HEADER = "cookie";
+    private static final String SET_COOKIE_HEADER = "set-cookie";
+    private static final String AUTHORIZATION_HEADER = "authorization";
 
     private final SecurityConfiguration defaultConfiguration;
     private final SecurityEventCounter eventCounter;
-    private final Map<SecurityConfiguration, PipelineFactory.PipelineSet> pipelineCache = new ConcurrentHashMap<>();
+    private final int authorizationCarveOutBudget;
+    private final @Nullable Integer cookieCarveOutBudget;
+    private final Map<SecurityConfiguration, RoutePipelines> pipelineCache = new ConcurrentHashMap<>();
 
     /**
      * @param defaultConfiguration the stage-1 default policy, used to skip a route whose config matches
      * @param eventCounter         the shared cui-http security event counter (never a local instance)
+     * @param cookieHeaderConfiguration the gateway's pre-route {@code Cookie} / {@code Set-Cookie}
+     *                             carve-out policy, or {@code null} for a gateway that is not an
+     *                             active cookie-mode BFF and therefore has no cookie carve-out to
+     *                             carry forward. Only its {@code maxHeaderValueLength} is read, as
+     *                             the carve-out BUDGET; every other dimension applied to a cookie
+     *                             value here comes from the ROUTE's configuration
+     * @param authorizationHeaderConfiguration the gateway's pre-route {@code Authorization} carve-out
+     *                             policy. Unconditional and never {@code null}, mirroring
+     *                             {@code BasicChecksStage}. Only its {@code maxHeaderValueLength} is
+     *                             read, as the carve-out BUDGET
      */
-    public ThoroughChecksStage(SecurityConfiguration defaultConfiguration, SecurityEventCounter eventCounter) {
+    public ThoroughChecksStage(SecurityConfiguration defaultConfiguration, SecurityEventCounter eventCounter,
+            @Nullable SecurityConfiguration cookieHeaderConfiguration,
+            SecurityConfiguration authorizationHeaderConfiguration) {
         this.defaultConfiguration = Objects.requireNonNull(defaultConfiguration, "defaultConfiguration");
         this.eventCounter = Objects.requireNonNull(eventCounter, "eventCounter");
+        Objects.requireNonNull(authorizationHeaderConfiguration, "authorizationHeaderConfiguration");
+        this.authorizationCarveOutBudget = authorizationHeaderConfiguration.maxHeaderValueLength();
+        this.cookieCarveOutBudget = cookieHeaderConfiguration == null
+                ? null
+                : cookieHeaderConfiguration.maxHeaderValueLength();
     }
 
     /**
@@ -139,7 +187,7 @@ public final class ThoroughChecksStage {
      * than predicate-driven.
      */
     private void validateParameters(PipelineRequest request, SecurityConfiguration routeConfig) {
-        PipelineFactory.PipelineSet pipelines = pipelinesFor(routeConfig);
+        PipelineFactory.PipelineSet pipelines = pipelinesFor(routeConfig).pipelines();
         try {
             for (Map.Entry<String, List<String>> parameter : request.queryParameters().entrySet()) {
                 pipelines.urlParameterPipeline().validate(parameter.getKey());
@@ -160,15 +208,22 @@ public final class ThoroughChecksStage {
      * {@code blocked_header_names}, a lower {@code maxHeaderNameLength}) would otherwise never have
      * it applied. The parameter loop is deliberately absent: {@link #validateParameters} already
      * ran under this same configuration, so re-running it here would be duplicate hot-path work.
+     * <p>
+     * Header VALUES go through the same three-way header-NAME dispatch the pre-route floor uses, so
+     * the {@code Authorization} and {@code Cookie} / {@code Set-Cookie} carve-outs are not undone
+     * here. See the class Javadoc for the {@code max}-bounded cap and the by-header / by-validator
+     * bounds.
      */
     private void reRunPipelines(PipelineRequest request, SecurityConfiguration routeConfig, String canonicalPath) {
-        PipelineFactory.PipelineSet pipelines = pipelinesFor(routeConfig);
+        RoutePipelines pipelines = pipelinesFor(routeConfig);
         try {
-            pipelines.urlPathPipeline().validate(canonicalPath);
+            pipelines.pipelines().urlPathPipeline().validate(canonicalPath);
             for (Map.Entry<String, List<String>> header : request.headers().entrySet()) {
-                pipelines.headerNamePipeline().validate(header.getKey());
+                String name = header.getKey();
+                pipelines.pipelines().headerNamePipeline().validate(name);
+                HttpSecurityValidator valuePipeline = pipelines.valuePipelineFor(name);
                 for (String value : header.getValue()) {
-                    pipelines.headerValuePipeline().validate(value);
+                    valuePipeline.validate(value);
                 }
             }
         } catch (UrlSecurityException violation) {
@@ -176,9 +231,86 @@ public final class ThoroughChecksStage {
         }
     }
 
-    private PipelineFactory.PipelineSet pipelinesFor(SecurityConfiguration routeConfig) {
-        return pipelineCache.computeIfAbsent(routeConfig,
-                config -> PipelineFactory.createCommonPipelines(config, eventCounter));
+    private RoutePipelines pipelinesFor(SecurityConfiguration routeConfig) {
+        return pipelineCache.computeIfAbsent(routeConfig, this::buildPipelines);
+    }
+
+    /**
+     * Builds the per-route pipeline triple: the route's own common pipeline set plus the two
+     * carve-out header-value validators derived from it. Cached per route configuration, so the
+     * carve-out derivation is a boot-shaped cost rather than a per-request one.
+     */
+    private RoutePipelines buildPipelines(SecurityConfiguration routeConfig) {
+        PipelineFactory.PipelineSet routePipelines =
+                PipelineFactory.createCommonPipelines(routeConfig, eventCounter);
+        HttpSecurityValidator authorization =
+                carveOutValuePipeline(routeConfig, authorizationCarveOutBudget, routePipelines);
+        // A gateway that is not an active cookie-mode BFF supplies no cookie budget, so its Cookie /
+        // Set-Cookie values stay on the ROUTE's own header-value pipeline like any other header —
+        // the same by-deployment bound the pre-route floor applies.
+        HttpSecurityValidator cookie = cookieCarveOutBudget == null
+                ? routePipelines.headerValuePipeline()
+                : carveOutValuePipeline(routeConfig, cookieCarveOutBudget, routePipelines);
+        return new RoutePipelines(routePipelines, authorization, cookie);
+    }
+
+    /**
+     * Resolves the value pipeline for one carve-out, reusing the route's own header-value pipeline
+     * whenever the route's cap already meets or exceeds the budget — so a route that raised its own
+     * cap allocates no second pipeline and, more importantly, is never measured against a lower one.
+     */
+    private HttpSecurityValidator carveOutValuePipeline(SecurityConfiguration routeConfig, int budget,
+            PipelineFactory.PipelineSet routePipelines) {
+        SecurityConfiguration carveOut = carveOutConfigurationFor(routeConfig, budget);
+        return carveOut.equals(routeConfig)
+                ? routePipelines.headerValuePipeline()
+                : PipelineFactory.createHeaderValuePipeline(carveOut, eventCounter);
+    }
+
+    /**
+     * The per-route carve-out policy: {@code routeConfig} with its header-value cap raised to
+     * {@code max(routeConfig.maxHeaderValueLength(), budget)} and <strong>nothing else changed</strong>.
+     * <p>
+     * Seeded through the shared {@link SecurityConfigurations#builderSeededFrom(SecurityConfiguration)}
+     * rather than a locally-written component list, which is what makes "differs from the ROUTE
+     * configuration in {@code maxHeaderValueLength} alone" structurally true instead of a comment.
+     * Returns {@code routeConfig} itself when the route's own cap already meets the budget, so the
+     * carve-out can only ever raise a cap, never lower one.
+     * <p>
+     * Package-private so the seeding is asserted directly rather than only through a booted pipeline,
+     * matching the precedent the two pre-route carve-out factories set.
+     *
+     * @param routeConfig the route's resolved configuration, the sole seed for every dimension
+     * @param budget      the gateway-wide carve-out budget for this header name
+     * @return the carve-out policy, or {@code routeConfig} unchanged when its cap already suffices
+     */
+    static SecurityConfiguration carveOutConfigurationFor(SecurityConfiguration routeConfig, int budget) {
+        if (routeConfig.maxHeaderValueLength() >= budget) {
+            return routeConfig;
+        }
+        return SecurityConfigurations.builderSeededFrom(routeConfig)
+                .maxHeaderValueLength(budget)
+                .build();
+    }
+
+    /**
+     * The three-way header-name dispatch, mirroring the pre-route floor: {@code Authorization} and
+     * {@code Cookie} / {@code Set-Cookie} each resolve to their own carve-out pipeline, everything
+     * else to the route's own header-value pipeline. The two carve-out names are disjoint, so the
+     * order of the branches carries no precedence decision.
+     */
+    private record RoutePipelines(PipelineFactory.PipelineSet pipelines,
+    HttpSecurityValidator authorization, HttpSecurityValidator cookie) {
+
+        HttpSecurityValidator valuePipelineFor(String name) {
+            if (AUTHORIZATION_HEADER.equalsIgnoreCase(name)) {
+                return authorization;
+            }
+            if (COOKIE_HEADER.equalsIgnoreCase(name) || SET_COOKIE_HEADER.equalsIgnoreCase(name)) {
+                return cookie;
+            }
+            return pipelines.headerValuePipeline();
+        }
     }
 
     private static GatewayException rejected(UrlSecurityException violation) {

--- a/api-sheriff/src/main/resources/schema/gateway.schema.json
+++ b/api-sheriff/src/main/resources/schema/gateway.schema.json
@@ -129,7 +129,12 @@
       "additionalProperties": false,
       "description": "Global inbound-filter baseline. An omitted block — or a block without 'profile' — resolves the gateway-wide profile to 'strict'. 'none' is a partial disable: it turns off only the url-parameter name/value validation and the per-route pipeline re-run, and is refused at boot on effectively-authenticated and BFF routes (see ADR-0024).",
       "properties": {
-        "profile": { "type": "string", "enum": ["strict", "lenient", "none"] }
+        "profile": { "type": "string", "enum": ["strict", "lenient", "none"] },
+        "max_authorization_header_value_length": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Budget for the pre-route 'Authorization' header-value carve-out (ADR-0019). A bearer token plus the 'Bearer ' prefix routinely exceeds the resolved profile's header-value cap (~1028 characters against strict's 1024), which the non-skippable pre-route floor would otherwise reject 400 before route selection. Defaults to 8192 when omitted. Boot-refused when declared below the resolved baseline max_header_value_length, since that would make the carve-out a tightening in disguise."
+        }
       }
     },
     "allowed_methods": {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
@@ -668,7 +668,8 @@ class RouteTableBuilderTest {
         void shouldLogResolvedProfileForRouteOmittingTheKnob() {
             // Arrange — no security_filter anywhere, so the route inherits the gateway-wide profile
             GatewayConfig config = gateway()
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("lenient"))))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("lenient"),
+                            Optional.empty())))
                     .build();
             EndpointConfig endpoint = endpoint("orders", "ORDERS")
                     .routes(List.of(routeWithPrefix("orders-read", "/orders", HttpMethod.GET))).build();
@@ -700,7 +701,8 @@ class RouteTableBuilderTest {
         void shouldLogDeclaredRouteProfile() {
             // Arrange
             GatewayConfig config = gateway()
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("strict"))))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("strict"),
+                            Optional.empty())))
                     .build();
             RouteConfig declared = RouteConfig.builder().id("orders-read").match(match("/orders", HttpMethod.GET))
                     .securityFilter(Optional.of(filter("none"))).build();
@@ -1120,7 +1122,8 @@ class RouteTableBuilderTest {
         @DisplayName("Should resolve a declared security_defaults profile")
         void shouldResolveDeclaredGlobalProfile() {
             GatewayConfig config = gateway()
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("lenient"))))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("lenient"),
+                            Optional.empty())))
                     .build();
 
             assertEquals(SecurityProfile.LENIENT, RouteTableBuilder.globalProfile(config));
@@ -1136,7 +1139,7 @@ class RouteTableBuilderTest {
         @DisplayName("Should resolve a security_defaults block without a profile to the fail-closed default")
         void shouldResolveBlockWithoutProfileToDefault() {
             GatewayConfig config = gateway()
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.empty())))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.empty(), Optional.empty())))
                     .build();
 
             assertEquals(SecurityProfile.DEFAULT_PROFILE, RouteTableBuilder.globalProfile(config));

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
@@ -40,6 +40,7 @@ import de.cuioss.sheriff.gateway.config.model.HttpMethod;
 import de.cuioss.sheriff.gateway.config.model.IssuerConfig;
 import de.cuioss.sheriff.gateway.config.model.Protocol;
 import de.cuioss.sheriff.gateway.config.model.RouteConfig;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.UpstreamDefaultsConfig;
 
 import org.junit.jupiter.api.Test;
@@ -424,6 +425,80 @@ class ConfigLoaderTest {
                                 && error.pointer().contains("security_defaults")),
                 () -> "expected a schema violation naming the security_defaults key, got: "
                         + exception.errors());
+    }
+
+    /**
+     * The {@code max_authorization_header_value_length} value RANGE is owned by the bundled JSON
+     * Schema ({@code integer}, {@code minimum: 1}), so an out-of-range value is refused at bind time,
+     * before the configuration validator's cross-cutting baseline comparison ever runs.
+     */
+    @ParameterizedTest(name = "security_defaults.max_authorization_header_value_length ''{0}'' fails the boot")
+    @ValueSource(strings = {"0", "-1", "\"not-a-number\""})
+    void rejectsOutOfRangeAuthorizationHeaderValueLength(String value) throws Exception {
+        // Arrange
+        writeConfig("gateway.yaml", """
+                version: 1
+                security_defaults:
+                  profile: strict
+                  max_authorization_header_value_length: %s
+                """.formatted(value));
+
+        // Act
+        ConfigLoader loader = loader(Map.of());
+        ConfigLoadException exception = assertThrows(ConfigLoadException.class, loader::load);
+
+        // Assert
+        assertTrue(exception.errors().stream()
+                        .anyMatch(error -> "gateway.yaml".equals(error.file())
+                                && error.pointer().contains("security_defaults")),
+                () -> "expected a schema violation naming the security_defaults key, got: "
+                        + exception.errors());
+    }
+
+    /**
+     * The end-to-end proof that the snake-cased key binds to the record component without an explicit
+     * Jackson annotation — {@code ConfigLoader} binds under {@code PropertyNamingStrategies.SNAKE_CASE},
+     * so the mapping is by convention and would break silently if that strategy ever changed.
+     */
+    @Test
+    void bindsDeclaredAuthorizationHeaderValueLength() throws Exception {
+        // Arrange
+        writeConfig("gateway.yaml", """
+                version: 1
+                security_defaults:
+                  profile: strict
+                  max_authorization_header_value_length: 12000
+                """);
+
+        // Act
+        ConfigLoader.LoadedConfig loaded = loader(Map.of()).load();
+
+        // Assert
+        SecurityDefaultsConfig securityDefaults = loaded.gateway().securityDefaults().orElseThrow();
+        assertEquals(Optional.of(12000), securityDefaults.maxAuthorizationHeaderValueLength(),
+                "the snake_cased key binds to the record component with no explicit annotation");
+        assertEquals(12000, securityDefaults.effectiveMaxAuthorizationHeaderValueLength(),
+                "a declared budget is what the carve-out enforces");
+    }
+
+    @Test
+    void resolvesOmittedAuthorizationHeaderValueLengthToTheDefault() throws Exception {
+        // Arrange — the matched negative half: an omitted key must bind empty and resolve to the
+        // documented default rather than to zero or to a bind failure.
+        writeConfig("gateway.yaml", """
+                version: 1
+                security_defaults:
+                  profile: strict
+                """);
+
+        // Act
+        ConfigLoader.LoadedConfig loaded = loader(Map.of()).load();
+
+        // Assert
+        SecurityDefaultsConfig securityDefaults = loaded.gateway().securityDefaults().orElseThrow();
+        assertEquals(Optional.empty(), securityDefaults.maxAuthorizationHeaderValueLength());
+        assertEquals(SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH,
+                securityDefaults.effectiveMaxAuthorizationHeaderValueLength());
     }
 
     @ParameterizedTest(name = "anchor security_filter.profile ''{0}'' fails the boot")

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
@@ -87,7 +87,7 @@ class ConfigModelContractTest {
                 .metadata(Optional.of(new Metadata(Optional.of("2024-01"))))
                 .tls(Optional.of(tlsConfig()))
                 .securityHeaders(Optional.of(securityHeadersConfig()))
-                .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("strict"))))
+                .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(8192))))
                 .allowedMethods(List.of(HttpMethod.GET, HttpMethod.POST))
                 .anchors(Map.of("api", anchorConfig()))
                 .upstreamDefaults(Optional.of(UpstreamDefaultsConfig.defaults()))
@@ -284,9 +284,17 @@ class ConfigModelContractTest {
                                     List.of("Accept"), Optional.of(false)),
                             new SecurityHeadersConfig.Cors(Optional.of(false), List.of("b"), List.of("POST"),
                                     List.of("Authorization"), Optional.of(true))),
-                    voCase("SecurityDefaultsConfig", new SecurityDefaultsConfig(Optional.of("strict")),
-                            new SecurityDefaultsConfig(Optional.of("strict")),
-                            new SecurityDefaultsConfig(Optional.of("lenient"))),
+                    // Two cases so the record contract is proven to discriminate on BOTH components:
+                    // an unequal instance differing only in 'profile' would leave the newer
+                    // max_authorization_header_value_length component silently out of equals().
+                    voCase("SecurityDefaultsConfig (profile)",
+                            new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(8192)),
+                            new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(8192)),
+                            new SecurityDefaultsConfig(Optional.of("lenient"), Optional.of(8192))),
+                    voCase("SecurityDefaultsConfig (max_authorization_header_value_length)",
+                            new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(8192)),
+                            new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(8192)),
+                            new SecurityDefaultsConfig(Optional.of("strict"), Optional.of(4096))),
                     voCase("AnchorConfig", anchorConfig(), anchorConfig(),
                             AnchorConfig.builder().name("bff").pathPrefix("/bff").type(AnchorType.BFF)
                                     .access(AccessLevel.AUTHENTICATED).build()),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -508,8 +508,8 @@ class ConfigValidatorTest {
         @Test
         @DisplayName("Should accept a max_authorization_header_value_length at or above the resolved baseline")
         void shouldAcceptAuthorizationCapAtOrAboveBaseline() {
-            // Arrange — the matched positive half: 2048 clears the strict baseline, and the same
-            // value is the boundary case 'exactly at the baseline' under a 2048-capped comparison.
+            // Arrange — the matched positive half: 2048 clears the strict 1024 baseline, and 1024 is
+            // the boundary case 'exactly at the baseline', which is not below it and is not refused.
             GatewayConfig above = gatewayWithAuthorizationCap("strict", Optional.of(2048));
             GatewayConfig atBaseline = gatewayWithAuthorizationCap("strict", Optional.of(1024));
             EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -119,6 +119,16 @@ class ConfigValidatorTest {
         return RouteConfig.builder().id(id).match(match).build();
     }
 
+    /**
+     * A gateway declaring the given global {@code profile} and — when present — the
+     * {@code max_authorization_header_value_length} carve-out budget the boot rule bounds.
+     */
+    private static GatewayConfig gatewayWithAuthorizationCap(String profile, Optional<Integer> cap) {
+        return validGateway()
+                .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of(profile), cap)))
+                .build();
+    }
+
     private static GatewayConfig gatewayWithPassthrough(Map<String, String> passthroughSni) {
         return validGateway()
                 .tls(Optional.of(TlsConfig.builder().passthroughSni(passthroughSni).build()))
@@ -459,6 +469,78 @@ class ConfigValidatorTest {
             List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
 
             assertTrue(errors.isEmpty(), "A valid admission budget raises no violation, but got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should reject a max_authorization_header_value_length below the strict baseline")
+        void shouldRejectAuthorizationCapBelowStrictBaseline() {
+            // Arrange — strict resolves a 1024-character baseline; 512 would make the 'carve-out'
+            // a per-header tightening wearing a relaxation key's name.
+            GatewayConfig gateway = gatewayWithAuthorizationCap("strict", Optional.of(512));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            // Act
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            // Assert
+            assertHasError(errors, "/security_defaults/max_authorization_header_value_length",
+                    "is below the resolved baseline max_header_value_length");
+            assertEquals(1, errors.size(), () -> "expected exactly one violation, got: " + errors);
+        }
+
+        @Test
+        @DisplayName("Should reject a max_authorization_header_value_length below the lenient baseline")
+        void shouldRejectAuthorizationCapBelowLenientBaseline() {
+            // Arrange — the value that is legal under strict (2048 > 1024) is refused under lenient
+            // (2048 < 8192), which is what proves the rule compares against the RESOLVED profile
+            // rather than against a constant.
+            GatewayConfig gateway = gatewayWithAuthorizationCap("lenient", Optional.of(2048));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            // Act
+            List<ConfigError> errors = validator.validate(gateway, List.of(endpoint), topologyWith("ORDERS"));
+
+            // Assert
+            assertHasError(errors, "/security_defaults/max_authorization_header_value_length",
+                    "is below the resolved baseline max_header_value_length");
+        }
+
+        @Test
+        @DisplayName("Should accept a max_authorization_header_value_length at or above the resolved baseline")
+        void shouldAcceptAuthorizationCapAtOrAboveBaseline() {
+            // Arrange — the matched positive half: 2048 clears the strict baseline, and the same
+            // value is the boundary case 'exactly at the baseline' under a 2048-capped comparison.
+            GatewayConfig above = gatewayWithAuthorizationCap("strict", Optional.of(2048));
+            GatewayConfig atBaseline = gatewayWithAuthorizationCap("strict", Optional.of(1024));
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            // Act
+            List<ConfigError> aboveErrors = validator.validate(above, List.of(endpoint), topologyWith("ORDERS"));
+            List<ConfigError> atBaselineErrors =
+                    validator.validate(atBaseline, List.of(endpoint), topologyWith("ORDERS"));
+
+            // Assert
+            assertTrue(aboveErrors.isEmpty(), () -> "a raised cap raises no violation, but got: " + aboveErrors);
+            assertTrue(atBaselineErrors.isEmpty(),
+                    () -> "a cap exactly at the baseline is not below it, but got: " + atBaselineErrors);
+        }
+
+        @Test
+        @DisplayName("Should never refuse an omitted max_authorization_header_value_length")
+        void shouldAcceptOmittedAuthorizationCap() {
+            // Arrange — an omitted key resolves to the documented default and is never a violation,
+            // under either profile.
+            GatewayConfig strict = gatewayWithAuthorizationCap("strict", Optional.empty());
+            GatewayConfig lenient = gatewayWithAuthorizationCap("lenient", Optional.empty());
+            GatewayConfig blockAbsent = validGateway().build();
+            EndpointConfig endpoint = endpoint("orders", "ORDERS", List.of(), route("r", HttpMethod.GET));
+
+            // Act + Assert
+            assertAll("an omitted key never refuses",
+                    () -> assertTrue(validator.validate(strict, List.of(endpoint), topologyWith("ORDERS")).isEmpty()),
+                    () -> assertTrue(validator.validate(lenient, List.of(endpoint), topologyWith("ORDERS")).isEmpty()),
+                    () -> assertTrue(
+                            validator.validate(blockAbsent, List.of(endpoint), topologyWith("ORDERS")).isEmpty()));
         }
 
         @Test
@@ -1622,7 +1704,8 @@ class ConfigValidatorTest {
         private static GatewayConfig gatewayWithGlobalProfile(AnchorConfig anchorConfig, String globalProfile) {
             return validGateway()
                     .anchors(Map.of(anchorConfig.name(), anchorConfig))
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of(globalProfile))))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of(globalProfile),
+                            Optional.empty())))
                     .tokenValidation(Optional.of(new TokenValidationConfig(List.of(
                             IssuerConfig.builder().name("main").issuer("https://idp.example").build()))))
                     .build();
@@ -1721,7 +1804,8 @@ class ConfigValidatorTest {
             GatewayConfig gateway = validGateway()
                     .anchors(Map.of("open",
                             matrixAnchor("open", "/open", AnchorType.PROXY, AccessLevel.PUBLIC, null)))
-                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of(NONE_PROFILE))))
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of(NONE_PROFILE),
+                            Optional.empty())))
                     .build();
             EndpointConfig endpoint = anchoredEndpoint("public-api", "API", "open",
                     Optional.of(new AuthConfig(REQUIRE_NONE, List.of())),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
@@ -467,8 +467,12 @@ class GatewayEdgeRouteBffWiringTest {
                 .build();
     }
 
-    /** The server-mode seam over an in-memory store, standing in for whichever binding is in force. */
-    private static SessionBinding serverBinding(SessionStore store) {
+    /**
+     * The server-mode seam over an in-memory store, standing in for whichever binding is in force.
+     * Package-private so {@code GatewayEdgeRouteTest} can obtain an active runtime for the
+     * cookie-mode carve-out assertions without duplicating this assembly.
+     */
+    static SessionBinding serverBinding(SessionStore store) {
         return new ServerSessionBinding(store,
                 new SessionCookieCodec(SessionCookieCodec.DEFAULT_COOKIE_NAME, Duration.ofHours(1)));
     }
@@ -478,8 +482,12 @@ class GatewayEdgeRouteBffWiringTest {
      * handler is real, but the seams that would reach the confidential-client engine throw or no-op,
      * so the paths these tests drive (no-session, no-input, live-session short-circuit) never touch a
      * live IdP.
+     * <p>
+     * Package-private so {@code GatewayEdgeRouteTest} can assert the cookie-mode header carve-out —
+     * which is gated on {@link BffRuntime#isActive()} — against a real active runtime rather than
+     * duplicating this assembly.
      */
-    private static BffRuntime activeRuntime(SessionBinding binding) {
+    static BffRuntime activeRuntime(SessionBinding binding) {
         BindingCookieCodec bindingCodec = new BindingCookieCodec(PendingAuthorizationRecord.FIXED_TTL);
         PendingAuthorizationStore pendingStore = new PendingAuthorizationStore.InMemory(16);
         Duration ttl = Duration.ofHours(1);

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -20,11 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.RecordComponent;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
@@ -39,16 +42,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.sheriff.gateway.bff.cookie.SealedSessionCookieCodec;
 import de.cuioss.sheriff.gateway.bff.runtime.BffRuntime;
+import de.cuioss.sheriff.gateway.bff.session.InMemorySessionStore;
 import de.cuioss.sheriff.gateway.config.model.AuthConfig;
 import de.cuioss.sheriff.gateway.config.model.EdgeHardeningConfig;
 import de.cuioss.sheriff.gateway.config.model.GatewayConfig;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
 import de.cuioss.sheriff.gateway.config.model.MatchConfig;
+import de.cuioss.sheriff.gateway.config.model.OidcConfig;
 import de.cuioss.sheriff.gateway.config.model.Protocol;
 import de.cuioss.sheriff.gateway.config.model.ResolvedRoute;
 import de.cuioss.sheriff.gateway.config.model.ResolvedUpstream;
 import de.cuioss.sheriff.gateway.config.model.RouteTable;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityFilterConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
 import de.cuioss.sheriff.gateway.quarkus.SheriffMetrics;
@@ -523,6 +530,185 @@ class GatewayEdgeRouteTest {
             // Assert
             assertEquals(preset, resolved,
                     "seeding the builder from the %s preset must round-trip to that preset".formatted(profile));
+        }
+    }
+
+    /**
+     * The two pre-route header-value carve-outs the edge hands to {@code BasicChecksStage}. Both are
+     * asserted directly rather than through a booted edge, whose assembled stages are not observable.
+     * <p>
+     * The load-bearing assertion is that each carve-out differs from the <em>resolved baseline</em> in
+     * {@code maxHeaderValueLength} and in nothing else — ADR-0019's "only the length cap changes"
+     * bound. It was NOT true of the cookie carve-out before this change: seeding it from
+     * {@code SecurityConfiguration.builder()} silently also relaxed {@code failOnSuspiciousPatterns},
+     * {@code allowExtendedAscii} and {@code caseSensitiveComparison} on a strict gateway. The
+     * component sweep below is exhaustive and reflection-driven, so a future cui-http component is
+     * covered without editing this test.
+     */
+    @Nested
+    @DisplayName("pre-route header-value carve-outs (Authorization and Cookie)")
+    class HeaderCarveOutConfiguration {
+
+        private static final int DECLARED_AUTHORIZATION_CAP = 12_000;
+
+        @Test
+        @DisplayName("the Authorization carve-out differs from a strict baseline in the length cap alone")
+        void authorizationCarveOutSeededFromStrictBaseline() {
+            // Arrange — a bearer-only gateway declaring no security_defaults block at all
+            SecurityConfiguration baseline = SecurityConfiguration.strict();
+
+            // Act
+            SecurityConfiguration carveOut = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
+                    GatewayConfig.builder().version(1).build(), baseline);
+
+            // Assert
+            assertEquals(SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH,
+                    carveOut.maxHeaderValueLength(), "an omitted key resolves to the documented default");
+            assertNotEquals(baseline.maxHeaderValueLength(), carveOut.maxHeaderValueLength(),
+                    "the carve-out must actually raise the strict cap — otherwise it relaxes nothing");
+            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
+        }
+
+        @Test
+        @DisplayName("the Authorization carve-out differs from a lenient baseline in the length cap alone")
+        void authorizationCarveOutSeededFromLenientBaseline() {
+            // Arrange — a declared budget, so the cap genuinely differs from the lenient preset's own
+            SecurityConfiguration baseline = SecurityConfiguration.lenient();
+
+            // Act
+            SecurityConfiguration carveOut = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
+                    gatewayWithAuthorizationCap(Optional.of(DECLARED_AUTHORIZATION_CAP)), baseline);
+
+            // Assert
+            assertEquals(DECLARED_AUTHORIZATION_CAP, carveOut.maxHeaderValueLength());
+            assertNotEquals(baseline.maxHeaderValueLength(), carveOut.maxHeaderValueLength());
+            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
+        }
+
+        @Test
+        @DisplayName("the Authorization carve-out honours a declared max_authorization_header_value_length")
+        void authorizationCarveOutHonoursDeclaredBudget() {
+            // Arrange + Act
+            SecurityConfiguration carveOut = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
+                    gatewayWithAuthorizationCap(Optional.of(DECLARED_AUTHORIZATION_CAP)),
+                    SecurityConfiguration.strict());
+
+            // Assert
+            assertEquals(DECLARED_AUTHORIZATION_CAP, carveOut.maxHeaderValueLength(),
+                    "the operator-declared budget wins over the default");
+        }
+
+        @Test
+        @DisplayName("the Authorization carve-out falls back to the default when the key is omitted")
+        void authorizationCarveOutFallsBackToTheDefault() {
+            // Arrange — a security_defaults block that declares a profile but omits the budget key,
+            // which is a different shape from an entirely absent block and must resolve identically.
+
+            // Act
+            SecurityConfiguration blockPresent = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
+                    gatewayWithAuthorizationCap(Optional.empty()), SecurityConfiguration.strict());
+            SecurityConfiguration blockAbsent = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
+                    GatewayConfig.builder().version(1).build(), SecurityConfiguration.strict());
+
+            // Assert
+            assertEquals(SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH,
+                    blockPresent.maxHeaderValueLength(),
+                    "a declared block omitting the key resolves to the default");
+            assertEquals(blockAbsent, blockPresent,
+                    "an omitted key and an omitted block resolve to the same policy");
+        }
+
+        @Test
+        @DisplayName("the cookie carve-out is absent for a gateway that is not an active cookie-mode BFF")
+        void cookieCarveOutIsAbsentOutsideCookieMode() {
+            // Arrange — the two ways to miss the mode: no BFF runtime at all, and an active runtime
+            // whose session mode is not cookie.
+
+            // Act
+            SecurityConfiguration inertRuntime = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+                    cookieModeGateway(), BffRuntime.inert(), SecurityConfiguration.strict());
+            SecurityConfiguration serverMode = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+                    GatewayConfig.builder().version(1).build(), activeCookieRuntime(),
+                    SecurityConfiguration.strict());
+
+            // Assert
+            assertNull(inertRuntime, "a bearer-only gateway keeps the resolved baseline on every header");
+            assertNull(serverMode, "a non-cookie-mode gateway keeps the resolved baseline on every header");
+        }
+
+        @Test
+        @DisplayName("the cookie carve-out differs from a strict baseline in the length cap alone")
+        void cookieCarveOutSeededFromStrictBaseline() {
+            // Arrange — the regression this assertion exists for: on a strict gateway the cookie
+            // carve-out used to be built from the builder defaults, quietly relaxing three further
+            // validators the ADR promised were untouched.
+            SecurityConfiguration baseline = SecurityConfiguration.strict();
+
+            // Act
+            SecurityConfiguration carveOut = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+                    cookieModeGateway(), activeCookieRuntime(), baseline);
+
+            // Assert
+            assertNotNull(carveOut, "an active cookie-mode BFF gets a carve-out");
+            assertTrue(carveOut.maxHeaderValueLength() > SealedSessionCookieCodec.DEFAULT_COOKIE_VALUE_BUDGET,
+                    "the cap must admit the whole sealed-cookie budget plus the header overhead");
+            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
+        }
+
+        @Test
+        @DisplayName("the cookie carve-out differs from a lenient baseline in the length cap alone")
+        void cookieCarveOutSeededFromLenientBaseline() {
+            // Arrange
+            SecurityConfiguration baseline = SecurityConfiguration.lenient();
+
+            // Act
+            SecurityConfiguration carveOut = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+                    cookieModeGateway(), activeCookieRuntime(), baseline);
+
+            // Assert
+            assertNotNull(carveOut);
+            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
+        }
+
+        /**
+         * Exhaustive component sweep: every {@link SecurityConfiguration} record component except
+         * {@code maxHeaderValueLength} must carry the resolved baseline's value. Reflection rather
+         * than a hand-written list so a component added by a cui-http upgrade is covered here the
+         * moment it exists.
+         */
+        private void assertDiffersFromBaselineInCapAlone(SecurityConfiguration baseline,
+                SecurityConfiguration carveOut) {
+            for (RecordComponent component : SecurityConfiguration.class.getRecordComponents()) {
+                if ("maxHeaderValueLength".equals(component.getName())) {
+                    continue;
+                }
+                Object baselineValue = assertDoesNotThrow(() -> component.getAccessor().invoke(baseline));
+                Object carveOutValue = assertDoesNotThrow(() -> component.getAccessor().invoke(carveOut));
+                assertEquals(baselineValue, carveOutValue,
+                        "carve-out component '%s' must stay on the resolved baseline — only the length cap changes"
+                                .formatted(component.getName()));
+            }
+        }
+
+        private GatewayConfig gatewayWithAuthorizationCap(Optional<Integer> cap) {
+            return GatewayConfig.builder().version(1)
+                    .securityDefaults(Optional.of(new SecurityDefaultsConfig(Optional.of("strict"), cap)))
+                    .build();
+        }
+
+        private GatewayConfig cookieModeGateway() {
+            return GatewayConfig.builder().version(1)
+                    .oidc(Optional.of(OidcConfig.builder()
+                            .session(Optional.of(OidcConfig.Session.builder()
+                                    .mode(Optional.of(OidcConfig.Session.MODE_COOKIE))
+                                    .build()))
+                            .build()))
+                    .build();
+        }
+
+        private BffRuntime activeCookieRuntime() {
+            return GatewayEdgeRouteBffWiringTest.activeRuntime(
+                    GatewayEdgeRouteBffWiringTest.serverBinding(new InMemorySessionStore(16)));
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -624,19 +624,27 @@ class GatewayEdgeRouteTest {
         @Test
         @DisplayName("the cookie carve-out is absent for a gateway that is not an active cookie-mode BFF")
         void cookieCarveOutIsAbsentOutsideCookieMode() {
-            // Arrange — the two ways to miss the mode: no BFF runtime at all, and an active runtime
-            // whose session mode is not cookie.
+            // Arrange — the three ways to miss the mode: no BFF runtime at all, an active runtime on a
+            // gateway declaring no session block, and an active runtime whose declared mode is server.
+            // Only the last actually invokes isCookieMode(); the middle one is answered by orElse(false)
+            // before the predicate is reached, so on its own it leaves the defect-prone branch untested.
 
             // Act
             SecurityConfiguration inertRuntime = GatewayEdgeRoute.cookieHeaderConfigurationFor(
                     cookieModeGateway(), BffRuntime.inert(), SecurityConfiguration.strict());
-            SecurityConfiguration serverMode = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+            SecurityConfiguration sessionAbsent = GatewayEdgeRoute.cookieHeaderConfigurationFor(
                     GatewayConfig.builder().version(1).build(), activeCookieRuntime(),
+                    SecurityConfiguration.strict());
+            SecurityConfiguration serverMode = GatewayEdgeRoute.cookieHeaderConfigurationFor(
+                    sessionModeGateway(OidcConfig.Session.MODE_SERVER), activeCookieRuntime(),
                     SecurityConfiguration.strict());
 
             // Assert
             assertNull(inertRuntime, "a bearer-only gateway keeps the resolved baseline on every header");
-            assertNull(serverMode, "a non-cookie-mode gateway keeps the resolved baseline on every header");
+            assertNull(sessionAbsent,
+                    "a gateway declaring no session block keeps the resolved baseline on every header");
+            assertNull(serverMode,
+                    "an active server-mode BFF keeps the resolved baseline on every header");
         }
 
         @Test
@@ -713,10 +721,20 @@ class GatewayEdgeRouteTest {
         }
 
         private GatewayConfig cookieModeGateway() {
+            return sessionModeGateway(OidcConfig.Session.MODE_COOKIE);
+        }
+
+        /**
+         * A gateway declaring an {@code oidc.session} block at the given mode. Parameterised over the
+         * mode so a server-mode gateway can be built too: only a gateway that actually declares a
+         * session block reaches {@link OidcConfig.Session#isCookieMode()} at all — one without an
+         * {@code oidc} block is answered by the {@code orElse(false)} before the predicate is invoked.
+         */
+        private GatewayConfig sessionModeGateway(String mode) {
             return GatewayConfig.builder().version(1)
                     .oidc(Optional.of(OidcConfig.builder()
                             .session(Optional.of(OidcConfig.Session.builder()
-                                    .mode(Optional.of(OidcConfig.Session.MODE_COOKIE))
+                                    .mode(Optional.of(mode))
                                     .build()))
                             .build()))
                     .build();

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -544,12 +544,27 @@ class GatewayEdgeRouteTest {
      * {@code allowExtendedAscii} and {@code caseSensitiveComparison} on a strict gateway. The
      * component sweep below is exhaustive and reflection-driven, so a future cui-http component is
      * covered without editing this test.
+     * <p>
+     * The cookie tests are a matched control pair over ADR-0019's second bound — the DIRECTION of
+     * change is admit-more-length-only. The strict baseline is the positive control (the cap is
+     * genuinely raised, so the {@code max} did not neutralise the carve-out); the lenient baseline is
+     * the regression control (the cap must stay at the higher baseline rather than dropping to the
+     * smaller cookie budget). Each carries an explicit precondition assertion, so neither can pass
+     * vacuously if a preset's cap moves relative to the shipped default budget.
      */
     @Nested
     @DisplayName("pre-route header-value carve-outs (Authorization and Cookie)")
     class HeaderCarveOutConfiguration {
 
         private static final int DECLARED_AUTHORIZATION_CAP = 12_000;
+
+        /** Mirrors the private {@code GatewayEdgeRoute.COOKIE_HEADER_OVERHEAD_BYTES}. */
+        private static final int COOKIE_HEADER_OVERHEAD_BYTES = 512;
+
+        /** The cap the shipped-default cookie budget derives — 4608, deliberately compared against
+         * BOTH baselines below so the max() bound is pinned from above and from below. */
+        private static final int DEFAULT_COOKIE_HEADER_CAP =
+                SealedSessionCookieCodec.DEFAULT_COOKIE_VALUE_BUDGET + COOKIE_HEADER_OVERHEAD_BYTES;
 
         @Test
         @DisplayName("the Authorization carve-out differs from a strict baseline in the length cap alone")
@@ -625,28 +640,35 @@ class GatewayEdgeRouteTest {
         }
 
         @Test
-        @DisplayName("the cookie carve-out differs from a strict baseline in the length cap alone")
-        void cookieCarveOutSeededFromStrictBaseline() {
-            // Arrange — the regression this assertion exists for: on a strict gateway the cookie
-            // carve-out used to be built from the builder defaults, quietly relaxing three further
-            // validators the ADR promised were untouched.
+        @DisplayName("the cookie carve-out RAISES a strict baseline to the budget plus the header overhead")
+        void cookieCarveOutRaisesAStrictBaseline() {
+            // Arrange — the positive half of the max()-bound control pair, and the regression this
+            // assertion originally existed for: on a strict gateway the cookie carve-out used to be
+            // built from the builder defaults, quietly relaxing three further validators the ADR
+            // promised were untouched.
             SecurityConfiguration baseline = SecurityConfiguration.strict();
 
             // Act
             SecurityConfiguration carveOut = GatewayEdgeRoute.cookieHeaderConfigurationFor(
                     cookieModeGateway(), activeCookieRuntime(), baseline);
 
-            // Assert
+            // Assert — the max() must not neutralise the carve-out where it is genuinely needed
             assertNotNull(carveOut, "an active cookie-mode BFF gets a carve-out");
-            assertTrue(carveOut.maxHeaderValueLength() > SealedSessionCookieCodec.DEFAULT_COOKIE_VALUE_BUDGET,
+            assertTrue(baseline.maxHeaderValueLength() < DEFAULT_COOKIE_HEADER_CAP,
+                    "control precondition: the strict baseline must sit BELOW the default cookie cap");
+            assertEquals(DEFAULT_COOKIE_HEADER_CAP, carveOut.maxHeaderValueLength(),
                     "the cap must admit the whole sealed-cookie budget plus the header overhead");
             assertDiffersFromBaselineInCapAlone(baseline, carveOut);
         }
 
         @Test
-        @DisplayName("the cookie carve-out differs from a lenient baseline in the length cap alone")
-        void cookieCarveOutSeededFromLenientBaseline() {
-            // Arrange
+        @DisplayName("the cookie carve-out never LOWERS a lenient baseline to the smaller cookie budget")
+        void cookieCarveOutNeverLowersALenientBaseline() {
+            // Arrange — the regression half of the control pair. The shipped DEFAULT budget (4096)
+            // plus the 512-byte overhead is 4608, which sits BELOW the lenient preset's 8192 baseline,
+            // so setting the cap outright turned this carve-out into a per-header TIGHTENING: a
+            // cookie-mode BFF on a lenient gateway rejected 400 every Cookie value between 4609 and
+            // 8192 while admitting every other header to 8192. No misconfiguration required.
             SecurityConfiguration baseline = SecurityConfiguration.lenient();
 
             // Act
@@ -655,7 +677,13 @@ class GatewayEdgeRouteTest {
 
             // Assert
             assertNotNull(carveOut);
-            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
+            assertTrue(baseline.maxHeaderValueLength() > DEFAULT_COOKIE_HEADER_CAP,
+                    "control precondition: the lenient baseline must sit ABOVE the default cookie cap, "
+                            + "otherwise this test cannot observe a lowering");
+            assertEquals(baseline.maxHeaderValueLength(), carveOut.maxHeaderValueLength(),
+                    "a carve-out may only ever ADMIT MORE length — it must keep the higher baseline cap");
+            assertEquals(baseline, carveOut,
+                    "with the cap already sufficient the carve-out policy is the baseline itself");
         }
 
         /**

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -580,22 +580,10 @@ class GatewayEdgeRouteTest {
                     gatewayWithAuthorizationCap(Optional.of(DECLARED_AUTHORIZATION_CAP)), baseline);
 
             // Assert
-            assertEquals(DECLARED_AUTHORIZATION_CAP, carveOut.maxHeaderValueLength());
-            assertNotEquals(baseline.maxHeaderValueLength(), carveOut.maxHeaderValueLength());
-            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
-        }
-
-        @Test
-        @DisplayName("the Authorization carve-out honours a declared max_authorization_header_value_length")
-        void authorizationCarveOutHonoursDeclaredBudget() {
-            // Arrange + Act
-            SecurityConfiguration carveOut = GatewayEdgeRoute.authorizationHeaderConfigurationFor(
-                    gatewayWithAuthorizationCap(Optional.of(DECLARED_AUTHORIZATION_CAP)),
-                    SecurityConfiguration.strict());
-
-            // Assert
             assertEquals(DECLARED_AUTHORIZATION_CAP, carveOut.maxHeaderValueLength(),
                     "the operator-declared budget wins over the default");
+            assertNotEquals(baseline.maxHeaderValueLength(), carveOut.maxHeaderValueLength());
+            assertDiffersFromBaselineInCapAlone(baseline, carveOut);
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
@@ -32,6 +32,7 @@ import de.cuioss.http.security.database.AttackTestCase;
 import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
+import de.cuioss.sheriff.gateway.config.model.SecurityConfigurations;
 import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.events.EventType;
 import de.cuioss.sheriff.gateway.events.GatewayException;
@@ -408,20 +409,11 @@ class BasicChecksStageTest {
 
     /**
      * Mirrors the production seeding: a configuration identical to {@code baseline} in every
-     * dimension except {@code maxHeaderValueLength}. Building the carve-out from
-     * {@code SecurityConfiguration.builder()} instead is the defect this suite guards against, so
-     * the fixtures must not take that shortcut either.
+     * dimension except {@code maxHeaderValueLength}. Routed through the shared production seam so the
+     * fixture cannot drift from the component set the production carve-outs copy.
      */
     private static SecurityConfiguration withHeaderValueCap(SecurityConfiguration baseline, int cap) {
-        return new SecurityConfiguration(baseline.maxPathLength(), baseline.allowDoubleEncoding(),
-                baseline.maxParameterNameLength(), baseline.maxParameterValueLength(),
-                baseline.maxHeaderNameLength(), cap, baseline.maxCookieNameLength(),
-                baseline.maxCookieValueLength(), baseline.maxBodySize(), baseline.allowNullBytes(),
-                baseline.allowControlCharacters(), baseline.allowExtendedAscii(), baseline.normalizeUnicode(),
-                baseline.caseSensitiveComparison(), baseline.failOnSuspiciousPatterns(),
-                baseline.requireSecureCookies(), baseline.requireHttpOnlyCookies(), baseline.maxParameterCount(),
-                baseline.maxHeaderCount(), baseline.maxCookieCount(), baseline.allowedHeaderNames(),
-                baseline.blockedHeaderNames(), baseline.allowedContentTypes(), baseline.blockedContentTypes());
+        return SecurityConfigurations.builderSeededFrom(baseline).maxHeaderValueLength(cap).build();
     }
 
     private static PipelineRequest requestWithHeader(String name, String value) {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
@@ -32,17 +32,25 @@ import de.cuioss.http.security.database.AttackTestCase;
 import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.events.EventType;
 import de.cuioss.sheriff.gateway.events.GatewayException;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Contract of the non-skippable pre-route floor: collection caps, the URL path pipeline that
- * produces the canonical path, and header name/value validation.
+ * produces the canonical path, and header name/value validation including both header-name
+ * carve-outs.
+ * <p>
+ * Every stage is exercised against BOTH the {@code strict} baseline — what an undeclared deployment
+ * actually resolves to, and the baseline under which the {@code Authorization} regression appeared —
+ * and the looser {@code defaults()} preset. Asserting only against {@code defaults()} is precisely
+ * what let a strict-baseline regression stay invisible to this suite.
  * <p>
  * Query-parameter NAME and VALUE validation is deliberately absent here — it moved to the post-route
  * {@code ThoroughChecksStage}, where it runs under the route's own configuration and behind the
@@ -60,14 +68,24 @@ class BasicChecksStageTest {
      */
     private static final int COOKIE_HEADER_CAP = 4096 + 512;
 
+    /** The {@code Authorization} carve-out budget, as an omitted configuration key resolves it. */
+    private static final int AUTHORIZATION_CAP =
+            SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH;
+
+    private static final SecurityConfiguration STRICT = SecurityConfiguration.strict();
+    private static final SecurityConfiguration DEFAULTS = SecurityConfiguration.defaults();
+
+    /** An extended-ASCII character: admitted by the builder defaults, refused by {@code strict}. */
+    private static final String EXTENDED_ASCII = "é";
+
     private final SecurityEventCounter counter = new SecurityEventCounter();
-    private final BasicChecksStage strictStage =
-            new BasicChecksStage(SecurityConfiguration.strict(), counter, null);
-    private final BasicChecksStage defaultStage =
-            new BasicChecksStage(SecurityConfiguration.defaults(), counter, null);
+
+    private final BasicChecksStage strictStage = stageWithoutCookieCarveOut(STRICT);
+    private final BasicChecksStage defaultStage = stageWithoutCookieCarveOut(DEFAULTS);
     /** A cookie-mode gateway's stage: the raised cap applies to Cookie header values only. */
-    private final BasicChecksStage cookieModeStage = new BasicChecksStage(SecurityConfiguration.defaults(), counter,
-            SecurityConfiguration.builder().maxHeaderValueLength(COOKIE_HEADER_CAP).build());
+    private final BasicChecksStage cookieModeStage = stageWithCookieCarveOut(DEFAULTS);
+    /** The same cookie-mode gateway on the strict baseline every undeclared deployment resolves to. */
+    private final BasicChecksStage strictCookieModeStage = stageWithCookieCarveOut(STRICT);
 
     static Stream<AttackTestCase> owaspTop10() {
         return StreamSupport.stream(new OWASPTop10AttackDatabase().getAttackTestCases().spliterator(), false);
@@ -123,7 +141,7 @@ class BasicChecksStageTest {
     void rejectsExcessiveParameterCount() {
         // Arrange — the parameter COUNT cap stays in the floor even though the values it bounds are
         // validated post-route: a collection limit is a resource guard, not an injection defence.
-        int cap = SecurityConfiguration.defaults().maxParameterCount();
+        int cap = DEFAULTS.maxParameterCount();
         Map<String, List<String>> parameters = new LinkedHashMap<>();
         for (int i = 0; i <= cap; i++) {
             parameters.put("p" + i, List.of("1"));
@@ -145,7 +163,7 @@ class BasicChecksStageTest {
     @DisplayName("rejects a header count beyond the configured cap")
     void rejectsExcessiveHeaderCount() {
         // Arrange
-        int cap = SecurityConfiguration.defaults().maxHeaderCount();
+        int cap = DEFAULTS.maxHeaderCount();
         Map<String, List<String>> headers = new LinkedHashMap<>();
         for (int i = 0; i <= cap; i++) {
             headers.put("x-h" + i, List.of("v"));
@@ -163,57 +181,256 @@ class BasicChecksStageTest {
         assertEquals(EventType.PARAMETER_LIMIT_EXCEEDED, thrown.getEventType());
     }
 
-    @Test
-    @DisplayName("cookie mode: accepts a Cookie header value at the configured sealed-cookie budget")
-    void cookieModeAcceptsCookieHeaderAtBudget() {
-        // Arrange — the pre-route cap must admit the largest Cookie header a compliant sealed
-        // session can produce; before the fix this was rejected 400 at 2048 characters.
-        PipelineRequest request = requestWithHeader("Cookie", "__Host-sheriff-session=" + "a".repeat(4096));
+    @Nested
+    @DisplayName("Cookie / Set-Cookie carve-out")
+    class CookieCarveOut {
 
-        // Act + Assert
-        assertDoesNotThrow(() -> cookieModeStage.process(request));
+        @Test
+        @DisplayName("accepts a Cookie header value at the configured sealed-cookie budget")
+        void acceptsCookieHeaderAtBudget() {
+            // Arrange — the pre-route cap must admit the largest Cookie header a compliant sealed
+            // session can produce; before the fix this was rejected 400 at the baseline cap.
+            PipelineRequest request = requestWithHeader("Cookie", "__Host-sheriff-session=" + "a".repeat(4096));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> cookieModeStage.process(request));
+        }
+
+        @Test
+        @DisplayName("strict baseline: accepts a Cookie header value at the configured budget")
+        void strictBaselineAcceptsCookieHeaderAtBudget() {
+            // Arrange — the strict-baseline peer: the carve-out must clear the 1024 strict cap too,
+            // not merely the looser preset the suite used to measure against.
+            PipelineRequest request = requestWithHeader("Cookie", "__Host-sheriff-session=" + "a".repeat(4096));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> strictCookieModeStage.process(request));
+        }
+
+        @Test
+        @DisplayName("still rejects a Cookie header value beyond the raised cap")
+        void rejectsCookieHeaderBeyondCap() {
+            // Arrange — the relaxation raises the cap, it does not remove it.
+            PipelineRequest request = requestWithHeader("Cookie", "a".repeat(COOKIE_HEADER_CAP + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> cookieModeStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("strict baseline: still rejects a Cookie header value beyond the raised cap")
+        void strictBaselineRejectsCookieHeaderBeyondCap() {
+            // Arrange
+            PipelineRequest request = requestWithHeader("Cookie", "a".repeat(COOKIE_HEADER_CAP + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictCookieModeStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("an oversized NON-cookie header is still rejected at the baseline cap")
+        void rejectsOversizedNonCookieHeader() {
+            // Arrange — the carve-out is scoped to the Cookie header; every other header keeps the
+            // resolved baseline cap.
+            PipelineRequest request = requestWithHeader("X-Custom", "a".repeat(DEFAULTS.maxHeaderValueLength() + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> cookieModeStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("strict baseline: an oversized NON-cookie header is still rejected at the baseline cap")
+        void strictBaselineRejectsOversizedNonCookieHeader() {
+            // Arrange
+            PipelineRequest request = requestWithHeader("X-Custom", "a".repeat(STRICT.maxHeaderValueLength() + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictCookieModeStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("server / bearer-only mode: an oversized Cookie header is still rejected at the baseline cap")
+        void nonCookieModeRejectsOversizedCookieHeader() {
+            // Arrange — proves the lift did not leak across modes: a gateway that is not a
+            // cookie-mode BFF keeps the baseline cap on the Cookie header exactly as before.
+            PipelineRequest request = requestWithHeader("Cookie", "a".repeat(DEFAULTS.maxHeaderValueLength() + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> defaultStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("strict baseline, bearer-only mode: an oversized Cookie header is still rejected")
+        void strictBaselineNonCookieModeRejectsOversizedCookieHeader() {
+            // Arrange
+            PipelineRequest request = requestWithHeader("Cookie", "a".repeat(STRICT.maxHeaderValueLength() + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> strictStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
     }
 
-    @Test
-    @DisplayName("cookie mode: still rejects a Cookie header value beyond the raised cap")
-    void cookieModeRejectsCookieHeaderBeyondCap() {
-        // Arrange — the relaxation raises the cap, it does not remove it.
-        PipelineRequest request = requestWithHeader("Cookie", "a".repeat(COOKIE_HEADER_CAP + 1));
+    @Nested
+    @DisplayName("Authorization carve-out")
+    class AuthorizationCarveOut {
 
-        // Act
-        GatewayException thrown = assertThrows(GatewayException.class, () -> cookieModeStage.process(request));
+        @Test
+        @DisplayName("admits a bearer token above the strict baseline cap and within the configured cap")
+        void admitsBearerTokenAboveBaselineCap() {
+            // Arrange — the regression itself: a real access token plus the 'Bearer ' prefix lands
+            // above the strict 1024 cap, which rejected every bearer request 400 at this floor.
+            String value = "Bearer " + "a".repeat(2000);
+            PipelineRequest request = requestWithHeader("Authorization", value);
 
-        // Assert
-        assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+            // Act + Assert
+            assertDoesNotThrow(() -> strictStage.process(request),
+                    "an Authorization value within the carve-out budget must clear the pre-route floor");
+        }
+
+        @Test
+        @DisplayName("still rejects an Authorization value beyond the configured cap")
+        void rejectsAuthorizationBeyondConfiguredCap() {
+            // Arrange — the carve-out raises the cap, it does not remove it.
+            PipelineRequest request = requestWithHeader("Authorization", "a".repeat(AUTHORIZATION_CAP + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> strictStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("matches the header name case-insensitively, as HTTP requires")
+        void matchesHeaderNameCaseInsensitively() {
+            // Arrange — inbound header names arrive in whatever case the client sent.
+            PipelineRequest request = requestWithHeader("authorization", "Bearer " + "a".repeat(2000));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> strictStage.process(request));
+        }
+
+        @Test
+        @DisplayName("an oversized header that is neither Authorization nor a cookie keeps the baseline cap")
+        void doesNotLeakToOtherHeaders() {
+            // Arrange — the carve-out is scoped by header name and must not widen the floor.
+            PipelineRequest request = requestWithHeader("X-Custom", "a".repeat(STRICT.maxHeaderValueLength() + 1));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> strictStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("is present on a bearer-only gateway — the carve-out has no mode axis")
+        void isPresentWithoutACookieCarveOut() {
+            // Arrange — unlike the cookie carve-out there is no mode that switches this one off;
+            // strictStage is built with NO cookie configuration at all.
+            PipelineRequest request = requestWithHeader("Authorization", "Bearer " + "a".repeat(2000));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> strictStage.process(request));
+        }
     }
 
-    @Test
-    @DisplayName("cookie mode: an oversized NON-cookie header is still rejected at the default cap")
-    void cookieModeRejectsOversizedNonCookieHeader() {
-        // Arrange — the carve-out is scoped to the Cookie header; every other header keeps 2048.
-        int defaultCap = SecurityConfiguration.defaults().maxHeaderValueLength();
-        PipelineRequest request = requestWithHeader("X-Custom", "a".repeat(defaultCap + 1));
+    @Nested
+    @DisplayName("Carve-out validator inheritance — only the length cap changes")
+    class CarveOutValidatorInheritance {
 
-        // Act
-        GatewayException thrown = assertThrows(GatewayException.class, () -> cookieModeStage.process(request));
+        @Test
+        @DisplayName("an Authorization value within the cap is still refused for an extended-ASCII character")
+        void authorizationValueStillRefusesExtendedAscii() {
+            // Arrange — the ADR-0019 'only the length cap changes' bound: the carve-out pipeline
+            // applies every NON-length validator of the baseline it was seeded from. A carve-out
+            // seeded from the builder defaults instead would admit this value, because the builder
+            // defaults permit extended ASCII while strict does not.
+            PipelineRequest request = requestWithHeader("Authorization", "Bearer " + EXTENDED_ASCII + "token");
 
-        // Assert
-        assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class, () -> strictStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("a Cookie value within the cap is still refused for an extended-ASCII character")
+        void cookieValueStillRefusesExtendedAscii() {
+            // Arrange — the same bound for the cookie carve-out, which is where it was actually
+            // broken: builder-default seeding silently relaxed extended-ASCII, suspicious-pattern
+            // and case-sensitivity handling for cookie header values on a strict gateway.
+            PipelineRequest request = requestWithHeader("Cookie",
+                    "__Host-sheriff-session=" + EXTENDED_ASCII + "value");
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictCookieModeStage.process(request));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("the same extended-ASCII value is admitted under a baseline that permits it")
+        void extendedAsciiIsAdmittedUnderAPermissiveBaseline() {
+            // Arrange — the matched control: without it the two refusals above could not distinguish
+            // 'the carve-out inherited the strict baseline' from 'the value is refused regardless'.
+            PipelineRequest request = requestWithHeader("Authorization", "Bearer " + EXTENDED_ASCII + "token");
+
+            // Act + Assert
+            assertDoesNotThrow(() -> defaultStage.process(request),
+                    "the builder-default baseline permits extended ASCII, so the refusal above is "
+                            + "attributable to the strict seeding and not to the value itself");
+        }
     }
 
-    @Test
-    @DisplayName("server / bearer-only mode: an oversized Cookie header is still rejected at the default cap")
-    void nonCookieModeRejectsOversizedCookieHeader() {
-        // Arrange — proves the lift did not leak across modes: a gateway that is not a cookie-mode
-        // BFF keeps the 2048 default on the Cookie header exactly as before.
-        int defaultCap = SecurityConfiguration.defaults().maxHeaderValueLength();
-        PipelineRequest request = requestWithHeader("Cookie", "a".repeat(defaultCap + 1));
+    private BasicChecksStage stageWithoutCookieCarveOut(SecurityConfiguration baseline) {
+        return new BasicChecksStage(baseline, counter, null, withHeaderValueCap(baseline, AUTHORIZATION_CAP));
+    }
 
-        // Act
-        GatewayException thrown = assertThrows(GatewayException.class, () -> defaultStage.process(request));
+    private BasicChecksStage stageWithCookieCarveOut(SecurityConfiguration baseline) {
+        return new BasicChecksStage(baseline, counter, withHeaderValueCap(baseline, COOKIE_HEADER_CAP),
+                withHeaderValueCap(baseline, AUTHORIZATION_CAP));
+    }
 
-        // Assert
-        assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+    /**
+     * Mirrors the production seeding: a configuration identical to {@code baseline} in every
+     * dimension except {@code maxHeaderValueLength}. Building the carve-out from
+     * {@code SecurityConfiguration.builder()} instead is the defect this suite guards against, so
+     * the fixtures must not take that shortcut either.
+     */
+    private static SecurityConfiguration withHeaderValueCap(SecurityConfiguration baseline, int cap) {
+        return new SecurityConfiguration(baseline.maxPathLength(), baseline.allowDoubleEncoding(),
+                baseline.maxParameterNameLength(), baseline.maxParameterValueLength(),
+                baseline.maxHeaderNameLength(), cap, baseline.maxCookieNameLength(),
+                baseline.maxCookieValueLength(), baseline.maxBodySize(), baseline.allowNullBytes(),
+                baseline.allowControlCharacters(), baseline.allowExtendedAscii(), baseline.normalizeUnicode(),
+                baseline.caseSensitiveComparison(), baseline.failOnSuspiciousPatterns(),
+                baseline.requireSecureCookies(), baseline.requireHttpOnlyCookies(), baseline.maxParameterCount(),
+                baseline.maxHeaderCount(), baseline.maxCookieCount(), baseline.allowedHeaderNames(),
+                baseline.blockedHeaderNames(), baseline.allowedContentTypes(), baseline.blockedContentTypes());
     }
 
     private static PipelineRequest requestWithHeader(String name, String value) {

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
@@ -299,6 +299,8 @@ class BasicChecksStageTest {
         void admitsBearerTokenAboveBaselineCap() {
             // Arrange — the regression itself: a real access token plus the 'Bearer ' prefix lands
             // above the strict 1024 cap, which rejected every bearer request 400 at this floor.
+            // strictStage carries NO cookie configuration, so this doubles as the proof that the
+            // Authorization carve-out has no mode axis: it is present on a bearer-only gateway.
             String value = "Bearer " + "a".repeat(2000);
             PipelineRequest request = requestWithHeader("Authorization", value);
 
@@ -341,17 +343,6 @@ class BasicChecksStageTest {
 
             // Assert
             assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
-        }
-
-        @Test
-        @DisplayName("is present on a bearer-only gateway — the carve-out has no mode axis")
-        void isPresentWithoutACookieCarveOut() {
-            // Arrange — unlike the cookie carve-out there is no mode that switches this one off;
-            // strictStage is built with NO cookie configuration at all.
-            PipelineRequest request = requestWithHeader("Authorization", "Bearer " + "a".repeat(2000));
-
-            // Act + Assert
-            assertDoesNotThrow(() -> strictStage.process(request));
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
@@ -17,9 +17,11 @@ package de.cuioss.sheriff.gateway.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.RecordComponent;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,18 +35,22 @@ import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
 import de.cuioss.sheriff.gateway.config.model.MatchConfig;
+import de.cuioss.sheriff.gateway.config.model.SecurityConfigurations;
+import de.cuioss.sheriff.gateway.config.model.SecurityDefaultsConfig;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
 import de.cuioss.sheriff.gateway.events.EventType;
 import de.cuioss.sheriff.gateway.events.GatewayException;
 import de.cuioss.sheriff.gateway.routing.RouteMatcher;
 import de.cuioss.sheriff.gateway.routing.RouteRuntime;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("ThoroughChecksStage — stage 3, always dispatched, with a profile-gated skippable half")
 class ThoroughChecksStageTest {
@@ -54,9 +60,16 @@ class ThoroughChecksStageTest {
     /** A parameter name the url-parameter pipeline rejects (an embedded null byte). */
     private static final String REJECTED_PARAMETER_NAME = "evil\0name";
 
+    /** The {@code Authorization} carve-out budget, as an omitted configuration key resolves it. */
+    private static final int AUTHORIZATION_CAP =
+            SecurityDefaultsConfig.DEFAULT_MAX_AUTHORIZATION_HEADER_VALUE_LENGTH;
+
+    /** A cookie-mode gateway's sealed-cookie budget plus the header overhead the edge adds. */
+    private static final int COOKIE_HEADER_CAP = 4096 + 512;
+
     private final SecurityConfiguration defaultConfiguration = SecurityConfiguration.defaults();
     private final SecurityEventCounter counter = new SecurityEventCounter();
-    private final ThoroughChecksStage stage = new ThoroughChecksStage(defaultConfiguration, counter);
+    private final ThoroughChecksStage stage = stageWith(defaultConfiguration, null);
 
     static Stream<AttackTestCase> owaspTop10() {
         return StreamSupport.stream(new OWASPTop10AttackDatabase().getAttackTestCases().spliterator(), false);
@@ -407,8 +420,8 @@ class ThoroughChecksStageTest {
             // Arrange — a stage whose BASELINE itself refuses the name, and a route carrying exactly
             // that baseline: the skip-if-equal guard must leave the name to the pre-route stage.
             SecurityConfiguration baseline = stricterHeaderNamePolicy();
-            ThoroughChecksStage baselineEqualStage =
-                    new ThoroughChecksStage(baseline, new SecurityEventCounter());
+            ThoroughChecksStage baselineEqualStage = new ThoroughChecksStage(baseline,
+                    new SecurityEventCounter(), null, withHeaderValueCap(baseline, AUTHORIZATION_CAP));
             PipelineRequest request = requestWithHeaders(
                     Map.of(OVERLONG_HEADER_NAME, List.of("abc123")),
                     route(SecurityProfile.STRICT, Optional.of(baseline)));
@@ -421,6 +434,274 @@ class ThoroughChecksStageTest {
         private static SecurityConfiguration stricterHeaderNamePolicy() {
             return SecurityConfiguration.builder().maxHeaderNameLength(8).build();
         }
+    }
+
+    /**
+     * The post-route half of the two header-value carve-outs (finding 5a573e). The pre-route floor
+     * grants {@code Authorization} and {@code Cookie} / {@code Set-Cookie} a raised length cap; this
+     * stage re-validates every header value under the ROUTE's configuration whenever that
+     * configuration diverges from the baseline, and used to do so with no carve-out at all — silently
+     * undoing both relaxations one stage later, and doing it BEFORE the authentication stage, so an
+     * {@code Authorization} value was still present to be rejected.
+     * <p>
+     * The whole suite runs on the {@code strict} baseline every undeclared deployment resolves to,
+     * because that is the baseline under which the regression appears.
+     */
+    @Nested
+    @DisplayName("post-route header-value carve-outs")
+    class PostRouteHeaderCarveOuts {
+
+        /** The strict gateway baseline: a 1024-character header-value cap. */
+        private final SecurityConfiguration strictBaseline = SecurityConfiguration.strict();
+
+        /**
+         * The auditor's exact route shape and the {@code /upload} anchor's shape in the integration
+         * topology: a route declaring <em>nothing but</em> a raised {@code max_body_bytes}. It leaves
+         * the header-value cap on the strict baseline, yet diverges from that baseline — which is
+         * precisely what arms the re-run.
+         */
+        private final SecurityConfiguration raisedBodyRoute = SecurityConfigurations
+                .builderSeededFrom(strictBaseline)
+                .maxBodySize(64L * 1024 * 1024)
+                .build();
+
+        /** A route that legitimately RAISES its own header-value cap above the carve-out budget. */
+        private final SecurityConfiguration raisedHeaderCapRoute = SecurityConfigurations
+                .builderSeededFrom(strictBaseline)
+                .maxHeaderValueLength(AUTHORIZATION_CAP * 2)
+                .build();
+
+        /** 1107 characters — the value the audit measured, above the strict 1024 cap. */
+        private final String longBearer = "Bearer " + "a".repeat(1100);
+
+        /** A bearer-only strict gateway: the Authorization carve-out only, no cookie carve-out. */
+        private final ThoroughChecksStage strictStage = stageWith(strictBaseline, null);
+
+        /** An active cookie-mode BFF on the same strict baseline. */
+        private final ThoroughChecksStage cookieModeStage =
+                stageWith(strictBaseline, withHeaderValueCap(strictBaseline, COOKIE_HEADER_CAP));
+
+        @Test
+        @DisplayName("admits a >1024-character Authorization value on a route declaring only a raised max_body_bytes")
+        void admitsLongAuthorizationOnBodyCapOnlyRoute() {
+            // Arrange — the empirically confirmed regression: this exact request was rejected 400
+            // with SECURITY_FILTER_VIOLATION here, one stage before bearer validation ever ran.
+            assertTrue(longBearer.length() > strictBaseline.maxHeaderValueLength(),
+                    "the value must exceed the strict cap, otherwise the case proves nothing");
+            assertNotEquals(strictBaseline, raisedBodyRoute,
+                    "the route must diverge from the baseline, otherwise the re-run is skipped");
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Authorization", List.of(longBearer)),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> strictStage.process(request, List.of()),
+                    "the pre-route Authorization carve-out must survive the divergent-route re-run");
+        }
+
+        @Test
+        @DisplayName("without the carve-out budget the same request is rejected — the pre-fix behaviour")
+        void rejectsLongAuthorizationWhenNoCarveOutBudgetExists() {
+            // Arrange — the matched negative control pinning what the fix changed: a stage whose
+            // Authorization budget does not exceed the route's own cap has no carve-out to apply, so
+            // the re-run measures the value at the route cap exactly as the unfixed stage did.
+            ThoroughChecksStage withoutCarveOut = new ThoroughChecksStage(strictBaseline, counter,
+                    null, strictBaseline);
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Authorization", List.of(longBearer)),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> withoutCarveOut.process(request, List.of()));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType(),
+                    "the admission above is attributable to the carve-out, not to the value being short");
+        }
+
+        @ParameterizedTest(name = "admits a long {0} value on a cookie-mode gateway")
+        @ValueSource(strings = {"Cookie", "Set-Cookie"})
+        @DisplayName("admits a >1024-character cookie header value on the same body-cap-only route")
+        void admitsLongCookieOnCookieModeGateway(String headerName) {
+            // Arrange — the symmetric case for the second carve-out
+            String sealedCookie = "__Host-sheriff-session=" + "a".repeat(4096);
+            PipelineRequest request = requestWithHeaders(
+                    Map.of(headerName, List.of(sealedCookie)),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> cookieModeStage.process(request, List.of()),
+                    "the pre-route cookie carve-out must survive the divergent-route re-run");
+        }
+
+        @Test
+        @DisplayName("a bearer-only gateway still rejects the same long cookie — the by-deployment bound holds")
+        void bearerOnlyGatewayStillRejectsLongCookie() {
+            // Arrange — the cookie carve-out has a MODE axis the Authorization one does not; carrying
+            // it post-route must not quietly grant it to gateways that never had it.
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Cookie", List.of("__Host-sheriff-session=" + "a".repeat(4096))),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictStage.process(request, List.of()));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("an oversized header that is neither Authorization nor a cookie keeps the ROUTE's cap")
+        void doesNotLeakToOtherHeaders() {
+            // Arrange — the by-header bound: exactly two names, never a third
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("X-Custom", List.of("a".repeat(1100))),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> cookieModeStage.process(request, List.of()));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("the carve-out raises the cap, it does not remove it")
+        void stillRejectsBeyondTheCarveOutBudget() {
+            // Arrange
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Authorization", List.of("a".repeat(AUTHORIZATION_CAP + 1))),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictStage.process(request, List.of()));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("the carve-out differs from the ROUTE configuration in the length cap alone")
+        void carveOutDiffersFromRouteConfigInCapAlone() {
+            // Arrange + Act — seeded from the ROUTE's own policy, never from the gateway baseline
+            SecurityConfiguration carveOut =
+                    ThoroughChecksStage.carveOutConfigurationFor(raisedBodyRoute, AUTHORIZATION_CAP);
+
+            // Assert
+            assertEquals(AUTHORIZATION_CAP, carveOut.maxHeaderValueLength(),
+                    "the carve-out budget raises the route's cap for the carved-out header");
+            assertNotEquals(raisedBodyRoute.maxHeaderValueLength(), carveOut.maxHeaderValueLength());
+            assertDiffersFromRouteConfigInCapAlone(raisedBodyRoute, carveOut);
+        }
+
+        @Test
+        @DisplayName("a route whose own cap exceeds the carve-out budget keeps its higher cap")
+        void routeCapAboveTheBudgetIsNeverLowered() {
+            // Arrange — max(routeCap, budget), never a blind override: this route declared 16384
+            assertTrue(raisedHeaderCapRoute.maxHeaderValueLength() > AUTHORIZATION_CAP,
+                    "the route must out-declare the budget, otherwise max() is not being exercised");
+            String aboveBudget = "Bearer " + "a".repeat(AUTHORIZATION_CAP + 500);
+
+            // Act
+            SecurityConfiguration carveOut = ThoroughChecksStage.carveOutConfigurationFor(
+                    raisedHeaderCapRoute, AUTHORIZATION_CAP);
+            PipelineRequest admitted = requestWithHeaders(
+                    Map.of("Authorization", List.of(aboveBudget)),
+                    route(SecurityProfile.STRICT, Optional.of(raisedHeaderCapRoute)));
+            PipelineRequest refused = requestWithHeaders(
+                    Map.of("Authorization", List.of("a".repeat(
+                            raisedHeaderCapRoute.maxHeaderValueLength() + 1))),
+                    route(SecurityProfile.STRICT, Optional.of(raisedHeaderCapRoute)));
+
+            // Assert
+            assertEquals(raisedHeaderCapRoute.maxHeaderValueLength(), carveOut.maxHeaderValueLength(),
+                    "the route's higher cap wins over the lower carve-out budget");
+            assertEquals(raisedHeaderCapRoute, carveOut,
+                    "no dimension changes at all when the route already out-declares the budget");
+            assertDoesNotThrow(() -> strictStage.process(admitted, List.of()),
+                    "a value above the budget but within the route's own cap must be admitted");
+            assertThrows(GatewayException.class, () -> strictStage.process(refused, List.of()),
+                    "the route's own cap is still enforced above the budget");
+        }
+
+        @Test
+        @DisplayName("a carved-out value is still refused for an extended-ASCII character")
+        void carveOutKeepsEveryNonLengthValidatorOnTheRouteSetting() {
+            // Arrange — the by-validator bound, behaviourally: the strict route forbids extended
+            // ASCII, and the carve-out must not relax that while raising the length cap. A carve-out
+            // seeded from the builder defaults instead would admit this value.
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Authorization", List.of("Bearer é" + "a".repeat(1100))),
+                    route(SecurityProfile.STRICT, Optional.of(raisedBodyRoute)));
+
+            // Act
+            GatewayException thrown = assertThrows(GatewayException.class,
+                    () -> strictStage.process(request, List.of()));
+
+            // Assert
+            assertEquals(EventType.SECURITY_FILTER_VIOLATION, thrown.getEventType());
+        }
+
+        @Test
+        @DisplayName("the same extended-ASCII value is admitted under a route whose policy permits it")
+        void extendedAsciiIsAdmittedUnderAPermissiveRoute() {
+            // Arrange — the matched control: without it the refusal above could not distinguish 'the
+            // carve-out inherited the ROUTE's strict setting' from 'the value is refused regardless'.
+            SecurityConfiguration permissiveRoute = SecurityConfiguration.defaults();
+            assertTrue(permissiveRoute.allowExtendedAscii(),
+                    "the control route must permit what the strict route refuses");
+            PipelineRequest request = requestWithHeaders(
+                    Map.of("Authorization", List.of("Bearer é" + "a".repeat(1100))),
+                    route(SecurityProfile.STRICT, Optional.of(permissiveRoute)));
+
+            // Act + Assert
+            assertDoesNotThrow(() -> strictStage.process(request, List.of()),
+                    "the refusal above is attributable to the route's own policy, not to the value");
+        }
+
+        /**
+         * Exhaustive component sweep, mirroring {@code GatewayEdgeRouteTest}'s pre-route peer: every
+         * {@link SecurityConfiguration} record component except {@code maxHeaderValueLength} must
+         * carry the ROUTE configuration's value. Reflection rather than a hand-written list so a
+         * component added by a cui-http upgrade is covered the moment it exists.
+         */
+        private void assertDiffersFromRouteConfigInCapAlone(SecurityConfiguration routeConfig,
+                SecurityConfiguration carveOut) {
+            for (RecordComponent component : SecurityConfiguration.class.getRecordComponents()) {
+                if ("maxHeaderValueLength".equals(component.getName())) {
+                    continue;
+                }
+                Object routeValue = assertDoesNotThrow(() -> component.getAccessor().invoke(routeConfig));
+                Object carveOutValue = assertDoesNotThrow(() -> component.getAccessor().invoke(carveOut));
+                assertEquals(routeValue, carveOutValue,
+                        "carve-out component '%s' must stay on the ROUTE's setting — only the length cap changes"
+                                .formatted(component.getName()));
+            }
+        }
+    }
+
+    /**
+     * Builds a stage as {@code GatewayEdgeRoute} wires it: the gateway baseline plus the two
+     * header-value carve-out policies the pre-route floor receives, the {@code Authorization} one
+     * unconditional and the cookie one supplied only by an active cookie-mode BFF.
+     */
+    private ThoroughChecksStage stageWith(SecurityConfiguration baseline,
+            @Nullable SecurityConfiguration cookieHeaderConfiguration) {
+        return new ThoroughChecksStage(baseline, counter, cookieHeaderConfiguration,
+                withHeaderValueCap(baseline, AUTHORIZATION_CAP));
+    }
+
+    /**
+     * Mirrors the production seeding: a configuration identical to {@code baseline} in every
+     * dimension except {@code maxHeaderValueLength}. Routed through the shared production seam so the
+     * fixture cannot drift from the component set the production carve-outs copy.
+     */
+    private static SecurityConfiguration withHeaderValueCap(SecurityConfiguration baseline, int cap) {
+        return SecurityConfigurations.builderSeededFrom(baseline).maxHeaderValueLength(cap).build();
     }
 
     private static PipelineRequest requestWithHeaders(Map<String, List<String>> headers, RouteRuntime route) {

--- a/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
+++ b/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
@@ -7,8 +7,8 @@
 // Progressive-disclosure metadata block (see manage-adr SKILL.md → "ADR Template
 // Structure"). Read by `manage-adr.py scan` so a caller can assess an ADR's
 // relevance without reading the full file. List fields are comma-separated.
-// summary: Two deliberate inbound-validation relaxations the BFF requires — the url-parameter value pipeline is not applied to matched reserved paths, and the cookie-header value-length raise is necessarily gateway-wide
-// tags: security, bff, reserved-paths, input-validation, cookie-header, relaxation, blast-radius
+// summary: Two deliberate inbound-validation relaxations the BFF requires — the url-parameter value pipeline is not applied to matched reserved paths, and the pre-route header-value raise is necessarily gateway-wide; amended to cover the Authorization header alongside Cookie/Set-Cookie
+// tags: security, bff, reserved-paths, input-validation, cookie-header, authorization-header, relaxation, blast-radius
 // affects: api-sheriff
 // supersedes:
 // end-adr-metadata
@@ -77,6 +77,10 @@ no reserved path and is byte-for-byte unaffected.
 
 === (b) The cookie-header value-length relaxation is gateway-wide
 
+See the second Amendment below: this decision now covers *two* pre-route header-value relaxations —
+the `Cookie` / `Set-Cookie` one described here and an `Authorization` one on the same seam — and the
+"only the length cap changes" bound below has been corrected and is now enforced structurally.
+
 The stage accepts an optional cookie-header policy whose *only* difference from the default is a
 raised maximum header-value length, and applies it to the `Cookie` and `Set-Cookie` header values
 only. It is supplied only by a cookie-mode BFF gateway; a bearer-only or server-mode gateway
@@ -141,6 +145,68 @@ Consequences of the amendment:
 The amendment strengthens the original decision rather than qualifying it: the relaxation the record
 granted deliberately is now a property of where reserved paths terminate, which cannot drift out of
 agreement with itself the way a predicate could.
+
+== Amendment: decision (b) covers both pre-route header-value carve-outs, and its "only the length cap changes" bound is now structurally true
+
+*This record is amended, not superseded.* Decision (b) is *extended* to a second header on the same
+seam, and one of its three bounding axes is *corrected*: it was stated as a guarantee but was not in
+fact being upheld for the cookie carve-out.
+
+=== The extension: `Authorization` joins `Cookie` / `Set-Cookie`
+
+The pre-route floor measures every inbound header value against the gateway's *resolved baseline*
+`maxHeaderValueLength`. Once the gateway-wide `security_defaults.profile` knob became load-bearing,
+that baseline became the `strict` preset's 1024 characters. A bearer token plus its `Bearer ` prefix
+routinely exceeds 1024, so *every* bearer-authenticated request was rejected at the floor, before
+route selection and before bearer validation ever ran.
+
+This is decision (b)'s situation exactly, on a different header: a legitimate request class that a
+defence does not fit, at a pipeline position where no anchor exists to scope a per-route exception
+to. The same answer therefore applies — a carve-out selected on the header *name*, raising the length
+cap for `Authorization` values and nothing else. It is an *extension of the existing decision*, not a
+new one: it relaxes the *same* validator, on one further header, for the same structural reason. (The
+Risks bullet "Relaxation creep" reserves a separate record for relaxing a *different* validator; that
+bound is unchanged and is not being spent here.)
+
+Its blast radius is bounded on the same three axes, and the third is *deliberately weaker* than the
+cookie carve-out's — the amendment states this rather than implying parity:
+
+* *By header.* Only `Authorization` values are affected. Every other header keeps the resolved
+  baseline cap.
+* *By validator.* Only the length cap changes — see the correction below, which is what makes this
+  claim true.
+* *By deployment.* *Unconditional.* Unlike the cookie carve-out, which exists only in an active
+  cookie-mode BFF, this one is present on every gateway, because a bearer-capable gateway is every
+  gateway. There is no mode axis to contain it. That is a genuinely larger residual exposure than
+  decision (b)'s original third axis, and it is accepted knowingly: the alternative is a gateway that
+  cannot serve bearer traffic at all.
+
+The budget is operator-declared, not a fixed constant, because the right value is a property of the
+deployment's identity provider rather than of the gateway: `security_defaults.max_authorization_header_value_length`,
+defaulting to 8192 — the `lenient` preset's own header-value ceiling, so the carve-out never admits a
+value the loosest shipped profile would itself reject. A declared value *below* the resolved baseline
+is refused at boot, since that would be a per-header tightening wearing a relaxation key's name.
+
+*The key's placement directly answers this record's own Risks bullet* "Misreading the configuration
+key's placement". That risk was raised because the cookie budget sits on `oidc.session`, a block whose
+name says nothing about scope. This key sits on `security_defaults` — a block that is *by name*
+gateway-wide — so its global scope cannot be misread. The risk is retired for this carve-out; it
+stands unchanged for the cookie one.
+
+=== The correction: "only the length cap changes" was not true
+
+Decision (b) states, as a bounding axis, that *only the length cap changes*. For the cookie carve-out
+that was not the case. The cookie policy was built from the `cui-http` builder's bare defaults rather
+than from the gateway's resolved baseline, so on a `strict` gateway it silently also relaxed
+`failOnSuspiciousPatterns`, `allowExtendedAscii` and `caseSensitiveComparison` for cookie header
+values. The stated bound and the shipped behaviour had diverged: the record promised a *longer* value,
+never a *differently-shaped* one, while the implementation admitted a differently-shaped one too.
+
+This is recorded as a *corrected defect*, not as a restatement. The correction: both carve-out
+policies are now seeded component-by-component *from the resolved baseline* and override the length
+cap alone. The bound is therefore enforced *structurally* — by the seeding, which cannot silently
+drop a validator — rather than by an unchecked comment asserting it. Decision (b)'s "By validator"
+axis is true for the first time, and true for both carve-outs.
 
 == Consequences
 
@@ -222,5 +288,7 @@ limit is structural and is stated as such rather than left to be discovered.
 * link:0024-Inbound_filter_modes_none_is_a_partial_disable_retaining_the_body_cap_and_path_allowlist_and_is_refused_on_authenticated_and_BFF_routes.adoc[ADR-0024 -- Inbound filter modes] -- relocates the url-parameter validation into the post-route stage, which is what makes relaxation (a) structural (see the Amendment above). Does not supersede this record.
 * link:../architecture.adoc[Architecture] -- the inbound pipeline's position ahead of routing.
 * link:../configuration.adoc#_oidc[Configuration Reference -- `oidc`] -- the session block carrying the cookie-size budget.
+* link:../configuration.adoc#_pre_route_header_carve_outs[Configuration Reference -- Pre-route header-name carve-outs] -- both carve-outs, their budget keys and their bounds, side by side.
+* link:../configuration.adoc#_preset_limits[Configuration Reference -- Preset limits] -- the concrete `strict` / `lenient` numbers the resolved baseline takes.
 * link:../variants/03-bff-cookie.adoc[Variant 3 -- BFF, Cookie-based] -- the variant whose sealed cookie motivates the length relaxation.
 * link:../development/bff-cookie.adoc[Contributor guide -- cookie-based BFF] -- the sealed-cookie format the budget bounds.

--- a/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
+++ b/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
@@ -252,6 +252,53 @@ This also removes a secure-design pressure the divergence created: an operator h
 most plausibly have raised that route's `max_header_value_length`, relaxing *every* header on the route
 — precisely the blunt, gateway-widening relaxation the name-scoped carve-out exists to avoid.
 
+== Amendment: the admit-more-length-only direction is now enforced at all three sites
+
+*This record is amended, not superseded.* No bound changes; the *direction of change* stated
+immediately above — `admit-more-length-only, for exactly two header names` — is now honoured at every
+site that derives a carved-out cap, rather than at two of the three.
+
+The amendment above bounded the *post-route* re-run with `max(route cap, budget)` and called that
+`max` load-bearing. The *pre-route* cookie site was left setting its cap outright from the budget, and
+that made it the sole outlier. The shipped default triggers the divergence with no operator
+misconfiguration at all: the default cookie budget (4096) plus the fixed 512-byte header overhead is
+4608, which sits *below* the `lenient` preset's 8192 baseline. On a `lenient` cookie-mode gateway the
+carve-out therefore *lowered* the cap for `Cookie` / `Set-Cookie` — rejecting `400` every request whose
+cookie value fell between 4609 and 8192, while every *other* header on the same gateway was admitted to
+8192. A relaxation key that tightens exactly the header it names is the failure shape this record has
+already corrected once, in "The correction: 'only the length cap changes' was not true".
+
+The correction: the pre-route cookie cap is `max(resolved baseline maxHeaderValueLength, budget +
+header overhead)`. The three sites that can move a carved-out cap now share one invariant:
+
+[cols="1,2,2", options="header"]
+|===
+| Site | Bound | Mechanism
+
+| Pre-route `Cookie` / `Set-Cookie`
+| `max(baseline cap, budget + overhead)`
+| Silent `max` — the budget is a *codec transport* property with its own floor/ceiling validation, so
+  a value below the baseline is a legitimate cookie budget rather than an operator error, and clamping
+  it is the correct, non-surprising response.
+
+| Pre-route `Authorization`
+| Declared budget, with a below-baseline value refused at boot
+| *Loud refusal*, deliberately not a silent `max`. The key
+  (`security_defaults.max_authorization_header_value_length`) is by name a *relaxation* knob on a
+  gateway-wide block, so a below-baseline value is a misconfiguration and is worth a boot diagnostic;
+  an omitted key resolves to 8192, at or above every shipped baseline. Adding a silent `max` here
+  would trade that diagnostic for silent coercion.
+
+| Post-route re-run (both names)
+| `max(route cap, budget)`
+| Silent `max` — a route that raised its own cap keeps it, and a route at or below the baseline still
+  admits the carved-out header to the budget.
+|===
+
+The two mechanisms differ on purpose and the difference is the point: *no site may lower a cap*, but
+where the lower value is an operator error it is refused rather than quietly clamped. The direction of
+change is admit-more-length-only at every one of them.
+
 == Consequences
 
 === Positive

--- a/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
+++ b/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
@@ -211,6 +211,24 @@ cap alone. The bound is therefore enforced *structurally* — by the seeding, wh
 drop a validator — rather than by an unchecked comment asserting it. Decision (b)'s "By validator"
 axis is true for the first time, and true for both carve-outs.
 
+=== The post-amendment limit, restated
+
+*This restatement answers this record's own Risks bullet* "Relaxation creep", which enumerates the
+bound as "one header pair, one validator, one deployment mode". Two of those three clauses describe
+the state *before* this amendment. The original bullet is left as written and corrected here in
+prose, exactly as the "Misreading the configuration key's placement" risk is retired above rather
+than edited.
+
+The limit now accepted is *two header names* — `Cookie` / `Set-Cookie` and `Authorization` — *one
+validator*, the length cap, and a *deployment-mode axis that binds the cookie carve-out alone*: the
+`Authorization` carve-out is unconditional, so there is no mode axis to bound it. Only the "one
+validator" clause survives unchanged, and it is the clause that bullet actually spends — a future
+request to relax a *different* validator is still a separate decision requiring its own record.
+
+The Risks bullet is therefore to be read together with this restatement. The residual exposure this
+record claims to keep "explicitly enumerable rather than emergent" is the exposure enumerated here,
+not the narrower one the unedited bullet describes.
+
 == Amendment: both carve-outs are honoured by the post-route re-run, so the by-header bound holds on every route
 
 *This record is amended, not superseded.* The two carve-outs' *bounds* are unchanged; what changes is

--- a/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
+++ b/doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc
@@ -77,9 +77,11 @@ no reserved path and is byte-for-byte unaffected.
 
 === (b) The cookie-header value-length relaxation is gateway-wide
 
-See the second Amendment below: this decision now covers *two* pre-route header-value relaxations —
-the `Cookie` / `Set-Cookie` one described here and an `Authorization` one on the same seam — and the
-"only the length cap changes" bound below has been corrected and is now enforced structurally.
+See the second Amendment below: this decision now covers *two* header-value relaxations — the
+`Cookie` / `Set-Cookie` one described here and an `Authorization` one on the same seam — and the
+"only the length cap changes" bound below has been corrected and is now enforced structurally. Both
+are *declared* on the pre-route floor and, per the third Amendment, are *honoured* by the post-route
+per-route re-run as well.
 
 The stage accepts an optional cookie-header policy whose *only* difference from the default is a
 raised maximum header-value length, and applies it to the `Cookie` and `Set-Cookie` header values
@@ -138,9 +140,10 @@ Consequences of the amendment:
   runs in the pre-route floor and still yields the single canonical path later stages consume, the
   parameter- and header-*count* caps still apply, and every header validator still applies. The
   relocation moved the *value* pipeline only.
-* *Relaxation (b), the cookie-header value-length raise, is untouched* by this amendment. It remains a
-  pre-route relaxation, remains gateway-wide for the structural reason decision (b) gives, and its
-  three bounding axes are unchanged.
+* *Relaxation (b), the cookie-header value-length raise, is untouched* by this amendment. It is still
+  declared pre-route, remains gateway-wide for the structural reason decision (b) gives, and its three
+  bounding axes are unchanged. (The third Amendment below extends where it is *honoured* — the
+  post-route re-run — without touching those axes.)
 
 The amendment strengthens the original decision rather than qualifying it: the relaxation the record
 granted deliberately is now a property of where reserved paths terminate, which cannot drift out of
@@ -207,6 +210,47 @@ policies are now seeded component-by-component *from the resolved baseline* and 
 cap alone. The bound is therefore enforced *structurally* — by the seeding, which cannot silently
 drop a validator — rather than by an unchecked comment asserting it. Decision (b)'s "By validator"
 axis is true for the first time, and true for both carve-outs.
+
+== Amendment: both carve-outs are honoured by the post-route re-run, so the by-header bound holds on every route
+
+*This record is amended, not superseded.* The two carve-outs' *bounds* are unchanged; what changes is
+that decision (b) is now upheld at *both* points that measure a header value, rather than only at the
+first.
+
+Both carve-outs were named "pre-route" because the stage that grants them runs before route
+selection. That name described where they are *declared*, but it was silently also describing where
+they *stopped*: the post-route stage re-validates every header name and value under the route's own
+configuration whenever that configuration diverges from the gateway baseline, and it did so with no
+carve-out at all. Since it runs *before* the authentication stage, an `Authorization` value was still
+present to be rejected there. A route declaring nothing but a raised `max_body_bytes` already
+diverges, so on a `strict` gateway such a route rejected a 1107-character bearer token `400` — the
+exact failure decision (b)'s `Authorization` extension exists to prevent, reinstated one stage later
+for any bearer-protected route that also declares a `security_filter`.
+
+The correction: the post-route re-run performs the *same* three-way header-name dispatch, seeding each
+carve-out from the *route's* configuration rather than from the gateway baseline. Its cap is
+`max(route maxHeaderValueLength, budget)`. The `max` is load-bearing in both directions — a route that
+legitimately raises its own cap above the budget keeps its higher cap, and the carve-out never *lowers*
+a route's own cap.
+
+The three bounding axes are unchanged and now hold uniformly:
+
+* *By header.* Still exactly `Authorization` and `Cookie` / `Set-Cookie`. Every other header is
+  measured at the route's own cap by the re-run, exactly as before.
+* *By validator.* Still the length cap alone. The post-route carve-out is seeded from the route's
+  configuration through the same shared seam as the pre-route one, so every non-length validator stays
+  on the *route's* setting — a route stricter than the gateway keeps its strictness for the carved-out
+  headers too.
+* *By deployment.* Unchanged and asymmetric as recorded: a gateway that is not an active cookie-mode
+  BFF supplies no cookie budget, so its `Cookie` / `Set-Cookie` values stay on the route's own cap
+  post-route as well.
+
+The direction of change is *admit-more-length-only, for exactly two header names*. No route's posture
+is weakened on any other axis, and no route's own declared cap is reduced.
+
+This also removes a secure-design pressure the divergence created: an operator hitting the `400` would
+most plausibly have raised that route's `max_header_value_length`, relaxing *every* header on the route
+— precisely the blunt, gateway-widening relaxation the name-scoped carve-out exists to avoid.
 
 == Consequences
 

--- a/doc/adr/0025-A_security_bound_declared_at_one_inbound-validation_stage_is_re-asserted_at_every_later_stage_that_re-validates_the_same_input.adoc
+++ b/doc/adr/0025-A_security_bound_declared_at_one_inbound-validation_stage_is_re-asserted_at_every_later_stage_that_re-validates_the_same_input.adoc
@@ -1,0 +1,169 @@
+= ADR-0025: A security bound declared at one inbound-validation stage is re-asserted at every later stage that re-validates the same input
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// Progressive-disclosure metadata block (see manage-adr SKILL.md → "ADR Template
+// Structure"). Read by `manage-adr.py scan` so a caller can assess an ADR's
+// relevance without reading the full file. List fields are comma-separated.
+// summary: A bound declared at one inbound-validation stage — a carve-out, a relaxation, a cap — is either re-asserted at every later stage that re-validates the same input or explicitly delegated to it; the derivation is owned by one shared seam so the stages cannot silently disagree
+// tags: security, input-validation, pipeline-stages, invariants, defence-in-depth, configuration-derivation, blast-radius
+// affects: api-sheriff
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+Inbound validation is not one check but a sequence of stages either side of route selection. A
+pre-route floor runs before any route is known, so it must measure every request against the
+gateway-wide baseline. A post-route stage re-validates the same request under the route's own
+configuration whenever that configuration diverges from the baseline. Both stages measure the same
+inbound properties of the same request; they differ only in which configuration they measure it
+against.
+
+That shape is deliberate and is not going away: routing must decide on canonicalised, validated
+input, so some validation necessarily precedes it, and a route that declares its own security
+posture must have that posture applied, so some validation necessarily follows it.
+
+The shape creates a failure mode that has no natural detector. When a deliberate exception is
+granted — a carve-out admitting a longer value for one named header, a bound stated as a guarantee —
+it is granted *at a stage*. The stage that grants it is visible, reviewed and documented. The later
+stage that re-derives its own configuration from a different source is not obviously part of that
+decision at all, and it independently arrives at a stricter answer. The request is admitted by the
+stage that was reasoned about and rejected by the stage that was not.
+
+Nothing about this is loud. Every stage is individually correct against its own configuration. No
+validator is missing. The exception's record is accurate about the stage it names. The defect exists
+only in the *relationship* between stages, and the relationship is exactly what no single stage's
+code, tests or documentation describes. The same is true of derivation: when two stages each
+construct their own copy of a multi-component configuration object, the copies agree only for as
+long as someone remembers both exist, and a component added to one is silently dropped by the other.
+
+The question this record settles is what a validation stage owes a bound that some other stage
+declared.
+
+== Decision
+
+*A bound declared at one inbound-validation stage is either re-asserted at every later stage that
+re-validates the same input, or explicitly delegated to a named later stage. Silence is not a third
+option, and the derivation that realises the bound is owned by one shared seam rather than
+reconstructed per stage.*
+
+Three obligations follow, and they are jointly what makes the property hold.
+
+=== Re-assert or delegate, never assume
+
+A stage that re-validates an input another stage already validated inherits every bound asserted
+about that input. Either it applies the bound under its own configuration, or the declaring record
+names the stage the check moves to and what that stage validates instead. The delegation form is
+legitimate and is used: a request terminating at a gateway-owned handler never reaches the
+post-route stage, and its parameter validation moves to a handler that knows each parameter's
+grammar — a check strictly more precise than the generic one. What is not legitimate is a bound
+that simply stops at a stage boundary because no one asked where it stopped.
+
+=== One derivation seam, not one per stage
+
+Where several stages must derive the same policy from different configurations, the derivation is
+written once and parameterised by the configuration, not copied per stage. A shared seam takes the
+stage's own resolved configuration and applies the exception to it, so each stage's answer differs
+in exactly the way the stages differ — the configuration it was handed — and in no other way. This
+is what makes a bound like "only the length cap changes" structurally true rather than
+comment-asserted: a seeding that carries every component forward cannot silently drop one, whereas
+a per-stage copy of a component list is a list that must be maintained twice and will not be.
+
+=== The direction of a relaxation is uniform across sites
+
+A relaxation must relax at every site that honours it. A site deriving a *stricter* value than the
+bound it implements has inverted the exception's purpose, and it does so most easily at a site whose
+configuration differs from the one the bound was reasoned against. Each site therefore states its
+direction explicitly. Where a value below the baseline is a legitimate input from another subsystem,
+the site clamps; where it is an operator error, the site refuses fail-closed at boot rather than
+quietly clamping, so the diagnostic is not traded away for uniformity of mechanism.
+
+== Consequences
+
+=== Positive
+
+* A relaxation's stated blast radius is its actual blast radius at every stage, so the enumeration a
+  reviewer reads is the one the gateway enforces.
+* A defect in the relationship between stages becomes a defect in one shared seam, where it is
+  reviewable and testable, rather than an emergent property of two independently correct components.
+* Adding a validation stage, or adding a carve-out to an existing one, has an explicit obligation
+  attached: enumerate the stages that re-validate the same input and state each one's position.
+* A configuration object gaining a component propagates to every derived policy automatically,
+  instead of silently reverting the new component to a default at whichever site was not updated.
+
+=== Negative
+
+* Every new carve-out costs more than its declaring site: the author must walk the pipeline and
+  state a position per stage, even where the position is "unchanged".
+* A shared derivation seam couples the stages that consume it. A change to the seam is a change to
+  every stage, which is the intended trade but is a real constraint on changing one stage alone.
+* Uniform direction does not imply uniform mechanism — clamping at one site and boot refusal at
+  another is deliberate, and the asymmetry has to be stated at each site or it reads as an
+  inconsistency.
+
+=== Risks
+
+* *Stage inventory drift.* The obligation is only as good as the enumeration of stages that
+  re-validate a given input. A newly added stage that re-derives its own policy reintroduces exactly
+  the failure this record addresses, and it does so silently.
+* *Delegation without a receiver.* The delegate form moves a check rather than removing it, so it
+  holds only while the named receiver actually performs it. A delegation whose receiver never
+  implements the check is indistinguishable, from the pipeline's perspective, from an omission.
+* *Seam erosion.* A stage under pressure to differ "just slightly" from the shared derivation is the
+  first step back to per-stage copies. The seam's value is that it has no per-stage branch.
+
+== Alternatives Considered
+
+*Let each stage derive its own policy from its own configuration, and document the relationship.*
+This is the smallest possible arrangement and keeps every stage independently comprehensible.
+Rejected because documentation is the mechanism that has already been observed to fail in exactly
+this position: a bound stated as a guarantee in prose, with nothing structural upholding it,
+diverged from the shipped behaviour without any check noticing. Prose cannot enforce a relationship
+between two components that never reference each other.
+
+*Collapse validation into a single stage so no relationship exists.* This removes the failure class
+outright rather than managing it. Rejected because it is not achievable: routing must decide on
+validated input, and a route's own declared posture must be applied to it, so at least one check
+must precede route selection and at least one must follow it. Deferring all validation until after
+routing means routing on unvalidated input, which is a strictly worse exposure than the one being
+avoided.
+
+*Make the later stage simply skip inputs an earlier stage already accepted.* This would make the
+first decision final and needs no shared derivation at all. Rejected because it discards the entire
+purpose of per-route posture: a route stricter than the gateway would no longer be stricter, and the
+route-level configuration surface would silently stop meaning anything for every property the floor
+also checks. It fixes the disagreement by deleting one side of it.
+
+*Enforce the property with a test per carve-out rather than a structural seam.* Tests are cheap and
+name the invariant explicitly. Rejected as the primary mechanism because a test asserts the cases
+someone thought to write; the failure mode here is precisely a stage or a component nobody thought
+about. Tests remain valuable as controls, but they detect a known instance rather than preventing
+the class.
+
+The rejected options divide into two kinds. One kind removes the relationship by removing a
+capability the architecture needs — per-route posture, or validation ahead of routing. The other
+kind leaves the relationship in place and relies on someone remembering it. The chosen position
+keeps both stages and both capabilities, and makes the relationship a component with a name.
+
+== Generalisation
+
+Wherever the same input is validated more than once against different configurations, an exception
+granted at one validation point is a statement about the input, not about the point. The diagnostic
+question when granting one is: *which other component re-examines this same input, and under which
+configuration?* Each answer is either "it applies the same exception, derived from its own
+configuration" or "the exception is delegated to it and it validates the input another way". A
+component that answers neither is where the exception ends, and it will end there quietly.
+
+== References
+
+* link:0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc[ADR-0019 -- Reserved BFF paths and the header-value relaxations] -- the concrete carve-outs whose per-site positions this record generalises. Not superseded; ADR-0019 remains authoritative for each carve-out's bounds.
+* link:0024-Inbound_filter_modes_none_is_a_partial_disable_retaining_the_body_cap_and_path_allowlist_and_is_refused_on_authenticated_and_BFF_routes.adoc[ADR-0024 -- Inbound filter modes] -- fixes which checks live at which stage, and so establishes the multi-stage shape this record constrains.
+* link:../architecture.adoc[Architecture] -- the inbound pipeline's stages and their position relative to route selection.
+* link:../configuration.adoc#_pre_route_header_carve_outs[Configuration Reference -- Pre-route header-name carve-outs] -- the operator-facing surface of the carve-outs and their per-site bounds.

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -1956,9 +1956,12 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
 * `security_defaults.max_authorization_header_value_length`, when declared, must not be *below* the
   resolved baseline `max_header_value_length` (1024 under `strict`, 8192 under `lenient`). The key
   exists to *raise* the pre-route cap for `Authorization` values; a lower value is not a carve-out at
-  all but a per-header *tightening* expressed in the wrong place -- tightening belongs on
-  `security_defaults.profile` or on a route's `security_filter` -- and it would silently make
-  `Authorization` the single most-restricted header while reading like a relaxation key. The
-  comparison uses the *resolved* profile, which is why it is a boot rule rather than a schema range;
-  the schema owns only the `integer` / `minimum: 1` range. An omitted key is never refused -- it
-  resolves to the default `8192`.
+  all but a per-header *tightening* expressed through the one key that cannot express one, and it
+  would silently make `Authorization` the single most-restricted header while reading like a
+  relaxation key. The refusal offers no downward path because none exists: a route's
+  `security_filter` cannot lower the `Authorization` cap (the post-route re-run floors it back up to
+  `max(route max_header_value_length, budget)` for that header name), and `security_defaults.profile`
+  cannot either (the budget is this key or its fixed `8192` default, and does not track the profile).
+  Both bound *general* header values instead. The comparison uses the *resolved* profile, which is
+  why it is a boot rule rather than a schema range; the schema owns only the `integer` /
+  `minimum: 1` range. An omitted key is never refused -- it resolves to the default `8192`.

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -1406,10 +1406,13 @@ ignored when no route's effective auth is `require: session`.
   The raised cap is scoped twice, and is *not* a general widening of inbound header validation:
 
   * *By mode* -- only a gateway that resolves an active cookie-mode BFF raises it. A bearer-only or
-    `session.mode: server` gateway keeps the 2048-character default on every header, unchanged.
+    `session.mode: server` gateway keeps the resolved baseline `max_header_value_length` on every
+    header, unchanged (see <<_preset_limits>> for the per-preset figure).
   * *By header* -- within a cookie-mode gateway only `Cookie` and `Set-Cookie` header *values* use
-    the raised cap. Every other header keeps the default, and every non-length validator
-    (null-byte, control-character, injection-pattern) still applies to the cookie value.
+    the raised cap. Every other header keeps the resolved baseline, and every non-length validator
+    (null-byte, control-character, injection-pattern) still applies to the cookie value. The
+    `Authorization` carve-out described in <<_pre_route_header_carve_outs>> is the one other
+    exception, and it is independent of session mode.
 
   [IMPORTANT]
   ====

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -988,6 +988,88 @@ The explicit *not-a-WAF* boundary: allowlists and limits, no attack-signature ma
 | Optional `Content-Type` allowlist for request bodies.
 |===
 
+[[_preset_limits]]
+==== Preset limits
+
+The two presets are not just "tight" and "loose" labels -- they carry concrete numbers, and a route
+that declares no limit key of its own lands exactly on them. Because an omitted `security_defaults`
+block resolves to `strict`, the `strict` column is what an undeclared deployment actually enforces.
+
+[cols="3,1,1"]
+|===
+| Limit | `strict` | `lenient`
+
+| `max_body_bytes` (`maxBodySize`)
+| 1 MiB (1048576)
+| 10 MiB (10485760)
+
+| `max_query_params` (`maxParameterCount`)
+| 20
+| 500
+
+| `max_header_count` (`maxHeaderCount`)
+| 20
+| 100
+
+| `max_param_value_length` (`maxParameterValueLength`)
+| 1024
+| 8192
+
+| `max_header_value_length` (`maxHeaderValueLength`)
+| 1024
+| 8192
+
+| path length (`maxPathLength`)
+| 1024
+| 8192
+
+| parameter / header / cookie *name* length
+| 64
+| 256
+
+| cookie value length / cookie count
+| 1024 / 10
+| 8192 / 50
+|===
+
+All length limits are measured in *characters* -- the `cui-http` unit -- not bytes. The presets also
+differ in their non-length validators: `strict` normalizes Unicode, compares case-sensitively, fails
+on suspicious patterns, and permits neither double encoding, control characters, nor extended ASCII;
+`lenient` inverts each of those. Neither preset ever permits null bytes.
+
+[[_pre_route_header_carve_outs]]
+==== Pre-route header-name carve-outs
+
+The *non-skippable pre-route floor* measures every inbound header value against the resolved
+baseline `max_header_value_length` above. Two header names are carved out of that cap, each by a
+dedicated value pipeline selected on the header *name*. Both carve-outs are declared on gateway-wide
+blocks, because the floor runs *before route selection* -- no anchor is resolved at that point, so
+neither relaxation can be scoped per route or per anchor
+(link:adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc[ADR-0019]).
+
+[cols="1,2,2"]
+|===
+| Header | Budget key | Bound
+
+| `Cookie` / `Set-Cookie`
+| `oidc.session.max_cookie_size` (plus a fixed cookie-header overhead)
+| Present *only* in an active cookie-mode BFF; a bearer-only or server-mode gateway keeps the
+  resolved baseline on every header. A sealed session cookie is designed to a multi-kilobyte budget
+  the baseline would otherwise reject on every authenticated request.
+
+| `Authorization`
+| `security_defaults.max_authorization_header_value_length` (default `8192`)
+| *Unconditional* -- every gateway is bearer-capable, so there is no mode that switches it off. A
+  bearer token plus its `Bearer ` prefix routinely exceeds the `strict` baseline of 1024 characters,
+  which would reject every bearer request `400` before bearer validation ever runs.
+|===
+
+*Only the length cap changes.* Each carve-out configuration is seeded from the resolved baseline and
+overrides `max_header_value_length` alone, so every non-length validator -- null-byte,
+control-character, extended-ASCII and injection-pattern checks -- still applies to the carved-out
+value exactly as to any other header. That bound is enforced *structurally* by the seeding, not by
+convention.
+
 *The framework body-size floor.* `max_body_bytes` is a cap the gateway applies *on top of* an
 underlying HTTP-framework limit, `quarkus.http.limits.max-body-size`. The framework limit is the
 floor every declared cap sits under: a route cannot accept more than the floor allows, whatever it
@@ -1553,7 +1635,24 @@ set has exactly three members:
 |===
 
 *An omitted `security_defaults` block -- or a block omitting `profile` -- resolves to `strict`*, the
-fail-closed choice. A deployment wanting a looser baseline must declare `lenient` explicitly.
+fail-closed choice. A deployment wanting a looser baseline must declare `lenient` explicitly. The
+concrete numbers each mode carries are tabulated under link:#_preset_limits[Preset limits].
+
+The block carries one further key:
+
+[cols="1,4"]
+|===
+| Key | Meaning
+
+| `max_authorization_header_value_length`
+| *Integer, minimum `1`, default `8192`.* The budget for the pre-route `Authorization` header-value
+  carve-out (see link:#_pre_route_header_carve_outs[Pre-route header-name carve-outs]). It raises the
+  header-value cap for `Authorization` values *only*; every other header stays on the resolved
+  baseline. The default is the `lenient` preset's own header-value ceiling, so the carve-out never
+  admits a value the loosest shipped profile would itself reject. It sits on the gateway-wide
+  `security_defaults` block because the floor that enforces it runs before route selection -- its
+  placement must not be read as per-anchor enforcement.
+|===
 
 [IMPORTANT]
 ====
@@ -1838,3 +1937,12 @@ topology leak RFC 7239 §8.2/§8.3 warn about more simply than the obfuscation t
   value could never bind and would silently disable the sub-cap the operator meant to impose. The
   comparison uses the *effective* values; because an omitted relay cap is derived from the admission
   cap it can only be tripped by an *explicitly declared* relay cap.
+* `security_defaults.max_authorization_header_value_length`, when declared, must not be *below* the
+  resolved baseline `max_header_value_length` (1024 under `strict`, 8192 under `lenient`). The key
+  exists to *raise* the pre-route cap for `Authorization` values; a lower value is not a carve-out at
+  all but a per-header *tightening* expressed in the wrong place -- tightening belongs on
+  `security_defaults.profile` or on a route's `security_filter` -- and it would silently make
+  `Authorization` the single most-restricted header while reading like a relaxation key. The
+  comparison uses the *resolved* profile, which is why it is a boot rule rather than a schema range;
+  the schema owns only the `integer` / `minimum: 1` range. An omitted key is never refused -- it
+  resolves to the default `8192`.

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -1070,6 +1070,17 @@ control-character, extended-ASCII and injection-pattern checks -- still applies 
 value exactly as to any other header. That bound is enforced *structurally* by the seeding, not by
 convention.
 
+*Both carve-outs survive the post-route re-run.* A route whose `security_filter` resolves to a
+configuration differing from the gateway baseline -- a route declaring nothing more than a raised
+`max_body_bytes` already qualifies -- has its headers re-validated after route selection under that
+route's own configuration. That re-validation applies the *same* two carve-outs, so the raised cap
+reaches `Authorization` and `Cookie` / `Set-Cookie` values on *every* route, not only on routes
+without a `security_filter` block. The post-route cap is `max(route max_header_value_length, budget)`:
+a route that raises its own cap above the budget keeps its higher cap, and the carve-out never lowers
+a route's own cap. Everything else is unchanged -- the re-run seeds each carve-out from the *route's*
+configuration, so every non-length validator stays on the route's setting, and the two header names
+are the only ones affected.
+
 *The framework body-size floor.* `max_body_bytes` is a cap the gateway applies *on top of* an
 underlying HTTP-framework limit, `quarkus.http.limits.max-body-size`. The framework limit is the
 floor every declared cap sits under: a route cannot accept more than the floor allows, whatever it
@@ -1645,13 +1656,15 @@ The block carries one further key:
 | Key | Meaning
 
 | `max_authorization_header_value_length`
-| *Integer, minimum `1`, default `8192`.* The budget for the pre-route `Authorization` header-value
-  carve-out (see link:#_pre_route_header_carve_outs[Pre-route header-name carve-outs]). It raises the
+| *Integer, minimum `1`, default `8192`.* The budget for the `Authorization` header-value carve-out
+  (see link:#_pre_route_header_carve_outs[Pre-route header-name carve-outs]). It raises the
   header-value cap for `Authorization` values *only*; every other header stays on the resolved
   baseline. The default is the `lenient` preset's own header-value ceiling, so the carve-out never
   admits a value the loosest shipped profile would itself reject. It sits on the gateway-wide
-  `security_defaults` block because the floor that enforces it runs before route selection -- its
-  placement must not be read as per-anchor enforcement.
+  `security_defaults` block because the floor that first enforces it runs before route selection --
+  its placement must not be read as per-anchor enforcement. The same budget is applied by the
+  post-route re-run, so the raised cap reaches `Authorization` values on every route, including one
+  declaring its own `security_filter`.
 |===
 
 [IMPORTANT]

--- a/integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh
+++ b/integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh
@@ -14,6 +14,13 @@
 #
 # Test-only material: the shipped default profile trusts no such CA. Passwords are non-secret test
 # fixtures matching the MtlsHandshakeIT / Failsafe defaults.
+#
+# The three retained artifacts are TRACKED in git, so regenerating them unconditionally would rewrite
+# tracked files with fresh random key material on every integration-test run and leave the working
+# tree dirty for reasons unrelated to the change in flight. This script therefore regenerates only
+# when the material is absent or close to expiry, mirroring the sibling scripts/build-native-if-
+# needed.sh guard bound to the same pre-integration-test phase. Force a regeneration with --force or
+# MTLS_CERTS_FORCE=true.
 
 set -e
 
@@ -22,7 +29,58 @@ CERT_DIR="${SCRIPT_DIR}"
 VALIDITY=730
 SUBJ_SUFFIX="/OU=Integration Testing/O=API-Sheriff/L=Berlin/ST=Berlin/C=DE"
 
-echo "Generating mTLS client certificate material in ${CERT_DIR}..."
+# Regenerate when the trust anchor expires within this window. The material is issued with a 730-day
+# validity, so a 30-day margin is ample and still stops a stale checkout silently running with
+# expired certificates.
+RENEWAL_MARGIN_SECONDS=$((30 * 24 * 60 * 60))
+
+# The artifacts this script retains (see the trailing cleanup): the trust anchor plus the two client
+# keystores. All three are produced by a single generation pass, so any one of them missing means the
+# whole set must be rebuilt.
+RETAINED_ARTIFACTS=(
+    "${CERT_DIR}/mtls-client-ca.crt"
+    "${CERT_DIR}/mtls-client.p12"
+    "${CERT_DIR}/mtls-wrong.p12"
+)
+
+FORCE=false
+if [[ "${1:-}" == "--force" || "${MTLS_CERTS_FORCE:-}" == "true" ]]; then
+    FORCE=true
+fi
+
+# Sets REGENERATION_REASON and returns 0 when the material must be rebuilt, 1 when it is usable as-is.
+regeneration_needed() {
+    if [[ "${FORCE}" == "true" ]]; then
+        REGENERATION_REASON="forced"
+        return 0
+    fi
+
+    local artifact
+    for artifact in "${RETAINED_ARTIFACTS[@]}"; do
+        if [[ ! -f "${artifact}" ]]; then
+            REGENERATION_REASON="missing $(basename "${artifact}")"
+            return 0
+        fi
+    done
+
+    # All three artifacts are issued in one pass with the same validity, so the CA certificate's
+    # expiry is representative of the set — and unlike the PKCS#12 keystores it can be inspected
+    # without a password. A non-zero exit here also covers unreadable/corrupt material.
+    if ! openssl x509 -checkend "${RENEWAL_MARGIN_SECONDS}" -noout -in "${CERT_DIR}/mtls-client-ca.crt" >/dev/null; then
+        REGENERATION_REASON="mtls-client-ca.crt expires within $((RENEWAL_MARGIN_SECONDS / 86400)) days"
+        return 0
+    fi
+
+    return 1
+}
+
+if ! regeneration_needed; then
+    echo "mTLS client material already present and valid - skipping regeneration."
+    echo "  (pass --force, or set MTLS_CERTS_FORCE=true, to regenerate deliberately)"
+    exit 0
+fi
+
+echo "Generating mTLS client certificate material in ${CERT_DIR} (${REGENERATION_REASON})..."
 
 # Clean any prior material so regeneration is deterministic.
 rm -f "${CERT_DIR}"/mtls-client-ca.crt "${CERT_DIR}"/mtls-client-ca.key \

--- a/integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh
+++ b/integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh
@@ -65,9 +65,13 @@ regeneration_needed() {
 
     # All three artifacts are issued in one pass with the same validity, so the CA certificate's
     # expiry is representative of the set — and unlike the PKCS#12 keystores it can be inspected
-    # without a password. A non-zero exit here also covers unreadable/corrupt material.
+    # without a password. A non-zero exit here also covers unreadable/corrupt material, which is
+    # why the reason below names those causes too rather than asserting expiry. The two keystores
+    # are checked for PRESENCE ONLY: they are tracked in git, so a truncated one is not a
+    # normal-operation state, and when it does occur MtlsHandshakeIT fails loudly on keystore load
+    # with --force as the one-step recovery. Nothing here may claim more than it checked.
     if ! openssl x509 -checkend "${RENEWAL_MARGIN_SECONDS}" -noout -in "${CERT_DIR}/mtls-client-ca.crt" >/dev/null; then
-        REGENERATION_REASON="mtls-client-ca.crt expires within $((RENEWAL_MARGIN_SECONDS / 86400)) days"
+        REGENERATION_REASON="mtls-client-ca.crt unreadable, unparseable, or expiring within $((RENEWAL_MARGIN_SECONDS / 86400)) days"
         return 0
     fi
 
@@ -75,7 +79,7 @@ regeneration_needed() {
 }
 
 if ! regeneration_needed; then
-    echo "mTLS client material already present and valid - skipping regeneration."
+    echo "mTLS client material: all three artifacts present, mtls-client-ca.crt readable and not expiring within $((RENEWAL_MARGIN_SECONDS / 86400)) days - skipping regeneration."
     echo "  (pass --force, or set MTLS_CERTS_FORCE=true, to regenerate deliberately)"
     exit 0
 fi

--- a/integration-tests/src/main/docker/sheriff-config/gateway.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/gateway.yaml
@@ -26,8 +26,19 @@ allowed_methods: ["GET", "POST", "PUT", "DELETE"]
 # parameters, 1024-character header values and parameter values, 1024-character paths) are the
 # floor the suite proves. The single `none`-mode route below is the only opt-out, and it is a
 # PARTIAL one.
+#
+# `max_authorization_header_value_length` bounds the `Authorization` header VALUE only, at the
+# non-skippable pre-route floor (BasicChecksStage) that runs BEFORE route selection. The strict
+# preset's 1024-character header-value cap cannot serve that header: a Keycloak-minted access token
+# plus the `Bearer ` prefix measures above it, so without this carve-out every bearer request is
+# rejected 400 before bearer validation ever runs. The key is gateway-wide because its enforcement
+# point precedes route selection — no anchor is resolved there, so it cannot be scoped per route.
+# Declared EXPLICITLY here, per the same convention as `profile` above, so the IT and benchmark
+# suites measure a pinned value rather than the omitted-key default. A declared value below the
+# resolved baseline cap is refused at boot.
 security_defaults:
   profile: strict
+  max_authorization_header_value_length: 8192
 tls:
   # ALPN advertises h2 alongside http/1.1 so the http2 benchmark aspect negotiates
   # HTTP/2 at the edge instead of silently falling back to HTTP/1.1 — a fallback

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
@@ -17,8 +17,12 @@ package de.cuioss.sheriff.gateway.integration;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,16 +31,37 @@ import org.junit.jupiter.api.Test;
  * Exercises stage 4 (offline bearer-token validation) over the public HTTPS edge against the
  * bearer-protected {@code /secure} route.
  * <p>
- * The mounted {@code secure} anchor declares {@code require: bearer}, and the gateway's own
- * {@code token_validation} issuer loads its key set from the static JWKS file mounted at
- * {@code /app/certificates/test-jwks.json} — so the validator is ready offline with no Keycloak
- * dependency. Only <em>rejection</em> scenarios are driven here (a valid signed token would need
- * the private key, out of scope for the black-box suite): a missing token and a malformed token
- * must both be rejected {@code 401} at the gateway and the upstream must never be reached. A
- * forwarded request would carry the {@code go-httpbin} echo (a non-null {@code method}); its
- * absence is the observable proof the upstream count stayed {@code 0} on every bearer rejection.
+ * The mounted {@code secure} anchor declares {@code require: bearer}, and the gateway trusts
+ * <em>two</em> issuers that matter here. The {@code it-static} issuer loads its key set from the
+ * static JWKS file mounted at {@code /app/certificates/test-jwks.json}, so the validator is ready
+ * offline with no Keycloak dependency — but the suite holds no private key for it and therefore
+ * cannot mint a token it would accept. The {@code integration-keycloak} issuer, by contrast, is the
+ * live compose Keycloak {@code integration} realm, which <em>can</em> mint one. The
+ * admitted-and-forwarded path is consequently in scope, and is driven below.
+ * <p>
+ * <strong>Rejection scenarios.</strong> A missing token and a malformed token must both be rejected
+ * {@code 401} at the gateway and the upstream must never be reached. A forwarded request would carry
+ * the {@code go-httpbin} echo (a non-null {@code method}); its absence is the observable proof the
+ * upstream count stayed {@code 0} on every bearer rejection.
+ * <p>
+ * <strong>The admitted scenario is a regression control.</strong> Before the {@code Authorization}
+ * header-value carve-out, a real Keycloak access token plus its {@code Bearer } prefix exceeded the
+ * strict preset's 1024-character pre-route header-value cap, so the request was rejected {@code 400}
+ * by {@code BasicChecksStage} — the non-skippable floor that runs <em>before</em> route selection —
+ * and stage-4 validation never ran at all. Every test in this class passed regardless, because none
+ * of them carried a full-size token. That gap is what this scenario closes.
  */
 class BearerValidationIT extends BaseIntegrationTest {
+
+    /** The seeded confidential client of the {@code integration} realm (direct grant enabled). */
+    private static final String CLIENT_ID = "integration-client";
+
+    /** The seeded client secret (see {@code integration-realm.json}); a test-fixture value only. */
+    private static final String CLIENT_SECRET = "integration-secret";
+
+    private static final String TOKEN_ENDPOINT =
+            "https://" + BffKeycloakLoginFlow.KEYCLOAK_HOST_AUTHORITY
+                    + "/realms/integration/protocol/openid-connect/token";
 
     @Test
     @DisplayName("a request with no bearer token is rejected 401 and never forwarded")
@@ -80,5 +105,57 @@ class BearerValidationIT extends BaseIntegrationTest {
                 .extract();
 
         assertEquals("GET", response.path("method"));
+    }
+
+    @Test
+    @DisplayName("a valid Keycloak bearer token is admitted and forwarded to the upstream")
+    void validBearerTokenAdmittedAndForwarded() {
+        // Arrange — a real, full-size access token from the trusted integration realm
+        String accessToken = mintIntegrationRealmAccessToken();
+
+        // Act
+        var response = given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/secure/get")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        // Assert — a non-null echoed method is the observable proof the request was not merely
+        // accepted but actually forwarded to the go-httpbin upstream.
+        assertEquals("GET", response.path("method"),
+                "an admitted bearer request must reach the upstream and echo its method");
+    }
+
+    /**
+     * Mints a real access token through the {@code integration} realm's direct-grant
+     * ({@code grant_type=password}) endpoint, reusing the seeded client and user the browser-driven
+     * BFF suite already relies on. The realm pins {@code frontendUrl https://keycloak:8443}, so the
+     * minted token carries the container-internal {@code iss} the gateway's {@code integration-keycloak}
+     * issuer declares — the host-published mint port does not change the issuer claim.
+     *
+     * @return the raw access token
+     */
+    private static String mintIntegrationRealmAccessToken() {
+        Response response = given()
+                .contentType(ContentType.URLENC)
+                .formParam("grant_type", "password")
+                .formParam("client_id", CLIENT_ID)
+                .formParam("client_secret", CLIENT_SECRET)
+                .formParam("username", BffKeycloakLoginFlow.USERNAME)
+                .formParam("password", BffKeycloakLoginFlow.PASSWORD)
+                .when()
+                .post(TOKEN_ENDPOINT)
+                .then()
+                .extract().response();
+
+        String accessToken = response.path("access_token");
+        // Fail loudly rather than driving the gateway with a null token, which would surface as a
+        // confusing 401 and mis-attribute an IdP/realm problem to the bearer-validation stage.
+        assertNotNull(accessToken,
+                () -> "the integration realm minted no access_token (HTTP %d): %s"
+                        .formatted(response.statusCode(), response.asString()));
+        return accessToken;
     }
 }

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
@@ -110,12 +110,20 @@ class BearerValidationIT extends BaseIntegrationTest {
     @Test
     @DisplayName("a valid Keycloak bearer token is admitted and forwarded to the upstream")
     void validBearerTokenAdmittedAndForwarded() {
-        // Arrange — a real, full-size access token from the trusted integration realm
-        String accessToken = mintIntegrationRealmAccessToken();
+        // Arrange — a real, full-size access token from the trusted integration realm. The length
+        // assertion is what keeps this scenario a genuine regression control: the carve-out is only
+        // exercised when the header value actually exceeds the strict preset's 1024-character
+        // pre-route cap, so without it the test would pass vacuously — green while never reaching
+        // the code path it exists to prove — should the IdP ever mint a token short enough to be
+        // admitted by the baseline outright.
+        String authorization = "Bearer " + mintIntegrationRealmAccessToken();
+        assertTrue(authorization.length() > 1024,
+                () -> "the integration token must exceed the strict 1024-character baseline to exercise "
+                        + "the Authorization carve-out, but measured %d".formatted(authorization.length()));
 
         // Act
         var response = given()
-                .header("Authorization", "Bearer " + accessToken)
+                .header("Authorization", authorization)
                 .when()
                 .get("/secure/get")
                 .then()


### PR DESCRIPTION
## Summary

Fixes the ~100% failure of the `bearerProxied` benchmark on `main` (run `30552703414`) by carving
`Authorization` out of the strict header-value cap at the non-skippable pre-route floor.

**This branch grew beyond its original brief.** It started as "diagnose and fix the bearer-proxied
benchmark regression". Diagnosis and the phase-6 security audit then surfaced **two further defects of
the same bug class** — a carve-out seeded from the wrong `SecurityConfiguration` baseline — that were
already on `main` and would have silently re-introduced the same rejection one pipeline stage later.
Both are fixed here rather than deferred, because shipping the pre-route carve-out alone would have
produced a fix that a diverging route config undoes.

## Root cause

PLAN-15 (commit `9b8ec4a`) wired the previously **inert** `security_defaults.profile` knob end-to-end.
Before that commit the knob had zero read sites and the gateway-wide inbound baseline was
`SecurityConfiguration.defaults()`; after it, `integration-tests/src/main/docker/sheriff-config/gateway.yaml`'s
declared `profile: strict` actually resolved — so the bearer-proxied route went from effectively
unfiltered to genuinely strict for the first time.

A realm-minted JWT plus its `Bearer ` prefix exceeds strict's **1024-character** `maxHeaderValueLength`
(the builder default is 2048). `BasicChecksStage` — the **non-skippable pre-route floor**, which runs
*before* route selection and *before* bearer validation — therefore rejected ~100% of bearer requests
with `400`. That is exactly the observed benchmark signature: `error_rate 0.999997` at ~10ms latency,
i.e. a fast local rejection rather than an upstream or auth failure.

Why no gate caught it:

- The benchmark lane runs **post-merge only**, so it is not a pre-merge gate.
- `BearerValidationIT` drove only *rejection* scenarios (malformed / missing tokens, all short headers)
  plus one public route — **never a valid bearer through the proxy**. A 21-character
  `Bearer not-a-real-jwt` is nowhere near the cap, so the suite stayed green.

## The fix

An `Authorization` header-value carve-out at the pre-route floor in
`api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java`, mirroring the
existing `Cookie`/`Set-Cookie` carve-out at the same header-name dispatch seam. Scoped by **header
name, never by route** — the stage runs before any anchor is resolved, so a per-route lever is
structurally unavailable (and is rejected by ADR-0019).

The budget is **operator-declared, not a hard-coded constant**: a new
`security_defaults.max_authorization_header_value_length` key, default **8192** (the lenient preset
ceiling), added to `SecurityDefaultsConfig.java`, declared in
`api-sheriff/src/main/resources/schema/gateway.schema.json`, and guarded by a boot-time rule in
`ConfigValidator.java` that **refuses a value below the resolved baseline** — so the knob can only
ever widen the cap for `Authorization`, never silently narrow it.

## Two additional defects found and fixed

Both are the same bug class: *a carve-out seeded from the wrong `SecurityConfiguration`.*

**1. `GatewayEdgeRoute.cookieHeaderConfigurationFor` seeded from the DEFAULT preset.** It built its
carve-out from `SecurityConfiguration.builder()` instead of the **resolved** baseline, silently
downgrading `failOnSuspiciousPatterns`, `allowExtendedAscii` and `caseSensitiveComparison` for
`Cookie` values on a strict gateway. ADR-0019's "only the length cap changes" bound is now
**structurally true for the first time**; `doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc`
is updated accordingly.

**2. `ThoroughChecksStage.reRunPipelines` undid BOTH carve-outs one stage later.** It re-validated
every header value under the *route* config with **no carve-out at all** — so for any route whose
`security_filter` diverges from the baseline, the identical `400`-before-bearer-validation regression
reappeared at stage 4. Found by the phase-6 security audit and then **confirmed empirically**, not
merely reasoned about. `ThoroughChecksStage.java` now repeats the same three-way header-name dispatch
with `cap = max(routeCap, budget)`.

## Structural improvement

The 24-component `SecurityConfiguration` copy was factored out of `GatewayEdgeRoute.java` into a
shared `SecurityConfigurations` seam in the ADR-0005-protected `config.model` package
(`api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityConfigurations.java`). The
component list now exists **exactly once** in production instead of being hand-copied — which is what
made defect (1) above possible in the first place.

## Regression control

- `integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java`
  gains a **valid-bearer-through-proxy** scenario: a real token minted from the Keycloak `integration`
  realm via direct grant, driven at the bearer-gated route, asserting the request is **admitted and
  forwarded** (upstream echo present). This is the control that would have caught the regression
  pre-merge. It was **actually run against the live containerised stack**, not merely compiled.
- 11 unit regression tests for the post-route (`ThoroughChecksStage`) carve-out.
- `integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh` no longer rewrites
  three **tracked** files on every run — an unrelated hygiene defect that made every IT run dirty the
  working tree.

## Known gap (stated plainly)

**No integration test covers a bearer-protected route that ALSO declares a `security_filter`.** The
`/secure` anchor in `gateway.yaml` declares none — which is precisely why `BearerValidationIT` could
not have caught the `ThoroughChecksStage` defect, and why that defect needed a security audit to
surface. Unit coverage closes this gap; **IT-level coverage does not.** Adding a diverging-filter
bearer anchor to the IT topology is a real follow-up, deliberately not bundled into this change.

## Changes

- `api-sheriff/.../pipeline/BasicChecksStage.java` — `Authorization` carve-out at the pre-route floor
- `api-sheriff/.../pipeline/ThoroughChecksStage.java` — same carve-out repeated post-route, `max(routeCap, budget)`
- `api-sheriff/.../edge/GatewayEdgeRoute.java` — cookie carve-out re-seeded from the resolved baseline
- `api-sheriff/.../config/model/SecurityConfigurations.java` — new shared 24-component copy seam
- `api-sheriff/.../config/model/SecurityDefaultsConfig.java` — new `max_authorization_header_value_length` key
- `api-sheriff/.../config/validation/ConfigValidator.java` — boot-time below-baseline refusal
- `api-sheriff/src/main/resources/schema/gateway.schema.json` — JSON-schema declaration for the new key
- `integration-tests/.../BearerValidationIT.java` — valid-bearer-through-proxy regression control
- `integration-tests/src/main/docker/sheriff-config/gateway.yaml` — IT gateway document
- `integration-tests/src/main/docker/certificates/generate-mtls-certificates.sh` — stop rewriting tracked files
- `doc/adr/0019-Reserved_BFF_paths_bypass_the_url-parameter_value_pipeline_and_the_cookie-header_length_relaxation_is_gateway-wide.adoc`, `doc/configuration.adoc` — documentation
- Unit tests: `BasicChecksStageTest`, `ThoroughChecksStageTest`, `GatewayEdgeRouteTest`,
  `GatewayEdgeRouteBffWiringTest`, `ConfigValidatorTest`, `ConfigLoaderTest`,
  `ConfigModelContractTest`, `RouteTableBuilderTest`
- `.plan/marshal.json` — steward-maintained artifact riding this PR

## Test Plan

- [x] Quality gate passed (`verify -Ppre-commit`) — zero errors, zero warnings
- [x] Full module test suite green — 1424 tests
- [x] Integration tests green against the live containerised stack — 87 tests
- [x] Pre-merge Performance Benchmark dispatched against this branch as a gate (run `30698473490`)
- [ ] Post-merge Performance Benchmark run — the orchestrator's acceptance check, deliberately outside
      this PR's scope

## Intent

**The problem.** Commit `9b8ec4a` made the `security_defaults.profile` knob live for the first time, so the gateway's inbound baseline became genuinely strict. Strict caps a header value at 1024 characters; a realm JWT plus `Bearer ` exceeds that. `BasicChecksStage` — the non-skippable pre-route floor, which runs before route selection and before bearer validation — therefore rejected essentially every bearer request with 400. No pre-merge gate saw it: the benchmark runs post-merge only, and the bearer IT drove only short rejection tokens.

**The chosen approach.** A carve-out for `Authorization` header values at the same header-name dispatch seam the existing `Cookie` carve-out already uses, scoped by header name and never by route — because at that stage no route is resolved yet, so a per-route lever does not exist. The budget is an operator-declared config key with a boot-time rule refusing any value below the resolved baseline, so the knob can only widen the cap, never narrow it. Relaxing the gateway-wide profile was explicitly rejected as a shipped security regression. The same carve-out is repeated in `ThoroughChecksStage`, because that stage re-validated header values under the route config with no carve-out and thus undid the fix one stage later for any route with a diverging `security_filter`.

**Explicit non-goals.** This change does not relax the gateway-wide

_[Intent truncated — 1392 of 1855 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum length for `Authorization` header values, defaulting to 8,192 characters.
  * Added gateway-wide handling for `Cookie`, `Set-Cookie`, and `Authorization` header limits while preserving other security checks.
* **Bug Fixes**
  * Invalid security limit configurations are now rejected during startup.
  * mTLS certificates are preserved when still valid, with forced renewal available when needed.
* **Documentation**
  * Documented security limits, header handling, configuration rules, and validation behavior.
* **Tests**
  * Expanded coverage for header validation, route processing, bearer authentication, and certificate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->