### PR TITLE
chore(steward): reconcile marshal.json to plan-marshall 0.1.1286

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -208,6 +208,23 @@
           "role": "config",
           "build_class": "verify"
         }
+      ],
+      "javascript": [
+        {
+          "glob": "*.js",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*.spec.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "package.json",
+          "role": "config",
+          "build_class": "verify"
+        }
       ]
     }
   },
@@ -304,9 +321,10 @@
       "temp_on_maintenance": true,
       "plugin_cache_keep_versions": 5,
       "plugin_cache_keep_days": 3,
-      "no_plan_body_days": 7
+      "no_plan_body_days": 7,
+      "build_results_days": 5
     },
-    "provisioned_version": "0.1.1275",
-    "config_seed_fingerprint": "59c217c3"
+    "provisioned_version": "0.1.1286",
+    "config_seed_fingerprint": "714f8058"
   }
 }


### PR DESCRIPTION
## Summary

Steward `upgrade` reconciliation against plan-marshall **0.1.1286**. Configuration-only — no production, test, or build code is touched.

## Changes (`.plan/marshal.json`)

| Area | Change |
|------|--------|
| `build.map` | Added the `javascript` domain (`*.js` → compile, `*.spec.js` → module-tests, `package.json` → verify), re-derived from the live tree. The demo-client SPA module (added in 645f8e3) was not yet represented, so JS-only changes did not activate the pre-push quality gate. |
| `system.retention` | Back-filled the new `build_results_days` default (`5`). |
| `system` | Re-stamped `provisioned_version` `0.1.1275` → `0.1.1286` and `config_seed_fingerprint`. |

## Steward run summary

- **Stage 1** — plugin cache verified `fresh` @ 0.1.1286; executor regenerated (141 scripts); retention sweep pruned 130 superseded cache version dirs (keep_versions=5, keep_days=3).
- **Stage 2** — `sync-defaults` + `steps-sort` + operator-approved `build.map` re-seed. Review-bot lists verified intact (`required_bots: coderabbit,pr-agent`, `optional_bots: sourcery`).
- **Stage 3** — executor preflight: `executor_action: fresh`, `marshal_status: fresh`, both @ 0.1.1286.

## Review notes

Labelled `skip-bot-review`: this is generated steward reconciliation output, not authored code. The label suppresses CodeRabbit and PR-Agent; Sourcery only skips if the repo's `.sourcery.yaml` opts in via `github.ignore_labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JPGqY2McGoc82ZzotLSYc
