### PR TITLE
feat(release): publish hardened, scanned and signed OCI image to GHCR

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -89,7 +89,7 @@ jobs:
       # The second pass is seconds: the action restores the Trivy DB from cache, so only the report
       # rendering is repeated.
       - name: Scan the pinned base image (report)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ steps.base.outputs.image }}
@@ -98,7 +98,7 @@ jobs:
           output: trivy-base-image.txt
 
       - name: Scan the pinned base image (SARIF)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ steps.base.outputs.image }}
@@ -107,7 +107,7 @@ jobs:
           output: trivy-base-image.sarif
 
       - name: Scan the repository filesystem (report)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -116,7 +116,7 @@ jobs:
           output: trivy-filesystem.txt
 
       - name: Scan the repository filesystem (SARIF)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,3 +23,135 @@ jobs:
       OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  # EARLY-WARNING SUPPLY-CHAIN SIGNAL — deliberately NON-GATING, and deliberately NOT redundant with
+  # the release lane's scan.
+  #
+  # This lane and the authoritative gate in release.yml are two distinct guarantees and neither is a
+  # simplification of the other: this one is an early signal on EVERY change, the release lane is the
+  # authoritative gate on the exact tested artifact before it is published. Do not fold them together.
+  #
+  # No `needs:` — the job neither delays nor is delayed by `build`, and no trigger changed.
+  #
+  # SCOPE: the pinned base image (by digest, read out of the Dockerfile rather than restated here)
+  # plus a filesystem scan of the repository. It deliberately does NOT build the application image:
+  # that would put a GraalVM native compile on every pull request, which is exactly the cost this
+  # arrangement avoids. The proxy is not as weak as it looks — the release image is the same pinned
+  # base plus one static binary carrying no package metadata, so a full app-image scan would report
+  # the same package findings, and the `fs` scan is what actually surfaces Java dependency CVEs.
+  supply-chain-scan:
+    name: Supply-chain scan (non-gating)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Read the pinned base image out of the Dockerfile rather than restating the digest here, so
+      # this lane cannot silently drift from what the production image is actually built on.
+      - name: Resolve the pinned base image
+        id: base
+        run: |
+          BASE="$(awk '/^FROM /{print $2; exit}' api-sheriff/src/main/docker/Dockerfile.native)"
+          case "$BASE" in
+            *@sha256:*) ;;
+            *) echo "::error::Base image in Dockerfile.native is not digest-pinned: '${BASE}'"; exit 1 ;;
+          esac
+          echo "image=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "Scanning pinned base image: ${BASE}"
+
+      - name: Generate the SPDX SBOM for the pinned base image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.base.outputs.image }}
+          format: spdx-json
+          artifact-name: base-image-sbom.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
+      # `exit-code: 0` on EVERY Trivy step below is what makes this lane non-gating.
+      # `continue-on-error` is deliberately NOT used: it would also mask a genuine tool or network
+      # failure, whereas `exit-code: 0` suppresses only the vulnerability verdict. A broken scan step
+      # must still turn the check red.
+      #
+      # Each target is scanned twice, once for the human summary and once for the SARIF artifact.
+      # The second pass is seconds: the action restores the Trivy DB from cache, so only the report
+      # rendering is repeated.
+      - name: Scan the pinned base image (report)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.base.outputs.image }}
+          exit-code: '0'
+          format: table
+          output: trivy-base-image.txt
+
+      - name: Scan the pinned base image (SARIF)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.base.outputs.image }}
+          exit-code: '0'
+          format: sarif
+          output: trivy-base-image.sarif
+
+      - name: Scan the repository filesystem (report)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          exit-code: '0'
+          format: table
+          output: trivy-filesystem.txt
+
+      - name: Scan the repository filesystem (SARIF)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          exit-code: '0'
+          format: sarif
+          output: trivy-filesystem.sarif
+
+      # The base image reaches the shell through the environment, never through `${{ }}` expansion
+      # inside the script body — expression interpolation into a run block is a script-injection sink.
+      - name: Publish the scan reports to the job summary
+        env:
+          BASE_IMAGE: ${{ steps.base.outputs.image }}
+        run: |
+          {
+            echo "## Supply-chain scan (non-gating)"
+            echo
+            echo "Findings below never fail this check. The authoritative gate runs in the release"
+            echo "lane against the exact tested image, at HIGH and CRITICAL."
+            echo
+            echo "### Pinned base image — \`${BASE_IMAGE}\`"
+            echo '```'
+            cat trivy-base-image.txt
+            echo '```'
+            echo
+            echo "### Repository filesystem"
+            echo '```'
+            cat trivy-filesystem.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the SARIF reports
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: trivy-sarif
+          path: |
+            trivy-base-image.sarif
+            trivy-filesystem.sarif
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,8 +37,9 @@ jobs:
   # plus a filesystem scan of the repository. It deliberately does NOT build the application image:
   # that would put a GraalVM native compile on every pull request, which is exactly the cost this
   # arrangement avoids. The proxy is not as weak as it looks — the release image is the same pinned
-  # base plus one static binary carrying no package metadata, so a full app-image scan would report
-  # the same package findings, and the `fs` scan is what actually surfaces Java dependency CVEs.
+  # base plus one native executable carrying no package metadata and no jars, so a full app-image
+  # scan would report the same package findings, and the `fs` scan is what actually surfaces Java
+  # dependency CVEs.
   supply-chain-scan:
     name: Supply-chain scan (non-gating)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,238 @@ jobs:
       OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  # Publishes the container image at the SAME version the Maven release just cut.
+  #
+  # COMPOSABILITY CAVEAT — read before "simplifying" the version lookup below.
+  # A caller workflow may hang a dependent sibling job off a `uses:` job; that part is ordinary
+  # GitHub Actions. But reusable-maven-release.yml@15376a19 declares NO `on.workflow_call.outputs`
+  # block — its `released-version` is a job-level output on the called workflow's own internal job
+  # and is therefore NOT readable by us. `needs.release.outputs.released-version` evaluates to the
+  # EMPTY STRING, which would tag and push `ghcr.io/cuioss/api-sheriff:` — a malformed reference, or
+  # worse, a silently mislabelled image. That is why the version is re-read from .github/project.yml
+  # with the same pinned action the release job used. Do not replace it with a `needs.` expression.
+  #
+  # The org workflow is NOT forked and the dispatch-only guarantee is NOT weakened by this job.
+  #
+  # LATENCY NOTE — `needs: [release]` waits for the whole called workflow, including its
+  # wait-for-maven-central (30-minute timeout) and propagate-to-consumers jobs. Both are `if:`-gated
+  # on a non-empty `consumers` output and .github/project.yml declares none, so both skip and add no
+  # wall time. A long wait here is Maven Central, not a hang.
+  publish-image:
+    name: Publish the tested image to GHCR
+    needs: [release]
+    runs-on: ubuntu-latest
+    # The native compile inside the integration-test lifecycle is the dominant term; the scan, push
+    # and smoke together are minutes.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      # Required for Cosign keyless OIDC signing. Not a novel posture for this repository —
+      # scorecards.yml, pr-agent.yml and claude.yml already declare it.
+      id-token: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      # Checked out into a side directory so the release-tag checkout below owns the workspace root
+      # untouched. Only .github/project.yml is needed here.
+      - name: Check out the release configuration
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          path: .release-config
+          sparse-checkout: .github/project.yml
+
+      - name: Read the released version
+        id: config
+        uses: cuioss/cuioss-organization/.github/actions/read-project-config@513eb16ca26c7e2e32d709f79e770808792bb540 # v0.17.0
+        with:
+          config-path: .release-config/.github/project.yml
+
+      # The RELEASE TAG, never the dispatching ref. cui-parent-pom configures maven-release-plugin
+      # with <tagNameFormat>@{project.version}</tagNameFormat>, so the SCM tag is literally the
+      # version string with no prefix, and the reusable workflow pushes it with `tags: true` before
+      # the job ends. Checking out the dispatching ref would build a -SNAPSHOT tree and label it with
+      # the release version — every step would still succeed, which is what makes it dangerous.
+      # If a future parent bump changes tagNameFormat this checkout fails loudly on an unresolvable
+      # ref: a red release rather than a wrong image.
+      - name: Check out the release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ steps.config.outputs.current-version }}
+
+      # The commit the `sha-` tag names: the release:prepare commit whose poms carry the released
+      # version, NOT the main HEAD the release was dispatched from.
+      - name: Resolve the release-tag commit
+        id: commit
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Before the version assertion, because the assertion evaluates project.version through Maven.
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      # THE STRUCTURAL GUARD that makes "image version identical to Maven version" a checked fact
+      # rather than an assumption. Fails loudly, before anything is built or pushed.
+      - name: Assert the checked-out project version matches the released version
+        env:
+          RELEASED_VERSION: ${{ steps.config.outputs.current-version }}
+        run: |
+          POM_VERSION="$(./mvnw --no-transfer-progress -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          if [ "$POM_VERSION" != "$RELEASED_VERSION" ]; then
+            echo "::error::Version identity violated: checked-out project.version='${POM_VERSION}' but .github/project.yml current-version='${RELEASED_VERSION}'. Refusing to build or publish."
+            exit 1
+          fi
+          echo "Version identity confirmed: ${POM_VERSION}"
+
+      # THE ONE AND ONLY IMAGE BUILD IN THIS LANE.
+      # integration-tests/pom.xml binds `docker compose build api-sheriff` to pre-integration-test,
+      # so the harness always builds the image. Letting that build be authoritative is what makes
+      # "push exactly what was tested" true BY CONSTRUCTION — there is only one build, so nothing can
+      # drift. Do NOT add a second `docker build` here, and do NOT add a skip-guard to
+      # integration-tests/pom.xml. APP_VERSION reaches the image label through the Compose service's
+      # build.args (see integration-tests/docker-compose.yml).
+      - name: Run the integration-test suite (builds the image)
+        env:
+          APP_VERSION: ${{ steps.config.outputs.current-version }}
+        run: |
+          ./mvnw --no-transfer-progress verify -Pintegration-tests -pl integration-tests -am
+
+      # The local image store is TAG-keyed and can serve a stale image, so every later step addresses
+      # the image by this content-derived ID rather than by the api-sheriff:distroless tag.
+      # An unpushed local image has an empty .RepoDigests — the registry manifest digest does not
+      # exist yet and must not be reached for here.
+      - name: Resolve the tested image ID
+        id: image
+        run: |
+          IMAGE_ID="$(docker image inspect --format '{{.Id}}' api-sheriff:distroless)"
+          if [ -z "$IMAGE_ID" ]; then
+            echo "::error::api-sheriff:distroless is absent from the local image store after the integration-test run."
+            exit 1
+          fi
+          echo "id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
+          echo "Tested image ID: ${IMAGE_ID}"
+
+      # The registry path is HARDCODED LOWERCASE on purpose: ${{ github.repository }} yields
+      # cuioss/API-Sheriff and GHCR rejects the uppercase, so deriving it from the context would fail
+      # at push time.
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Tag and push both release tags
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+          RELEASED_VERSION: ${{ steps.config.outputs.current-version }}
+          TAG_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          docker tag "$IMAGE_ID" "ghcr.io/cuioss/api-sheriff:${RELEASED_VERSION}"
+          docker tag "$IMAGE_ID" "ghcr.io/cuioss/api-sheriff:sha-${TAG_SHA}"
+          docker push "ghcr.io/cuioss/api-sheriff:${RELEASED_VERSION}"
+          docker push "ghcr.io/cuioss/api-sheriff:sha-${TAG_SHA}"
+
+      # Resolve the pushed registry manifest digest ONCE and assert both tags report the same one.
+      # From here on the image is addressed by digest, never by tag.
+      - name: Resolve the pushed manifest digest
+        id: digest
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+        run: |
+          mapfile -t DIGESTS < <(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$IMAGE_ID" \
+            | grep '^ghcr\.io/cuioss/api-sheriff@' | sed 's|.*@||' | sort -u)
+          if [ "${#DIGESTS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one ghcr.io/cuioss/api-sheriff manifest digest, found ${#DIGESTS[@]}: ${DIGESTS[*]}"
+            exit 1
+          fi
+          echo "value=${DIGESTS[0]}" >> "$GITHUB_OUTPUT"
+          echo "Published digest: ${DIGESTS[0]}"
+
+      # SMOKE THE PUBLISHED ARTIFACT, not the local one. The identity assertion (pulled ID equals the
+      # tested ID) is the LOAD-BEARING check and is independent of runtime configuration; the label
+      # and liveness legs are additive. If a leg ever proves fragile, weaken THAT leg — never the
+      # identity assertion.
+      #
+      # The run configuration is what the shipped artifact genuinely requires, not an idealised
+      # one-liner: sheriff.config.dir is relative and resolves inside the image, so the container
+      # FAILS FAST without a mounted configuration directory; the IT gateway.yaml declares
+      # tls.passthrough_sni, so the SNI front listener owns 8443 and the terminated listener must be
+      # moved to 8444 or the two collide; and management is HTTPS once the certificate pair is
+      # supplied, so the probe speaks TLS. The mounted material is the workspace fixture the
+      # integration-test run above already used — no new fixture is introduced.
+      #
+      # The probe is /q/health/live, not /q/health: the aggregate readiness endpoint includes JWKS
+      # readiness against the IT Keycloak, which is not running in this single-container smoke.
+      # Liveness is what this step can honestly assert — the published artifact boots and serves its
+      # management interface over TLS.
+      - name: Smoke the published image by digest
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+          RELEASED_VERSION: ${{ steps.config.outputs.current-version }}
+          DIGEST: ${{ steps.digest.outputs.value }}
+          TAG_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          REF="ghcr.io/cuioss/api-sheriff@${DIGEST}"
+
+          # Drop every local reference so the pull genuinely reaches the registry.
+          docker rmi "ghcr.io/cuioss/api-sheriff:${RELEASED_VERSION}" "ghcr.io/cuioss/api-sheriff:sha-${TAG_SHA}"
+          docker pull "$REF"
+
+          PULLED_ID="$(docker image inspect --format '{{.Id}}' "$REF")"
+          if [ "$PULLED_ID" != "$IMAGE_ID" ]; then
+            echo "::error::Published image is not the tested image: pulled ${PULLED_ID}, tested ${IMAGE_ID}."
+            exit 1
+          fi
+
+          PULLED_VERSION="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' "$REF")"
+          if [ "$PULLED_VERSION" != "$RELEASED_VERSION" ]; then
+            echo "::error::Published image label org.opencontainers.image.version='${PULLED_VERSION}' but the released version is '${RELEASED_VERSION}'."
+            exit 1
+          fi
+
+          CERTS="${GITHUB_WORKSPACE}/integration-tests/src/main/docker/certificates"
+          CONFIG="${GITHUB_WORKSPACE}/integration-tests/src/main/docker/sheriff-config"
+          docker run -d --name api-sheriff-smoke -p 19000:9000 \
+            -v "${CERTS}:/app/certificates:ro" \
+            -v "${CONFIG}:/app/sheriff-config:ro" \
+            -e QUARKUS_PROFILE=it \
+            -e SHERIFF_CONFIG_DIR=/app/sheriff-config \
+            -e QUARKUS_CONFIG_LOCATIONS=/app/certificates/benchmark-idp-trust.properties \
+            -e QUARKUS_HTTP_SSL_PORT=8444 \
+            -e QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/app/certificates/localhost.crt \
+            -e QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/app/certificates/localhost.key \
+            -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES=/app/certificates/localhost.crt \
+            -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_KEY_FILES=/app/certificates/localhost.key \
+            -e QUARKUS_TLS_DEFAULT_TRUST__STORE_P12_PATH=/app/certificates/localhost-truststore.p12 \
+            -e QUARKUS_TLS_DEFAULT_TRUST__STORE_P12_PASSWORD=localhost-trust \
+            -e OIDC_CLIENT_SECRET=smoke \
+            "$REF"
+
+          for _ in $(seq 1 60); do
+            if curl -fsSk https://127.0.0.1:19000/q/health/live > /dev/null; then
+              echo "Published image is live."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Published image did not become live within 120s."
+          docker logs api-sheriff-smoke
+          exit 1
+
+      # `|| true` is a deliberate guard, not sloppiness: this step runs on EVERY outcome, including
+      # the paths where the smoke step failed before `docker run` and there is nothing to remove.
+      # A teardown must never turn an otherwise-diagnosed failure into a second, misleading one.
+      - name: Tear down the smoke container
+        if: always()
+        run: |
+          docker rm -f api-sheriff-smoke || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,49 @@ jobs:
           echo "id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
           echo "Tested image ID: ${IMAGE_ID}"
 
+      # SBOM for the TESTED image, so it describes exactly what ships.
+      - name: Generate the SPDX SBOM for the tested image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.image.outputs.id }}
+          format: spdx-json
+          artifact-name: api-sheriff-${{ steps.config.outputs.current-version }}-sbom.spdx.json
+          upload-artifact: true
+          # The job holds `contents: read`; it must not attempt to attach assets to a GitHub release.
+          upload-release-assets: false
+
+      # THE GATE. A finding at HIGH **or** CRITICAL fails the job, and because this step sits ABOVE
+      # the `docker login` below, nothing has been pushed when it fires.
+      #
+      # The HIGH+CRITICAL threshold is deliberate, not a default: API Sheriff is a security-focused
+      # gateway, so the stricter posture is the point. Do not relax it to CRITICAL-only without an
+      # explicit, recorded decision.
+      #
+      # SCOPE HONESTY — what this scan can and cannot see. The image is the pinned distroless base
+      # plus exactly ONE layer: a statically linked GraalVM native executable
+      # (`COPY --chmod=0755 target/*-runner /app/application`). There are NO JARS IN THE IMAGE, so
+      # Trivy's Java analyzer finds nothing and this is in substance a scan of the pinned base
+      # image's OS packages. Java dependency CVEs are covered by the PR-lane filesystem scan in
+      # maven.yml and by the Sonar and Dependabot lanes — NOT here. A clean result here is not
+      # evidence of a clean dependency tree.
+      #
+      # ATTESTATION POSTURE, PINNED. This lane builds into the local image store (via the harness
+      # `docker compose build`) and then `docker tag` + `docker push`. It must NOT switch to
+      # `docker buildx build --push`: with buildx's default attestations a registry push produces a
+      # manifest LIST wrapping the image alongside provenance/SBOM attestations, and the top-level
+      # digest then addresses that list rather than the plain image manifest — which changes what the
+      # pull-by-digest smoke pulls and what Cosign signs. The current shape sidesteps the problem
+      # entirely rather than managing it.
+      - name: Scan the tested image (gating, HIGH and CRITICAL)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.id }}
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: 'false'
+          format: table
+
       # The registry path is HARDCODED LOWERCASE on purpose: ${{ github.repository }} yields
       # cuioss/API-Sheriff and GHCR rejects the uppercase, so deriving it from the context would fail
       # at push time.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       # pull-by-digest smoke pulls and what Cosign signs. The current shape sidesteps the problem
       # entirely rather than managing it.
       - name: Scan the tested image (gating, HIGH and CRITICAL)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ steps.image.outputs.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,19 @@ jobs:
 
       # Checked out into a side directory so the release-tag checkout below owns the workspace root
       # untouched. Only .github/project.yml is needed here.
+      #
+      # sparse-checkout-cone-mode MUST be false. Cone mode — the action's default — matches
+      # DIRECTORY entries only, so the single-file pattern below would match nothing and
+      # .release-config/.github/project.yml would simply not exist; the next step would then fail on
+      # a missing config for a reason that reads nothing like "sparse checkout mode". Non-cone mode
+      # applies gitignore-style patterns, which is what a single-file checkout needs.
       - name: Check out the release configuration
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           path: .release-config
           sparse-checkout: .github/project.yml
+          sparse-checkout-cone-mode: false
 
       - name: Read the released version
         id: config
@@ -106,7 +113,15 @@ jobs:
           cache: maven
 
       # THE STRUCTURAL GUARD that makes "image version identical to Maven version" a checked fact
-      # rather than an assumption. Fails loudly, before anything is built or pushed.
+      # rather than an assumption. Fails loudly, before anything is built or pushed TO GHCR.
+      #
+      # Scope of "before anything is pushed", stated precisely: this job runs AFTER `needs: [release]`,
+      # so the Maven Central publication has already happened by the time this assertion runs. It can
+      # therefore prevent a wrong IMAGE from being published; it cannot un-publish a jar. A failure
+      # anywhere in this job leaves a jars-only release — see release-process.adoc
+      # § "If the image lane fails after the Maven release" for the recovery procedure. Ordering this
+      # job before the release is not possible: the released version does not exist until the release
+      # job has cut it.
       - name: Assert the checked-out project version matches the released version
         env:
           RELEASED_VERSION: ${{ steps.config.outputs.current-version }}
@@ -158,7 +173,17 @@ jobs:
           upload-release-assets: false
 
       # THE GATE. A finding at HIGH **or** CRITICAL fails the job, and because this step sits ABOVE
-      # the `docker login` below, nothing has been pushed when it fires.
+      # the `docker login` below, nothing has been pushed TO GHCR when it fires. (The Maven artifacts
+      # were already published by the `release` job this one depends on — see the version-assertion
+      # step above for the partial-release scope and the recovery pointer.)
+      #
+      # `ignore-unfixed: 'false'` is deliberate, and it has a cost worth naming: an unfixed HIGH or
+      # CRITICAL CVE in the pinned base image blocks EVERY release until the base is re-pinned to a
+      # patched digest — including CVEs with no upstream fix available at all. There is deliberately
+      # no `.trivyignore` in the tree today, because an empty suppression file invites silent
+      # additions. The sanctioned escape hatch is documented in release-process.adoc
+      # § "If the scan blocks on an unfixable base-image CVE"; take it there, with a recorded
+      # justification, rather than relaxing this threshold.
       #
       # The HIGH+CRITICAL threshold is deliberate, not a default: API Sheriff is a security-focused
       # gateway, so the stricter posture is the point. Do not relax it to CRITICAL-only without an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,12 @@ jobs:
       # explicit, recorded decision.
       #
       # SCOPE HONESTY — what this scan can and cannot see. The image is the pinned distroless base
-      # plus exactly ONE layer: a statically linked GraalVM native executable
-      # (`COPY --chmod=0755 target/*-runner /app/application`). There are NO JARS IN THE IMAGE, so
+      # plus exactly ONE layer: a GraalVM native executable
+      # (`COPY --chmod=0755 target/*-runner /app/application`). It is dynamically linked — no
+      # --static and no --libc=musl is configured in quarkus.native.additional-build-args — which is
+      # why the base is the glibc-bearing quarkus-distroless-image rather than scratch. The
+      # load-bearing property is not how it is linked but that it carries NO PACKAGE METADATA AND NO
+      # JARS, so
       # Trivy's Java analyzer finds nothing and this is in substance a scan of the pinned base
       # image's OS packages. Java dependency CVEs are covered by the PR-lane filesystem scan in
       # maven.yml and by the Sonar and Dependabot lanes — NOT here. A clean result here is not

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,9 +192,14 @@ jobs:
       # The registry path is HARDCODED LOWERCASE on purpose: ${{ github.repository }} yields
       # cuioss/API-Sheriff and GHCR rejects the uppercase, so deriving it from the context would fail
       # at push time.
+      # Credentials reach the shell through the environment, never through `${{ }}` expansion inside
+      # the script body — expression interpolation into a run block is a script-injection sink.
       - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Tag and push both release tags
         env:
@@ -294,6 +299,33 @@ jobs:
           echo "::error::Published image did not become live within 120s."
           docker logs api-sheriff-smoke
           exit 1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # KEYLESS OIDC SIGNING, BY DIGEST — the last act of the lane, after the push and after the
+      # smoke, so the signed artifact is provably the tested and published one. Never sign a tag: a
+      # tag is a mutable pointer, so signing one signs nothing durable. The signature is stored in
+      # the registry alongside the image (the Sigstore sha256-<digest>.sig convention); there is no
+      # key store, no COSIGN_PRIVATE_KEY and no new secret. `id-token: write` is declared on this job.
+      #
+      # A CONSUMER VERIFIES WITH EXACTLY THESE TWO VALUES. Both are derived from THIS job's identity
+      # and will change silently if this workflow file is renamed or a release is dispatched from a
+      # ref other than main:
+      #
+      #   --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      #   --certificate-identity    https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main
+      #
+      # The identity names release.yml ITSELF, not the org reusable workflow, because publish-image
+      # is a local job in this caller. doc/user/container-image.adoc publishes the same two strings
+      # to operators; this comment is what keeps the two copies from drifting.
+      #
+      # SLSA provenance and any further attestation are deliberately out of scope.
+      - name: Sign the published digest (keyless)
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+        run: |
+          cosign sign --yes "ghcr.io/cuioss/api-sheriff@${DIGEST}"
 
       # `|| true` is a deliberate guard, not sloppiness: this step runs on EVERY outcome, including
       # the paths where the smoke step failed before `docker run` and there is nothing to remove.

--- a/api-sheriff/.dockerignore
+++ b/api-sheriff/.dockerignore
@@ -1,0 +1,19 @@
+# Build-context allowlist for api-sheriff/ — the ONE build context this project uses.
+#
+# Docker reads .dockerignore from the build-context ROOT, and the context is api-sheriff/:
+# integration-tests/docker-compose.yml declares `context: ../api-sheriff`, and the production build
+# is `docker build -f api-sheriff/src/main/docker/Dockerfile.native ... api-sheriff/`. A root-level
+# .dockerignore would be inert for every build this project performs.
+#
+# This is an ALLOWLIST, not a denylist: everything is excluded, then exactly the one artifact the
+# Dockerfile consumes (COPY --chmod=0755 target/*-runner /app/application) is re-included. Nothing
+# that is not the native runner binary can reach the daemon by accident, now or after a future file
+# lands under api-sheriff/. Re-including a path inside an excluded DIRECTORY requires the stepwise
+# form below — `!target` alone would not let `target/*-runner` through.
+#
+# The Dockerfile itself is transferred independently of the context, so excluding src/ does not make
+# src/main/docker/Dockerfile.native unreadable.
+**
+!target
+target/*
+!target/*-runner

--- a/api-sheriff/src/main/docker/Dockerfile.native
+++ b/api-sheriff/src/main/docker/Dockerfile.native
@@ -1,12 +1,21 @@
 # Production Dockerfile for API Sheriff native executable
 # Distroless: no shell, no package manager — minimal attack surface
 # No baked-in certificates — mount TLS certs at runtime via volumes or secrets
-# Health probes via management interface (port 9000, plain HTTP)
+# Health probes via the management interface on port 9000 — that interface has exactly ONE port
+# (no ssl-port, no insecure-requests), and its scheme is deployment-bound: HTTPS by default once the
+# deployment supplies QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES / _KEY_FILES (ADR-0025), with plain
+# HTTP reachable only through the named opt-out
+# quarkus.management.tls-configuration-name=plain-management.
 FROM quay.io/quarkus/quarkus-distroless-image:2.0@sha256:0278fd70d9627df836295570da0fd22034ea664efc12a834a0532cea7556a87b
+
+# Supplied by the build (docker compose build.args.APP_VERSION). The `dev` default is deliberate and
+# honest: a locally or PR-built image is never published, and a version-shaped default would lie the
+# moment the project version moved. The release lane exports the released version into this arg.
+ARG APP_VERSION=dev
 
 LABEL org.opencontainers.image.title="API Sheriff"
 LABEL org.opencontainers.image.description="Security-focused API Gateway — Quarkus native executable"
-LABEL org.opencontainers.image.version="0.1.0-SNAPSHOT"
+LABEL org.opencontainers.image.version="${APP_VERSION}"
 LABEL org.opencontainers.image.vendor="CUIoss"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/cuioss/API-Sheriff"

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -77,6 +77,16 @@ built* and *how the parts fit together*.
   guide] (configuring passthrough SNI / mTLS and the trust-root-replacement blast radius), and the
   link:development/tls-edge.adoc[developer topic] (front-listener architecture, the L4/L7 split, and
   the fail-closed GW-06 rationale).
+
+| Container Image (three-layer topic)
+| The published image at `ghcr.io/cuioss/api-sheriff`, documented across all three layers. The
+  reference layer is this statement: the image is a *packaging* of the same binary the
+  link:architecture.adoc[Architecture] already describes, so it adds no runtime component, no
+  request-lifecycle stage and no `gateway.yaml` key -- neither that document nor
+  link:configuration.adoc[Configuration] has a surface for it. The
+  link:user/container-image.adoc[operator guide] covers pulling, running and cryptographically
+  verifying the image, and the link:development/release-process.adoc[release-artifact policy]
+  covers the artifact set, the two-tag scheme, and why the image version equals the Maven version.
 |===
 
 == Deployment Variants

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -39,9 +39,12 @@ This tree is seeded here and grows as contributor-facing material lands.
 
 | link:release-process.adoc[Release Process -- dispatch-only]
 | How a release is cut -- declare the version in `.github/project.yml`, then deliberately dispatch
-  the Release workflow -- and why the `pull_request` trigger was removed after the 2026-07-12
-  accidental release, including the base-branch workflow-evaluation rule that forced the guard to
-  merge first.
+  the Release workflow -- what one dispatch produces (Maven coordinates, the GHCR image, its SBOM
+  and its Cosign signature), why the image version is a checked fact rather than a convention, the
+  test-which-builds/push-that-digest inversion that makes "push exactly what was tested" true by
+  construction, the two-tag scheme and the deliberate absence of `:latest`, and why the
+  `pull_request` trigger was removed after the 2026-07-12 accidental release, including the
+  base-branch workflow-evaluation rule that forced the guard to merge first.
 
 | link:protocol-processors.adoc[Protocol Processors -- SPI and dispatch seam]
 | The `ProtocolProcessor` SPI, the boot-time registry that binds a protocol to its processor, and

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -25,6 +25,100 @@ link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] delega
 cuioss-organization reusable Maven release workflow, pinned to a specific commit SHA. Neither the
 pin nor the `secrets:` block is part of the release decision -- they are build wiring.
 
+== What a release contains
+
+One dispatch produces one coherent set of artifacts, all carrying the same version:
+
+* *Maven coordinates on Maven Central* -- `de.cuioss.sheriff.gateway:api-sheriff` and its reactor
+  siblings, published by the reusable release workflow.
+* *A container image on GHCR* -- `ghcr.io/cuioss/api-sheriff`, built from the released source tree.
+* *An SPDX SBOM* for that image, retained as an artifact of the release run.
+* *A Cosign signature* over that image's digest, stored in the registry next to the image.
+
+A Helm chart and a Compose deployment sample are *explicitly out of scope* until the deployment
+artifacts change (PLAN-27) lands. They are named here so their absence reads as a known gap rather
+than an oversight.
+
+=== The image version is the Maven version
+
+The image is a packaging of the same released source tree, not a separately versioned product, so
+`ghcr.io/cuioss/api-sheriff:<version>` carries the Maven version verbatim. An operator who knows the
+Maven version must be able to derive the image reference without consulting a mapping table, and a
+divergence would make "which image contains fix X" unanswerable from the release notes alone.
+
+This is a checked fact rather than a convention. The publish job checks out the release tag the
+Maven release pushed, reads `current-version` from link:../../.github/project.yml[`.github/project.yml`]
+with the same pinned action the release job used, and asserts that the checked-out `project.version`
+equals it. A mismatch fails the release before anything is built or pushed.
+
+=== One build, and why the step order is inverted
+
+link:../../integration-tests/pom.xml[`integration-tests/pom.xml`] binds
+`docker compose build api-sheriff` to `pre-integration-test`, so the integration-test harness always
+builds the image. The publish lane is therefore ordered *test-which-builds, then
+push-that-digest* rather than the more obvious build, test, push: the harness build is the one and
+only image build in the lane, and the image it produced is the one that gets tagged, pushed and
+signed.
+
+The inversion exists so that "push exactly what was tested" holds *by construction*. There is only
+one build, so there is nothing that can drift between the tested artifact and the published one.
+
+[IMPORTANT]
+====
+Do not "correct" this back. Adding a second `docker build` to the publish lane, or adding a
+skip-guard to `integration-tests/pom.xml` so the harness stops building, reintroduces exactly the
+drift the inversion removes -- and the drift is silent, because both builds succeed.
+====
+
+=== Scan and signature guarantees
+
+* *Trivy gates the release at HIGH and CRITICAL.* A finding at either severity fails the job, and
+  the gate runs before the registry login, so nothing has been pushed when it fires. The threshold
+  is deliberately stricter than a CRITICAL-only gate: API Sheriff is a security-focused gateway.
+* *A Syft SBOM is produced for the same image* the gate scanned, and retained as an artifact of the
+  release run.
+* *The image is Cosign-signed keylessly, by digest*, under the workflow's GitHub OIDC identity. No
+  key material and no new secret is involved. A tag is a mutable pointer, so signing one would sign
+  nothing durable.
+
+The image scan is narrower than it looks. The image is the pinned distroless base plus one
+statically linked native executable and contains no jars, so it is in substance a scan of the base
+image's OS packages. Java dependency findings come from the pull-request supply-chain scan and from
+the Sonar and Dependabot lanes, not from here.
+
+=== One-time action after the first release
+
+A GHCR package created by a `GITHUB_TOKEN` push is *private by default*, and the in-workflow smoke
+step pulls with the job's own credentials, so it cannot detect this. The release checklist therefore
+carries one manual step:
+
+. After the *first* release, open the organisation's package settings and set the `api-sheriff`
+  package to *public*.
+
+Until that is done every check stays green while `docker pull` fails for everyone outside the
+organisation.
+
+== Container image tags
+
+Every release publishes exactly *two* tags, both resolving to the same tested digest.
+
+`ghcr.io/cuioss/api-sheriff:<version>`::
+The human-facing release reference. `<version>` is the Maven version, verbatim.
+
+`ghcr.io/cuioss/api-sheriff:sha-<commit>`::
+Immutable provenance. `<commit>` is the *full 40-character SHA of the commit the release tag points
+at* -- the `release:prepare` commit whose poms carry the released version -- and *not* the `main`
+HEAD the release was dispatched from. That is the commit whose source produced the image; naming the
+dispatch commit would point at a tree that never built it.
+
+*No floating `:latest` tag is published at pre-1.0*, and that is a decision rather than an omission.
+A floating tag invites an unpinned production pull whose contents change under the operator, which
+is precisely the posture a security-focused gateway should not encourage. Operators pin by version,
+or by digest for production.
+
+link:../user/container-image.adoc[The container image guide] covers pulling, running and
+cryptographically verifying the published image.
+
 == Why the pull_request trigger was removed
 
 The workflow previously also carried a `pull_request` trigger scoped to `types: [closed]` and
@@ -77,4 +171,5 @@ is gone from `main` before relying on it being gone.
 * link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] -- the dispatch-only
   release workflow.
 * link:../../.github/project.yml[`.github/project.yml`] -- where the released version is declared.
+* link:../user/container-image.adoc[Container Image] -- the operator layer for the published image.
 * link:README.adoc[Contributor Guide] -- the index for this documentation layer.

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -51,7 +51,34 @@ divergence would make "which image contains fix X" unanswerable from the release
 This is a checked fact rather than a convention. The publish job checks out the release tag the
 Maven release pushed, reads `current-version` from link:../../.github/project.yml[`.github/project.yml`]
 with the same pinned action the release job used, and asserts that the checked-out `project.version`
-equals it. A mismatch fails the release before anything is built or pushed.
+equals it. A mismatch fails the release before the image is built or pushed to GHCR.
+
+[#release-not-atomic]
+=== The release is NOT atomic
+
+The `publish-image` job declares `needs: [release]`, so *the Maven Central publication has already
+happened* by the time any image step runs. This is not an oversight and cannot be reordered away:
+the released version does not exist until the release job has cut it, so nothing about the image can
+be validated beforehand.
+
+The consequence is worth stating plainly rather than discovering during an incident. A failure in
+the integration-test suite, the SBOM step, the Trivy gate, the registry push, the smoke test or the
+Cosign signature leaves a *partial release*: the jars are on Maven Central and are irrevocable,
+while no image, or an unsigned image, exists in GHCR. Everywhere this document or the workflow says
+a step runs "before anything is pushed", read it as *before anything is pushed to GHCR*.
+
+==== If the image lane fails after the Maven release
+
+. *Do not re-run the whole workflow.* A second dispatch would attempt another Maven release of a
+  version that is already published.
+. Fix the cause on `main` and merge it.
+. Re-run the failed `publish-image` job alone from the Actions UI (*Re-run failed jobs*). It reads
+  its version from `.github/project.yml` at the dispatch SHA and checks out the release tag, so it
+  reproduces the same inputs without touching Maven Central.
+. If the failure was the Trivy gate on an unfixable base-image CVE, see
+  <<unfixable-base-image-cve>> before re-running.
+. If the version has to be abandoned, follow the relocation-stub precedent set on 2026-07-12: cut a
+  patch version and publish relocation stubs. Maven Central artifacts are never deleted.
 
 === One build, and why the step order is inverted
 
@@ -75,8 +102,9 @@ drift the inversion removes -- and the drift is silent, because both builds succ
 === Scan and signature guarantees
 
 * *Trivy gates the release at HIGH and CRITICAL.* A finding at either severity fails the job, and
-  the gate runs before the registry login, so nothing has been pushed when it fires. The threshold
-  is deliberately stricter than a CRITICAL-only gate: API Sheriff is a security-focused gateway.
+  the gate runs before the registry login, so nothing has been pushed to GHCR when it fires (the
+  Maven artifacts are already out -- see <<release-not-atomic>>). The threshold is
+  deliberately stricter than a CRITICAL-only gate: API Sheriff is a security-focused gateway.
 * *A Syft SBOM is produced for the same image* the gate scanned, and retained as an artifact of the
   release run.
 * *The image is Cosign-signed keylessly, by digest*, under the workflow's GitHub OIDC identity. No
@@ -87,6 +115,31 @@ The image scan is narrower than it looks. The image is the pinned distroless bas
 executable and contains no jars, so it is in substance a scan of the base image's OS packages -- and
 the SBOM, cataloguing that same image, carries exactly the same scope. Java dependency findings come
 from the pull-request supply-chain scan and from the Sonar and Dependabot lanes, not from here.
+
+[#unfixable-base-image-cve]
+=== If the scan blocks on an unfixable base-image CVE
+
+The gate runs with `ignore-unfixed: 'false'`, so it fails on HIGH and CRITICAL findings *including
+those with no upstream fix available*. Combined with a digest-pinned base image, that means a
+release can become blocked by a CVE in a layer this repository does not control and cannot patch.
+
+That is the intended default -- an unfixable CVE in the shipped base is a fact an operator deserves
+to know about, not something to route around silently. But it must have a sanctioned escape hatch,
+or the first occurrence turns into an ad-hoc threshold relaxation under release pressure.
+
+In order of preference:
+
+. *Re-pin the base image* to a newer digest that carries the fix. This resolves the finding rather
+  than hiding it, and is almost always available for a distroless base.
+. *If, and only if, no fixed base exists*, add a `.trivyignore` at the repository root with one
+  entry per CVE, each carrying a comment recording the CVE id, why it is not exploitable in this
+  image, who accepted it and the date. Trivy picks the file up automatically. There is deliberately
+  no `.trivyignore` in the tree today: an empty suppression file is an invitation to append to it
+  without the accompanying justification.
+
+Never relax `severity` or flip `exit-code` to `'0'` to get a release out. Those change the gate for
+every future release; a `.trivyignore` entry is scoped to the specific finding and is visible in
+review.
 
 === One-time action after the first release
 
@@ -108,10 +161,16 @@ Every release publishes exactly *two* tags, both resolving to the same tested di
 The human-facing release reference. `<version>` is the Maven version, verbatim.
 
 `ghcr.io/cuioss/api-sheriff:sha-<commit>`::
-Immutable provenance. `<commit>` is the *full 40-character SHA of the commit the release tag points
-at* -- the `release:prepare` commit whose poms carry the released version -- and *not* the `main`
-HEAD the release was dispatched from. That is the commit whose source produced the image; naming the
-dispatch commit would point at a tree that never built it.
+*Provenance, not immutability.* `<commit>` is the *full 40-character SHA of the commit the release
+tag points at* -- the `release:prepare` commit whose poms carry the released version -- and *not* the
+`main` HEAD the release was dispatched from. That is the commit whose source produced the image;
+naming the dispatch commit would point at a tree that never built it. The tag answers "which source
+produced this?" unambiguously, but it remains an ordinary mutable registry tag and is not the image
+digest -- which is exactly why Cosign signs the digest rather than either tag.
+
+*Neither tag is a deployment pin.* Only `ghcr.io/cuioss/api-sheriff@sha256:...` is immutable; both
+tags above can be repointed at the registry. Operator guidance for resolving and deploying the
+digest is in link:../user/container-image.adoc[the container image guide].
 
 *No floating `:latest` tag is published at pre-1.0*, and that is a decision rather than an omission.
 A floating tag invites an unpinned production pull whose contents change under the operator, which

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -39,6 +39,8 @@ A Helm chart and a Compose deployment sample are *explicitly out of scope* until
 artifacts change (PLAN-27) lands. They are named here so their absence reads as a known gap rather
 than an oversight.
 
+image::../resources/diagrams/release-publish-flow.svg[Release publish flow -- one dispatch drives the Maven release and a single image build whose output is scanned, pushed, smoked and signed, while an independent non-gating pull-request lane scans the pinned base image and the repository filesystem, align=center]
+
 === The image version is the Maven version
 
 The image is a packaging of the same released source tree, not a separately versioned product, so

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -83,10 +83,10 @@ drift the inversion removes -- and the drift is silent, because both builds succ
   key material and no new secret is involved. A tag is a mutable pointer, so signing one would sign
   nothing durable.
 
-The image scan is narrower than it looks. The image is the pinned distroless base plus one
-statically linked native executable and contains no jars, so it is in substance a scan of the base
-image's OS packages. Java dependency findings come from the pull-request supply-chain scan and from
-the Sonar and Dependabot lanes, not from here.
+The image scan is narrower than it looks. The image is the pinned distroless base plus one native
+executable and contains no jars, so it is in substance a scan of the base image's OS packages -- and
+the SBOM, cataloguing that same image, carries exactly the same scope. Java dependency findings come
+from the pull-request supply-chain scan and from the Sonar and Dependabot lanes, not from here.
 
 === One-time action after the first release
 

--- a/doc/resources/diagrams/release-publish-flow.svg
+++ b/doc/resources/diagrams/release-publish-flow.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Release publish flow — two independent tracks: the release lane (one dispatch, one image build,
+  everything downstream addressing that one image) and the pull-request lane (an independent,
+  non-gating early signal). The two tracks deliberately never converge.
+  theme-handling: A (theme-neutral)
+  see  pm-documents:ref-svg-diagrams/standards/diagram-type-flow.md
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1160 400"
+     role="img" aria-labelledby="title desc"
+     font-family="ui-sans-serif, -apple-system, system-ui, 'Segoe UI', sans-serif">
+  <title id="title">API Sheriff release publish flow</title>
+  <desc id="desc">Two independent tracks. On the release lane, a manual workflow_dispatch cuts the Maven release, the publish job checks out the release tag and asserts the version, and the integration-test suite runs — that suite's docker compose build is the ONE and ONLY image build in the lane, so what is published is by construction exactly what was tested. A Syft SBOM and a gating Trivy scan at HIGH and CRITICAL then run before any registry write; a finding at either severity fails the release. Only then are the two tags pushed, the published digest pulled back and asserted identical to the tested image, and that same digest signed keylessly with Cosign. On the pull-request lane, an independent non-gating scan of the pinned base image and the repository filesystem reports on every change without ever building an image or failing the check. The two lanes never converge.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow-fill"/>
+    </marker>
+    <style>
+      .lane       { font-size: 15px; font-weight: 600; fill: #6e7681; text-anchor: start; }
+      .stage      { font-size: 13px; font-weight: 600; fill: #6e7681; text-anchor: middle; }
+      .sub        { font-size: 11px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+      .note       { font-size: 11px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+      .stroke     { stroke: #6e7681; stroke-width: 1.2; fill: none; }
+      .track      { stroke: #6e7681; stroke-width: 1.5; fill: none; }
+      .arrow-fill { fill: #6e7681; }
+      .dash       { stroke: #6e7681; stroke-width: 0.6; stroke-dasharray: 3 3; fill: none; }
+      .caption    { font-size: 12px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+    </style>
+  </defs>
+
+  <!-- ============================ release lane ============================ -->
+  <text x="580" y="24" class="note">Manual dispatch is the only trigger &#8212; no event-driven trigger exists on the release workflow</text>
+  <text x="20" y="54" class="lane">Release lane</text>
+
+  <!-- track line (passes through every stage) -->
+  <circle cx="20" cy="136" r="4" class="stroke"/>
+  <line class="track" x1="20" y1="136" x2="1130" y2="136" marker-end="url(#arrow)"/>
+
+  <!-- event stages (h 60) -->
+  <rect class="stroke" x="30"  y="106" width="110" height="60" rx="6"/>
+  <rect class="stroke" x="302" y="106" width="110" height="60" rx="6"/>
+  <rect class="stroke" x="710" y="106" width="110" height="60" rx="6"/>
+  <rect class="stroke" x="846" y="106" width="110" height="60" rx="6"/>
+  <rect class="stroke" x="982" y="106" width="110" height="60" rx="6"/>
+  <!-- process stages (taller: work that takes time) -->
+  <rect class="stroke" x="166" y="98" width="110" height="76" rx="6"/>
+  <rect class="stroke" x="438" y="98" width="110" height="76" rx="6"/>
+  <!-- decision stage: the gate -->
+  <path class="stroke" d="M574,136 L629,98 L684,136 L629,174 Z"/>
+
+  <!-- stage labels (above the track) -->
+  <text x="85"   y="88" class="stage">Dispatch</text>
+  <text x="221"  y="88" class="stage">Maven release</text>
+  <text x="357"  y="88" class="stage">Check out tag</text>
+  <text x="493"  y="88" class="stage">IT suite</text>
+  <text x="629"  y="88" class="stage">SBOM + scan</text>
+  <text x="765"  y="88" class="stage">Tag &amp; push</text>
+  <text x="901"  y="88" class="stage">Smoke</text>
+  <text x="1037" y="88" class="stage">Cosign sign</text>
+
+  <!-- stage sub-detail (below the track) -->
+  <text x="85"   y="192" class="sub">operator-initiated</text>
+  <text x="221"  y="192" class="sub">pushes the release tag</text>
+  <text x="357"  y="192" class="sub">assert version match</text>
+  <text x="493"  y="192" class="sub">THE one image build</text>
+  <text x="629"  y="192" class="sub">gate: HIGH + CRITICAL</text>
+  <text x="765"  y="192" class="sub">two tags, one digest</text>
+  <text x="901"  y="192" class="sub">pulled ID = tested ID</text>
+  <text x="1037" y="192" class="sub">keyless, by digest</text>
+
+  <!-- ======================= lane separator (never converge) ======================= -->
+  <line class="dash" x1="20" y1="216" x2="1130" y2="216"/>
+
+  <!-- ============================ pull-request lane ============================ -->
+  <text x="20" y="240" class="lane">Pull-request lane</text>
+
+  <circle cx="20" cy="316" r="4" class="stroke"/>
+  <line class="track" x1="20" y1="316" x2="1000" y2="316" marker-end="url(#arrow)"/>
+
+  <rect class="stroke" x="30"  y="288" width="110" height="56" rx="6"/>
+  <rect class="stroke" x="302" y="288" width="110" height="56" rx="6"/>
+  <rect class="stroke" x="574" y="288" width="110" height="56" rx="6"/>
+  <rect class="stroke" x="846" y="288" width="110" height="56" rx="6"/>
+
+  <text x="85"  y="272" class="stage">Every change</text>
+  <text x="357" y="272" class="stage">Base image scan</text>
+  <text x="629" y="272" class="stage">Filesystem scan</text>
+  <text x="901" y="272" class="stage">Report only</text>
+
+  <text x="85"  y="362" class="sub">no image build</text>
+  <text x="357" y="362" class="sub">pinned digest, read from the Dockerfile</text>
+  <text x="629" y="362" class="sub">where Java dependency CVEs surface</text>
+  <text x="901" y="362" class="sub">exit-code 0 &#8212; never fails the check</text>
+
+  <!-- footer caption: the load-bearing idea -->
+  <text x="580" y="390" class="caption">One build feeds everything downstream on the release track; the pull-request track is an independent early signal. The two never converge.</text>
+</svg>

--- a/doc/user/README.adoc
+++ b/doc/user/README.adoc
@@ -69,6 +69,14 @@ layer.
   enumerated deployment-bound variables (ports, certificate and trust material, the management TLS
   selection), and an audit of where else the codebase offers a secure default with an override
   route. Read it before assuming an environment variable can change a given behaviour.
+
+| link:container-image.adoc[Container Image -- Pulling, Running and Verifying]
+| The operator layer for the published image at `ghcr.io/cuioss/api-sheriff`: the two-tag scheme and
+  why no `:latest` exists, a `docker run` that reflects what the artifact actually requires (a
+  mounted configuration directory, deployment-supplied certificate material, and the
+  `QUARKUS_HTTP_SSL_PORT` move under `tls.passthrough_sni`), what the SBOM and the HIGH+CRITICAL
+  vulnerability scan do and do not guarantee, and the complete `cosign verify` recipe with both
+  mandatory flags. Links to the release process for the artifact policy.
 |===
 
 == Scope of This Layer

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -21,24 +21,37 @@ The human-facing release reference -- use it when you want the reference to read
 notes.
 
 `ghcr.io/cuioss/api-sheriff:sha-<commit>`::
-Immutable provenance. `<commit>` is the full 40-character SHA of the commit the release tag points
-at. Use it when you need an unambiguous, provably-immutable reference.
+*Provenance, not immutability.* `<commit>` is the full 40-character SHA of the commit the release
+tag points at, so this tag answers "which source produced this image?" unambiguously. It is still an
+ordinary registry tag: nothing at the registry prevents it from being repointed, and it is not the
+image digest. Use it to trace an image back to its source -- not as a deployment pin.
 
 *There is no `:latest` tag, and that is deliberate -- the registry is not broken.* Pin by version,
 or by digest for production. The decision and the reasoning behind it are recorded once, in
 link:../development/release-process.adoc#_container_image_tags[the release-artifact policy].
 
-[TIP]
+[IMPORTANT]
 ====
-*For production, pin by digest.* Resolve it once and record it:
+*Only `ghcr.io/cuioss/api-sheriff@sha256:...` is immutable.* Both tags above are mutable by
+construction; a digest is the content address and cannot be repointed. For production, resolve the
+digest once and deploy that:
 
 [source,bash]
 ----
 docker pull ghcr.io/cuioss/api-sheriff:<version>
-docker image inspect --format '{{index .RepoDigests 0}}' ghcr.io/cuioss/api-sheriff:<version>
+
+# Filter for THIS repository and require exactly one match. `docker image inspect` reports
+# RepoDigests as a list whose order is not defined, and an image pulled from, or pushed to, more
+# than one repository has more than one entry -- so `{{index .RepoDigests 0}}` can silently hand you
+# a digest belonging to a different repository. The release workflow applies the same filter-and-
+# assert-one rule when it resolves the digest it signs.
+DIGEST="$(docker image inspect \
+  --format '{{range .RepoDigests}}{{println .}}{{end}}' ghcr.io/cuioss/api-sheriff:<version> \
+  | grep '^ghcr\.io/cuioss/api-sheriff@' | sort -u)"
+[ "$(printf '%s\n' "$DIGEST" | grep -c .)" -eq 1 ] || { echo "expected exactly one digest, got: $DIGEST"; exit 1; }
 ----
 
-Then deploy `ghcr.io/cuioss/api-sheriff@sha256:...`. A digest cannot be repointed; a tag can.
+Then deploy `"${DIGEST}"` verbatim.
 ====
 
 [NOTE]
@@ -91,7 +104,32 @@ docker run -d --name api-sheriff \
   ghcr.io/cuioss/api-sheriff:<version>
 ----
 
-`--cap-drop=ALL` and `--security-opt=no-new-privileges` are in the recipe rather than in a footnote
+The recipe above is the *terminating* deployment -- Quarkus itself terminates TLS on 8443. If your
+`gateway.yaml` declares `tls.passthrough_sni`, the SNI front listener takes 8443 and the terminated
+listener must move, or the two collide on the same port at start-up. Add one variable:
+
+[source,bash]
+----
+docker run -d --name api-sheriff \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  -p 8443:8443 -p 9000:9000 \
+  -v /etc/api-sheriff/config:/app/sheriff-config:ro \
+  -v /etc/api-sheriff/certs:/app/certificates:ro \
+  -e SHERIFF_CONFIG_DIR=/app/sheriff-config \
+  -e QUARKUS_HTTP_SSL_PORT=8444 \
+  -e QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/app/certificates/server.crt \
+  -e QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/app/certificates/server.key \
+  -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES=/app/certificates/server.crt \
+  -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_KEY_FILES=/app/certificates/server.key \
+  ghcr.io/cuioss/api-sheriff:<version>
+----
+
+`QUARKUS_HTTP_SSL_PORT=8444` is deliberately *absent* from the terminating recipe rather than set in
+both: on a terminating deployment it would move the listener off the port `-p 8443:8443` publishes,
+and the container would come up serving nothing on 8443.
+
+`--cap-drop=ALL` and `--security-opt=no-new-privileges` are in both recipes rather than in a footnote
 because the artifact needs neither: it runs as `nonroot`, binds only the unprivileged ports 8443 and
 9000, and, being distroless, contains no setuid binary that a privilege escalation could reach.
 Dropping both is free here, so there is no reason to run without them.
@@ -137,8 +175,13 @@ Resolve the digest once, verify it, and deploy it:
 [source,bash]
 ----
 docker pull ghcr.io/cuioss/api-sheriff:<version>
-DIGEST="$(docker image inspect --format '{{index .RepoDigests 0}}' \
-  ghcr.io/cuioss/api-sheriff:<version>)"
+
+# Same filter-and-assert-one rule as the digest-pinning recipe above -- RepoDigests is unordered and
+# may carry entries for other repositories, so never take element 0 on faith.
+DIGEST="$(docker image inspect \
+  --format '{{range .RepoDigests}}{{println .}}{{end}}' ghcr.io/cuioss/api-sheriff:<version> \
+  | grep '^ghcr\.io/cuioss/api-sheriff@' | sort -u)"
+[ "$(printf '%s\n' "$DIGEST" | grep -c .)" -eq 1 ] || { echo "expected exactly one digest, got: $DIGEST"; exit 1; }
 
 cosign verify \
   --certificate-identity https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main \
@@ -146,9 +189,9 @@ cosign verify \
   "${DIGEST}"
 ----
 
-`docker image inspect` reports `RepoDigests` as a fully-qualified
-`ghcr.io/cuioss/api-sheriff@sha256:...` reference, so the resolved value is passed to `cosign` and to
-your deployment manifest unchanged.
+`RepoDigests` entries are fully-qualified `ghcr.io/cuioss/api-sheriff@sha256:...` references, so the
+resolved value is passed to `cosign` and to your deployment manifest unchanged -- verify and deploy
+the same string.
 
 Both flags are mandatory, and each pins a different half of the claim:
 

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -1,0 +1,161 @@
+= API Sheriff -- Container Image: Pulling, Running and Verifying
+:toc:
+:toclevels: 2
+:sectnums:
+
+An operator guide to the published container image: *which tag to use*, *how to run it* with the
+configuration the artifact genuinely requires, *what the SBOM and the vulnerability scan do and do
+not guarantee*, and *how to cryptographically verify the image before deploying it*.
+
+The image lives at `ghcr.io/cuioss/api-sheriff`. Its version is always identical to the Maven
+version -- the image is a packaging of the same released source tree, not a separately versioned
+product, and the release lane asserts the identity rather than assuming it. The policy behind that
+guarantee is recorded in link:../development/release-process.adoc[the release process].
+
+== Which tag to use
+
+Every release publishes exactly two tags, both resolving to the same tested digest.
+
+`ghcr.io/cuioss/api-sheriff:<version>`::
+The human-facing release reference -- use it when you want the reference to read like the release
+notes.
+
+`ghcr.io/cuioss/api-sheriff:sha-<commit>`::
+Immutable provenance. `<commit>` is the full 40-character SHA of the commit the release tag points
+at. Use it when you need an unambiguous, provably-immutable reference.
+
+*There is no `:latest` tag, and that is deliberate -- the registry is not broken.* A floating tag
+invites an unpinned production pull whose contents change under you, which is not a posture a
+security gateway should encourage.
+
+[TIP]
+====
+*For production, pin by digest.* Resolve it once and record it:
+
+[source,bash]
+----
+docker pull ghcr.io/cuioss/api-sheriff:<version>
+docker image inspect --format '{{index .RepoDigests 0}}' ghcr.io/cuioss/api-sheriff:<version>
+----
+
+Then deploy `ghcr.io/cuioss/api-sheriff@sha256:...`. A digest cannot be repointed; a tag can.
+====
+
+[NOTE]
+====
+*If `docker pull` fails with a not-found or authentication error immediately after a release*, the
+GHCR package is most likely still private: a package created by a `GITHUB_TOKEN` push is private by
+default, and the in-workflow smoke test pulls with its own credentials so it cannot detect this. The
+fix is a one-time maintainer action recorded on the release checklist -- set the `api-sheriff`
+package to public in the organisation's package settings.
+====
+
+== Pull and run
+
+The image is distroless: it carries no shell and no package manager, and it runs as `nonroot`. It
+ships a statically linked native executable and nothing else.
+
+[source,bash]
+----
+docker pull ghcr.io/cuioss/api-sheriff:<version>
+----
+
+Running it takes more than a bare `docker run`, because the artifact has real prerequisites:
+
+* *A mounted configuration directory is mandatory.* `sheriff.config.dir` is a relative path that
+  resolves inside the image, so a container started without a mounted `gateway.yaml` tree *fails
+  fast* rather than serving on a partial configuration. Mount your configuration and point
+  `SHERIFF_CONFIG_DIR` at the mount.
+* *Certificate material is deployment-supplied*, for the terminated listener and, separately, for
+  the management interface. The image bakes in no certificates by design.
+* *Two ports are published*: `8443` for application traffic and `9000` for the management interface
+  (health and metrics).
+* *`QUARKUS_HTTP_SSL_PORT` must be moved when your `gateway.yaml` declares `tls.passthrough_sni`.*
+  With passthrough enabled, the SNI front listener owns the public TLS port, so the terminated
+  Quarkus listener has to move off it -- set `QUARKUS_HTTP_SSL_PORT=8444` or the two collide on
+  8443 at start-up.
+
+[source,bash]
+----
+docker run -d --name api-sheriff \
+  -p 8443:8443 -p 9000:9000 \
+  -v /etc/api-sheriff/config:/app/sheriff-config:ro \
+  -v /etc/api-sheriff/certs:/app/certificates:ro \
+  -e SHERIFF_CONFIG_DIR=/app/sheriff-config \
+  -e QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/app/certificates/server.crt \
+  -e QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/app/certificates/server.key \
+  -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES=/app/certificates/server.crt \
+  -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_KEY_FILES=/app/certificates/server.key \
+  ghcr.io/cuioss/api-sheriff:<version>
+----
+
+The full deployment-bound knob set -- which values the deployment owns and which `gateway.yaml`
+owns -- is enumerated in link:environment-variable-overrides.adoc[Environment-variable overrides].
+The management interface's scheme, its single-port constraint and the plain-HTTP opt-out are
+covered in link:tls-edge.adoc[TLS Edge]; supplying the management certificate pair above makes
+port 9000 speak HTTPS, so health probes against it must speak TLS.
+
+== What the SBOM and the scan guarantee -- and what they do not
+
+Each release publishes an SPDX SBOM for the exact published image, and the release fails before
+anything is pushed if Trivy reports a finding at *HIGH or CRITICAL* on that same image.
+
+*Read the scan's scope honestly.* The image is the pinned distroless base plus exactly one layer: a
+statically linked native executable that carries no package metadata. There are no jars in the
+image, so an image scan is in substance a scan of the base image's OS packages. It is not a
+statement about the application's Java dependency tree.
+
+If you need a Java dependency inventory, *read the SBOM* -- do not infer it from a clean scan
+result. Java dependency findings are covered upstream by the project's per-pull-request
+supply-chain scan and by its Sonar and Dependabot lanes.
+
+== Verify the signature before deploying
+
+Every published digest is signed keylessly with Cosign, using the release workflow's GitHub OIDC
+identity. The signature is stored in the registry alongside the image; there is no key to
+distribute.
+
+[source,bash]
+----
+cosign verify \
+  --certificate-identity https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/cuioss/api-sheriff:<version>
+----
+
+Both flags are mandatory, and each pins a different half of the claim:
+
+`--certificate-identity`::
+*Who* signed it -- the exact workflow, in the exact repository, on the exact ref. Without it, any
+signature produced by any workflow anywhere would satisfy the check.
+
+`--certificate-oidc-issuer`::
+*Which identity provider* vouched for that identity. Without it, an identity string asserted by some
+other issuer would be accepted.
+
+Omitting either flag makes the verification meaningless: an unconstrained `cosign verify` accepts
+any Sigstore identity, so it proves only that *somebody* signed the artifact.
+
+On success, `cosign` prints the verification checks it applied and the signature payload, and exits
+zero:
+
+[source,text]
+----
+Verification for ghcr.io/cuioss/api-sheriff:<version> --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+----
+
+*A non-zero exit means the artifact must not be deployed.* Treat it as a supply-chain failure, not
+as a tooling problem to work around.
+
+== See also
+
+* link:../development/release-process.adoc[Release process] -- the release-artifact policy, the
+  two-tag scheme, and why the image version equals the Maven version.
+* link:environment-variable-overrides.adoc[Environment-variable overrides] -- the deployment-bound
+  knob set referenced above.
+* link:tls-edge.adoc[TLS Edge] -- TLS policy, passthrough SNI, mTLS, and the management interface.
+* link:README.adoc[Operator Guide] -- the index for this documentation layer.

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -78,6 +78,8 @@ Running it takes more than a bare `docker run`, because the artifact has real pr
 [source,bash]
 ----
 docker run -d --name api-sheriff \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
   -p 8443:8443 -p 9000:9000 \
   -v /etc/api-sheriff/config:/app/sheriff-config:ro \
   -v /etc/api-sheriff/certs:/app/certificates:ro \
@@ -88,6 +90,16 @@ docker run -d --name api-sheriff \
   -e QUARKUS_MANAGEMENT_SSL_CERTIFICATE_KEY_FILES=/app/certificates/server.key \
   ghcr.io/cuioss/api-sheriff:<version>
 ----
+
+`--cap-drop=ALL` and `--security-opt=no-new-privileges` are in the recipe rather than in a footnote
+because the artifact needs neither: it runs as `nonroot`, binds only the unprivileged ports 8443 and
+9000, and, being distroless, contains no setuid binary that a privilege escalation could reach.
+Dropping both is free here, so there is no reason to run without them.
+
+Two further controls are worth adding once validated against your deployment, and are left out of
+the recipe above only because their correct values are deployment-specific: a read-only root
+filesystem (`--read-only` plus a writable `--tmpfs /tmp`) and explicit memory and CPU limits
+(`--memory`, `--cpus`). Both belong in any production orchestration manifest.
 
 The full deployment-bound knob set -- which values the deployment owns and which `gateway.yaml`
 owns -- is enumerated in link:environment-variable-overrides.adoc[Environment-variable overrides].
@@ -117,13 +129,26 @@ Every published digest is signed keylessly with Cosign, using the release workfl
 identity. The signature is stored in the registry alongside the image; there is no key to
 distribute.
 
+*Verify the digest, and deploy that same digest.* The signature is made over the digest, never over
+a tag. Verifying `:<version>` makes `cosign` resolve the tag itself, so what was verified and what
+is later deployed are two independent tag resolutions -- and a tag can be repointed between them.
+Resolve the digest once, verify it, and deploy it:
+
 [source,bash]
 ----
+docker pull ghcr.io/cuioss/api-sheriff:<version>
+DIGEST="$(docker image inspect --format '{{index .RepoDigests 0}}' \
+  ghcr.io/cuioss/api-sheriff:<version>)"
+
 cosign verify \
   --certificate-identity https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/cuioss/api-sheriff:<version>
+  "${DIGEST}"
 ----
+
+`docker image inspect` reports `RepoDigests` as a fully-qualified
+`ghcr.io/cuioss/api-sheriff@sha256:...` reference, so the resolved value is passed to `cosign` and to
+your deployment manifest unchanged.
 
 Both flags are mandatory, and each pins a different half of the claim:
 
@@ -144,7 +169,7 @@ zero:
 
 [source,text]
 ----
-Verification for ghcr.io/cuioss/api-sheriff:<version> --
+Verification for ghcr.io/cuioss/api-sheriff@sha256:... --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -24,9 +24,9 @@ notes.
 Immutable provenance. `<commit>` is the full 40-character SHA of the commit the release tag points
 at. Use it when you need an unambiguous, provably-immutable reference.
 
-*There is no `:latest` tag, and that is deliberate -- the registry is not broken.* A floating tag
-invites an unpinned production pull whose contents change under you, which is not a posture a
-security gateway should encourage.
+*There is no `:latest` tag, and that is deliberate -- the registry is not broken.* Pin by version,
+or by digest for production. The decision and the reasoning behind it are recorded once, in
+link:../development/release-process.adoc#_container_image_tags[the release-artifact policy].
 
 [TIP]
 ====
@@ -53,7 +53,7 @@ package to public in the organisation's package settings.
 == Pull and run
 
 The image is distroless: it carries no shell and no package manager, and it runs as `nonroot`. It
-ships a statically linked native executable and nothing else.
+ships one ahead-of-time-compiled native executable and nothing else.
 
 [source,bash]
 ----
@@ -97,17 +97,19 @@ port 9000 speak HTTPS, so health probes against it must speak TLS.
 
 == What the SBOM and the scan guarantee -- and what they do not
 
-Each release publishes an SPDX SBOM for the exact published image, and the release fails before
-anything is pushed if Trivy reports a finding at *HIGH or CRITICAL* on that same image.
+Each release produces an SPDX SBOM for the exact published image -- retained as an artifact of the
+release workflow run, not attached to the registry or to a GitHub release -- and the release fails
+before anything is pushed if Trivy reports a finding at *HIGH or CRITICAL* on that same image.
 
-*Read the scan's scope honestly.* The image is the pinned distroless base plus exactly one layer: a
-statically linked native executable that carries no package metadata. There are no jars in the
-image, so an image scan is in substance a scan of the base image's OS packages. It is not a
-statement about the application's Java dependency tree.
+*Read the scope honestly.* The image is the pinned distroless base plus exactly one layer: a native
+executable that carries no package metadata. There are no jars in the image, so an image scan is in
+substance a scan of the base image's OS packages -- and *the SBOM has exactly that scope too*,
+because it catalogues that same image. Neither artifact is an inventory of, or a statement about,
+the application's Java dependency tree.
 
-If you need a Java dependency inventory, *read the SBOM* -- do not infer it from a clean scan
-result. Java dependency findings are covered upstream by the project's per-pull-request
-supply-chain scan and by its Sonar and Dependabot lanes.
+Do not read either one as if it were. Java dependency findings come from the project's
+per-pull-request supply-chain scan -- a Trivy filesystem scan of the repository -- and from its
+Sonar and Dependabot lanes.
 
 == Verify the signature before deploying
 
@@ -126,15 +128,16 @@ cosign verify \
 Both flags are mandatory, and each pins a different half of the claim:
 
 `--certificate-identity`::
-*Who* signed it -- the exact workflow, in the exact repository, on the exact ref. Without it, any
-signature produced by any workflow anywhere would satisfy the check.
+*Who* signed it -- the exact workflow, in the exact repository, on the exact ref. It is what binds
+the check to this project's release lane rather than to any workflow anywhere.
 
 `--certificate-oidc-issuer`::
-*Which identity provider* vouched for that identity. Without it, an identity string asserted by some
-other issuer would be accepted.
+*Which identity provider* vouched for that identity. It is what stops the same identity string,
+asserted by some other issuer, from satisfying the check.
 
-Omitting either flag makes the verification meaningless: an unconstrained `cosign verify` accepts
-any Sigstore identity, so it proves only that *somebody* signed the artifact.
+`cosign` refuses to run a keyless verification without both, and that refusal is the point: a check
+that constrained neither the signer nor the issuer would prove only that *somebody* signed the
+artifact.
 
 On success, `cosign` prints the verification checks it applied and the signature payload, and exits
 zero:

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -168,6 +168,12 @@ services:
     build:
       context: ../api-sheriff
       dockerfile: src/main/docker/Dockerfile.native
+      # The harness build is the ONE image build in this project — the release lane runs this very
+      # compose build and pushes exactly the digest it produced — so this is the single supply point
+      # for the image's org.opencontainers.image.version label. The release lane exports
+      # APP_VERSION=<released version> into the Maven step's environment; locally it stays `dev`.
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
       cache_from:
         - quay.io/quarkus/quarkus-distroless-image:2.0
         - quay.io/quarkus/ubi9-quarkus-micro-image:2.0


### PR DESCRIPTION
## Intent

API Sheriff had a release **procedure** but no release **product definition**: `release.yml` published jars to Maven Central and nothing else, no container image was published anywhere, and no document stated what a release contains. This PR fixes both halves — it defines the release artifact set and makes the OCI container a first-class, hardened, scanned, signed, published release artifact.

Implements `PLAN-26` of the `api-sheriff-roadmap` epic (workstream WS-04, track **0.1.0 RELEASE**).

## Deliverables

| # | Deliverable | Footprint |
|---|---|---|
| 1 | OCI hardening: build-context allowlist + build-arg version label | `Dockerfile.native`, `api-sheriff/.dockerignore` (new), `integration-tests/docker-compose.yml` |
| 2 | Release-artifact policy: the artifact set, the two-tag scheme, version identity | `doc/development/release-process.adoc` |
| 3 | GHCR publish lane: a dependent sibling job on the dispatch-only release workflow | `.github/workflows/release.yml` |
| 4 | Release-lane SBOM + authoritative gating vulnerability scan | `.github/workflows/release.yml` |
| 5 | PR-lane non-gating supply-chain scan | `.github/workflows/maven.yml` |
| 6 | Cosign keyless-OIDC signing of the published digest | `.github/workflows/release.yml` |
| 7 | Operator guide: pulling, running and verifying the published image | `doc/user/container-image.adoc` (new), `doc/user/README.adoc` |
| 8 | Release-pipeline SVG flow diagram | `doc/resources/diagrams/release-publish-flow.svg` (new) |
| 9 | Reference-layer coverage for the container-image topic | `doc/README.adoc` |

No `api-sheriff/src/main/java/**` change — this is packaging, policy and CI, exactly as the plan predicted.

---

## Read this before "simplifying" the publish lane

### 1. The build → test → push order is deliberately INVERTED, and the inversion is what makes the guarantee true

The plan specified `docker build` once → run the ITs against that image → push it. That sequence is **not implementable as written**: `integration-tests/pom.xml:313-332` binds `docker compose build api-sheriff` to `pre-integration-test`, so running the IT suite *always* rebuilds the image. A literal implementation would have tested one image and pushed a different one — precisely the failure the deliverable exists to prevent.

The lane therefore runs the **IT suite first and lets its build be the one and only build**, then tags and pushes exactly the image it produced. One build total. "Never rebuild between test and push" now holds **by construction** rather than by discipline — there is only one build, so nothing can drift.

Do **not** "correct" this back toward the literal spec order, do not add a second `docker build`, and do not add a skip-guard to `integration-tests/pom.xml`.

### 2. Why this satisfies TEST THE DELIVERED ARTIFACT

A push is a **transfer, not a rebuild**. An image digest is computed from content, so the registry digest equals the local one and the suite ran against the published artifact **by digest identity**, not by assertion. The image is handed between steps by its content-derived ID and then by registry digest — never by tag, because the local image store is tag-keyed and will silently serve a stale image. (This project has already been bitten by exactly that in the IT fast loop.)

### 3. The two-lane scan arrangement was chosen over the cheaper single-lane option

The PR lane (`maven.yml`) is an **early-warning, non-gating** signal on every change; the release lane is the **authoritative gate** on the exact tested artifact before it is published. These are two distinct guarantees and neither is a simplification of the other. The cheaper release-lane-only option was explicitly considered and rejected. Non-gating is implemented with `exit-code: '0'` on every Trivy step — `continue-on-error` is deliberately **not** used, because it would also mask a genuine tool or network failure.

### 4. The composability hypothesis was half false — resolved without forking

A caller **can** hang a dependent sibling job off a `uses:` job. But `reusable-maven-release.yml@15376a19` declares **no `on.workflow_call.outputs` block**, so `needs.release.outputs.released-version` evaluates to the empty string and would push `ghcr.io/cuioss/api-sheriff:` — a malformed reference, or worse a silently mislabelled image. The version is instead re-read from `.github/project.yml` using the same pinned action the org workflow itself uses. **The org workflow is not forked and the dispatch-only guarantee is not weakened.**

### 5. The release trigger is untouched

`release.yml` remains `workflow_dispatch:`-only. The diff is strictly additive (`@@ -24,3 +24,317 @@`); the `on:` block and the comment recording the 2026-07-12 accidental Maven Central release are byte-identical to `main`. Both "Why…" sections of `release-process.adoc` were read in full before the file was touched.

---

## Decisions taken by the operator

- **Cosign signing: APPROVED, keyless OIDC only.** No managed key, no long-lived secret — `id-token: write` is the whole credential (already precedent at `scorecards.yml:18`, `pr-agent.yml:26`, `claude.yml:29`). Signing is **by digest**, after the push and after the smoke. SLSA provenance and further attestation are deliberately out of scope.
- **Trivy threshold: HIGH *and* CRITICAL both fail the release.** The stricter posture, chosen because API Sheriff is a security-focused gateway. Not a tool default.
- **Tags: `<version>` plus an immutable `sha-<40-char release-tag commit>`. No floating `:latest`** — a floating tag is exactly what makes a deployment non-reproducible.
- **Scan runs in BOTH lanes** (see §3 above).

## Three-layer documentation

- **Developer** (`doc/development/release-process.adoc`) — deliverable 1: the artifact set, the two-tag scheme, the version-identity guarantee, the one-build inversion, the one-time GHCR action. `doc/development/README.adoc` index entry updated.
- **Operator** (`doc/user/container-image.adoc`) — how to pull, run and verify the published image, including the exact `cosign verify` recipe with `--certificate-identity` / `--certificate-oidc-issuer`.
- **Reference** — `doc/README.adoc` gains the container-image topic. **`doc/configuration.adoc` and `doc/architecture.adoc` are genuinely unchanged**, not silently skipped: this plan introduces no configuration key and no architectural component. Verified — `git diff --stat` against both is empty.

## Scope honesty: what the image scan does and does not cover

The image is the pinned distroless base plus exactly **one** layer: a GraalVM native executable. It is dynamically linked (no `--static`, no `--libc=musl` is configured), which is why the base is the glibc-bearing `quarkus-distroless-image` rather than `scratch`. **There are no jars in the image**, so Trivy's Java analyzer finds nothing and the image scan is in substance a scan of the pinned base image's OS packages. Java dependency CVEs are covered by the PR-lane `fs` scan, Sonar and Dependabot — **not** by the image scan. A clean image scan is not evidence of a clean dependency tree. This is stated in the workflow and in the docs so it cannot be misread later.

## Known limitations, recorded rather than hidden

1. **The smoke step's pull-by-digest is not a real registry round-trip.** `docker rmi` removes only the two tags; the image stays resident under its `ghcr.io/cuioss/api-sheriff@sha256:…` RepoDigest, so the pull is a no-op and the `PULLED_ID != IMAGE_ID` assertion cannot fire. The **digest-identity guarantee still holds** by content addressing — what is unproven is registry *retrievability*. Not fixed here because evicting the image ID can fail against a stopped IT container and the step runs under `set -euo pipefail`, so a wrong guess breaks the release lane.
2. **`publish-image` runs harden-runner in `audit` mode** while holding `packages: write` + `id-token: write` simultaneously. `egress-policy: block` is the stronger posture, but a correct allowlist needs an observed audit run of a real dispatched release. Recommended follow-up after the first 0.1.0 release.
3. **A new GHCR package is private by default** and the in-workflow smoke pulls with its own credentials, so it cannot detect this. The first release needs a one-time manual visibility flip — on the release checklist in `release-process.adoc`.
4. **Unrelated pre-existing drift observed, not carried:** running `verify -Ppre-commit` applies OpenRewrite import-reordering to 8 files under `api-sheriff/src/{main,test}/java` that this plan does not own. Reverted rather than committed, to honour the plan's explicit no-production-source boundary. Worth its own follow-up.

## Verification performed

- `verify -Ppre-commit` — **green** (490s)
- `verify` (full) — **green** (342s)
- Both workflow files re-parse as valid YAML after every edit; `release.yml` triggers confirmed `{workflow_dispatch: None}` at each step.
- All 8 distinct `uses:` pins resolved against upstream refs. One was wrong and is fixed: `trivy-action` was pinned to the **annotated-tag object** SHA rather than a commit, which Dependabot's github-actions ecosystem does not track — a scanning action would have silently stopped receiving bumps.
- The two `cosign verify` strings duplicated between `release.yml` and `container-image.adoc` confirmed **character-identical** by exact literal match.
- The SVG was **rendered and read back** at both `#ffffff` and `#0d1117` via containerised `rsvg-convert`; the first pass surfaced three real layout defects which were fixed and re-rendered clean.
- The `.dockerignore` allowlist was traced rule-by-rule under Docker's last-match-wins semantics against the Dockerfile's single `COPY --chmod=0755 target/*-runner /app/application`.

**The deliverable-1 IT verification did not run locally** (`architecture resolve` reports `execution_tier: orchestrator`, 652s, exceeding the ceiling). It closes on this PR: `integration-tests.yml` runs `verify -Pintegration-tests -pl integration-tests -am`, which exercises `docker compose build api-sheriff` and therefore empirically proves the reduced build context, Dockerfile readability under the new `.dockerignore`, and the `APP_VERSION` wiring. **Please do not waive that check.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgENQAQcLGAWiLFfM414Yx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a published container image with version labels and support for digest-pinned deployment.
  * Added image signing, SBOM generation, vulnerability scanning, and release validation.
  * Management health probes now use HTTPS by default when certificates are configured.

* **Documentation**
  * Added guidance for pulling, running, verifying, and securely deploying the container image.
  * Expanded release documentation covering image tags, signatures, SBOMs, and security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->