### PR TITLE
test(config): assert boundaries for declared gateway security limits

### DIFF
--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -79,8 +79,9 @@ This tree is seeded here and grows as contributor-facing material lands.
 | link:declared-limit-assertion-coverage.adoc[Declared-Limit Assertion Coverage]
 | Which declared gateway limit has a boundary assertion and which does not -- the twelve-file
   descriptor surface, the strict preset's resolved caps that appear in no yaml, one row per limit
-  naming its enforcing component and its asserting test, the standing gap remainder, and the
-  report-only finding that the body-cap wiring guard's glob never reaches the `endpoints/` tree.
+  naming its enforcing component and its asserting test, the standing gap remainder, and the two
+  report-only findings -- that the body-cap wiring guard's glob never reaches the `endpoints/` tree,
+  and that the inventory guard partitions files rather than keys.
 
 | link:../../demo-client/doc/playwright-suite.adoc[Demo Client and the Playwright End-to-End Suite]
 | The `demo-client` module -- why the demo SPA is served by the gateway rather than a side-car

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -76,6 +76,12 @@ This tree is seeded here and grows as contributor-facing material lands.
   certificate and configuration material, and the two trust boundaries -- drawn from
   `docker-compose.yml` and the mounted `gateway.yaml`, which stay the authoritative sources.
 
+| link:declared-limit-assertion-coverage.adoc[Declared-Limit Assertion Coverage]
+| Which declared gateway limit has a boundary assertion and which does not -- the twelve-file
+  descriptor surface, the strict preset's resolved caps that appear in no yaml, one row per limit
+  naming its enforcing component and its asserting test, the standing gap remainder, and the
+  report-only finding that the body-cap wiring guard's glob never reaches the `endpoints/` tree.
+
 | link:../../demo-client/doc/playwright-suite.adoc[Demo Client and the Playwright End-to-End Suite]
 | The `demo-client` module -- why the demo SPA is served by the gateway rather than a side-car
   static server, the opt-in `skipPlaywrightTests` / `e2e-demo` build mechanism that keeps it out of

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -409,6 +409,33 @@ The same reasoning is why the bearer-protected `security_filter` route added by 
 `allowed_paths` rather than `max_body_bytes` -- adding a body cap in the endpoints tree would
 enlarge exactly the hole this note has chosen to report.
 
+== Report-Only Finding: the inventory guard partitions files, not keys
+
+`DescriptorInventoryWiringTest#limitShapedKeysLiveOnlyInTheRecordedSurfaces` builds a set of *file
+paths* -- those for which `declaresLimitShapedKey` returns `true` -- and asserts it equals the nine
+paths parsed from the `limit-bearing` block. `declaresLimitShapedKey` is a per-file *boolean*
+predicate ("does this file declare at least one limit-shaped key"), not a key enumeration, so the
+assertion's granularity is the file and never the key.
+
+The consequence: adding a limit-shaped key to one of the *nine already limit-bearing* files leaves
+the computed set identical to the parsed one. The build stays green and no Coverage Matrix row is
+forced. Only a key that makes one of the remaining three --
+`sheriff-config/endpoints/assets.yaml`, `sheriff-config/endpoints/assets-secure.yaml` or
+`sheriff-config/topology.properties` -- limit-bearing crosses the partition and fails the build.
+Nine of twelve is the *majority* of the surface, so this is the ordinary case rather than an edge
+one: for those nine files the "add its row here in the same change" instruction that closes this
+note rests on contributor convention, not on the guard.
+
+This is *reported, not fixed*, for the same reason as the finding above. Closing it means deriving
+the Coverage Matrix's own *qualified* keys and comparing them exactly against the descriptors --
+again a change to a guard whose blast radius reaches every committed descriptor, and one carrying
+real subtlety: YAML anchors resolve a single key literal to several qualified paths, this matrix's
+key column is deliberately non-uniform (qualified-with-value, qualified-bare, bare key, two keys in
+one row), and the Layer 2 rows document caps that appear in *no* yaml at all and could never be
+derived. Key-level enforcement therefore belongs in its own plan with its own verification rather
+than riding a coverage sweep. It is recorded here so the hole is a known, countable item rather than
+a latent surprise.
+
 == Keeping This Note Honest
 
 This table is prose, and prose drifts the moment a descriptor changes. Three properties limit that:
@@ -418,9 +445,14 @@ This table is prose, and prose drifts the moment a descriptor changes. Three pro
 . *The enumerated surface is stated explicitly* (twelve files, named) *and machine-checked against
   this note*. `DescriptorInventoryWiringTest` parses the marked blocks in "The Enumerated Surface"
   -- the inventory table, the sweep pattern and the nine limit-bearing paths -- and uses them as its
-  expected values instead of carrying its own copy, so a new descriptor directory, a new
-  `endpoints/*.yaml` or a new limit-shaped key fails the build until this note is updated. Updating
-  the test alone cannot make the build green: the test has no expectation of its own to update.
+  expected values instead of carrying its own copy. Both of its assertions are *file-level set
+  equalities*, and the guarantee is exactly that: a new descriptor directory or a new
+  `endpoints/*.yaml` breaks the exact-inventory equality and fails the build until this note is
+  updated, and a limit-shaped key fails the build *only when it makes a previously
+  non-limit-bearing file limit-bearing* -- when it moves a file across the nine/three partition.
+  Adding one to a file that already declares a limit changes neither set; see the report-only
+  finding above. Updating the test alone cannot make the build green: the test has no expectation of
+  its own to update.
 . *The wiring guards are the machine-enforced half.* `BodyLimitActivationWiringTest` and
   `EgressAllowlistActivationWiringTest` both assert a `COMMITTED_DESCRIPTOR_COUNT` floor, so a
   vacuous or mis-rooted glob fails loudly instead of passing over an empty set. This note indexes

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -47,8 +47,8 @@ identically for all six booted gateway instances.
 *No limit-shaped key lives outside this surface.* A key-shaped sweep
 (`max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold|budget|quota|window|depth`)
 over all twelve files returns hits only in the four `gateway.yaml` documents and in
-`endpoints/httpbin.yaml`, `endpoints/websocket.yaml`, `endpoints/bff-session.yaml` and
-`endpoints/grpc.yaml`. `assets.yaml`, `assets-secure.yaml`, `secure.yaml` and
+`endpoints/httpbin.yaml`, `endpoints/websocket.yaml`, `endpoints/bff-session.yaml`,
+`endpoints/grpc.yaml` and `endpoints/secure.yaml`. `assets.yaml`, `assets-secure.yaml` and
 `topology.properties` declare none.
 
 === Citation notation
@@ -174,6 +174,13 @@ declaration's *existence* is proven while its *boundary* is not.
 | COVERED
 | `MtlsHandshakeIT` (wrong-CA identity rejected; trusted identity admitted)
 
+| `secure-filtered.security_filter.profile: strict` / `allowed_paths`
+  `sheriff-config/endpoints/secure.yaml:19-56`
+| `ThoroughChecksStage` (stage 3) on a route that also inherits a bearer floor
+| COVERED
+| `BearerSecurityFilterInteractionIT` -- the four-case gate-interaction matrix, including which gate
+  wins when a request violates both
+
 | `asset_defaults.content_types`
   `sheriff-config/gateway.yaml:101-103`
 | Asset response envelope (add-only map, boot-enforced)
@@ -190,37 +197,40 @@ declaration's *existence* is proven while its *boundary* is not.
 | *G1* `security_defaults.max_authorization_header_value_length: 8192`
   `sheriff-config/gateway.yaml:50`
 | `BasicChecksStage` -- the non-skippable pre-route floor, *before* route selection
-| PARTIAL
-| `BearerValidationIT:120` asserts a real token exceeds 1024 and is still admitted, proving the
-  carve-out is *in force*. Nothing exercises the *8192 boundary*: no at-cap-admitted /
-  over-cap-rejected pair exists, and the literal `8192` appears nowhere in the corpus.
+| COVERED
+| `DeclaredLimitBoundaryIT` -- 8192 admitted and reaching bearer validation (401), 8193 rejected 400
+  at the floor; the 401-vs-400 delta on a one-character change is the discriminator.
+  `BearerValidationIT:120` independently proves the carve-out is in force on a real token.
 
 | *G2* `token_validation.issuers[*].jwks.allowed_egress_hosts`
   `gateway.yaml` ×4 -- base:222,245; cookie:97,110; mtls:104,121; ws:102,109
 | token-sheriff SSRF egress guard (GW-05 / BFF-07)
-| GAP
-| none
+| WIRED
+| `EgressAllowlistActivationWiringTest` -- every http-sourced issuer declares a non-empty allowlist
+  and every file-sourced issuer declares none. Descriptor-parsing only; no runtime egress refusal is
+  exercised, which is why this is `WIRED` and not `COVERED`.
 
 | *G3* Strict preset header-value length cap (1024)
   Layer 2 -- resolved, in no yaml
 | `BasicChecksStage` (pre-route floor, every header)
-| GAP
-| none -- and this is the exact cap G1 carves `Authorization` out of
+| COVERED
+| `DeclaredLimitBoundaryIT` -- a non-`Authorization` header admitted at 1024 and rejected 400 at
+  1025. Paired with G1 this proves the carve-out is scoped to `Authorization` and did not widen.
 
 | *G4* Strict preset body cap (1 MiB) on an *inheriting* route
   Layer 2 -- resolved, in no yaml
 | `ThoroughChecksStage` (GW-07 default body guard)
-| GAP
-| none -- only the deliberately raised (64 MiB) and deliberately lowered (1024) route caps are
-  asserted; the inherited default never is
+| COVERED
+| `DeclaredLimitBoundaryIT` -- one byte over is rejected 413 carrying the gateway's own RFC 9457
+  envelope (not the framework's bare 413), one byte under is forwarded and echoed
 
 | *G5* `forward.headers_allow` / `query_allow` deny-by-default
   `endpoints/httpbin.yaml:32-33,60-63,80,92,102` (5 routes);
   `endpoints/bff-session.yaml:25` (1 route); `endpoints/grpc.yaml:48-50,67-69` (2 routes)
 | Forward stage 5 (deny-by-default allow-listing)
-| GAP
-| none -- positive echo is asserted throughout, but no test proves a *non*-allow-listed name is
-  stripped
+| COVERED
+| `DeclaredLimitBoundaryIT` -- one request carrying both an allow-listed and a non-allow-listed
+  header *and* query parameter; the allow-listed pair is echoed, the other is stripped
 
 | *G6* Strict preset parameter-*value* length cap (1024)
   Layer 2 -- resolved, in no yaml
@@ -264,11 +274,13 @@ declaration's *existence* is proven while its *boundary* is not.
 
 == The Gap Count and This Plan's Selection
 
-*Real gap count: 11* -- eight outright `GAP` (G2--G9) plus three `PARTIAL` (G1, G10, G11).
+*Real gap count when this sweep began: 11* -- eight outright `GAP` (G2--G9) plus three `PARTIAL`
+(G1, G10, G11).
 
-The sweep's hard ceiling is five assertions, so *the cap binds at its ceiling*: five of the eleven
-are closed here, ranked by blast radius (a limit whose breach degrades the whole gateway outranks
-one that degrades a single request).
+The sweep's hard ceiling is five assertions, so *the cap bound at its ceiling*: **G1--G5 are now
+closed** (their rows above name the asserting tests), ranked below by blast radius -- a limit whose
+breach degrades the whole gateway outranks one that degrades a single request. *Six remain*, and
+they are listed as the standing remainder so the class stays countable.
 
 [cols="1,1,1,4"]
 |===
@@ -298,7 +310,7 @@ one that degrades a single request).
 
 === The standing remainder
 
-*G6--G11 are deliberately not authored here*, and are recorded so the class stays countable rather
+*G6--G11 are deliberately not authored*, and are recorded so the class stays countable rather
 than forgotten:
 
 * *G6* -- strict parameter-value length cap (1024)

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -1,0 +1,358 @@
+= Declared-Limit Assertion Coverage
+:toc:
+:toclevels: 2
+:sectnums:
+
+Every limit-shaped value the integration-test descriptor surface declares, and the test that
+asserts it -- or the record that none does.
+
+The gateway's security posture is declared in configuration and enforced in code. A declared limit
+that no test exercises is a value that can be silently weakened: the descriptor still reads
+correctly, the build stays green, and the guard is gone. This note is the index that makes that
+class countable.
+
+It is a *human-readable index over machine-enforced guards, not the enforcement itself*. The
+wiring guards named below (`BodyLimitActivationWiringTest`, `EgressAllowlistActivationWiringTest`,
+`TlsEdgeActivationWiringTest`, and their siblings) are what actually fail on drift. This note tells
+a contributor which limits have such a guard, which have only a runtime assertion, and which have
+neither.
+
+== The Enumerated Surface
+
+The declared surface is *twelve files* under `integration-tests/src/main/docker/`:
+
+[cols="2,1,3"]
+|===
+| Surface | Count | Files
+
+| `sheriff-config*/gateway.yaml`
+| 4
+| `sheriff-config` (base), `sheriff-config-cookie`, `sheriff-config-mtls`,
+  `sheriff-config-ws-admission`
+
+| `sheriff-config/endpoints/*.yaml`
+| 7
+| `assets.yaml`, `assets-secure.yaml`, `bff-session.yaml`, `grpc.yaml`, `httpbin.yaml`,
+  `secure.yaml`, `websocket.yaml`
+
+| `sheriff-config/topology.properties`
+| 1
+| Alias bindings only -- declares *no* limit-shaped key
+|===
+
+Only the base directory carries `endpoints/` and `topology.properties`; the three overlay
+directories replace `gateway.yaml` and nothing else, which is why the endpoints tree resolves
+identically for all six booted gateway instances.
+
+*No limit-shaped key lives outside this surface.* A key-shaped sweep
+(`max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold|budget|quota|window|depth`)
+over all twelve files returns hits only in the four `gateway.yaml` documents and in
+`endpoints/httpbin.yaml`, `endpoints/websocket.yaml`, `endpoints/bff-session.yaml` and
+`endpoints/grpc.yaml`. `assets.yaml`, `assets-secure.yaml`, `secure.yaml` and
+`topology.properties` declare none.
+
+=== Citation notation
+
+Paths below are relative to `integration-tests/src/main/docker/`. Because a key declared in all
+four `gateway.yaml` documents sits at a different line in each, such rows cite every line
+explicitly as `×4 -- base:N, cookie:N, mtls:N, ws:N`, where `ws` is `sheriff-config-ws-admission`.
+A row citing a bare `sheriff-config/gateway.yaml:N` is declared in the *base document only* and is
+inherited by the overlays as the omitted-key default.
+
+The `security_defaults` block in particular is *base-only*: the cookie, mTLS and ws-admission
+overlays declare no `security_defaults` at all and resolve the shipped defaults.
+
+== The Two Declaration Layers
+
+The matrix spans both layers, because only one of them is greppable:
+
+Layer 1 -- *literal descriptor keys*:: A value written into a `gateway.yaml` or an
+`endpoints/*.yaml`. It can be found by reading the file.
+
+Layer 2 -- *the strict preset's resolved effective caps*:: `security_defaults.profile: strict`
+resolves to a set of caps that apply to *every route that declares no `security_filter.profile`* --
+a 1 MiB body cap, 20 query parameters, 1024-character header values, 1024-character parameter
+values and 1024-character paths. *None of these numbers appears in any yaml file.* They are the
+floor the whole suite is measured against, and a limit that appears nowhere in the descriptors is
+exactly the limit most likely to lose its assertion unnoticed.
+
+== Status Vocabulary
+
+`COVERED`:: A test asserts the value *at its boundary* with a matched positive control -- proving
+the cap rejects because of the value, not because the route refuses the shape outright.
+
+`WIRED`:: A descriptor-parsing guard asserts the declaration is *present*, but no runtime boundary
+is exercised.
+
+`PARTIAL`:: One leg landed. Either the positive control or the negative boundary is missing, or the
+declaration's *existence* is proven while its *boundary* is not.
+
+`GAP`:: No test names or exercises it.
+
+== Coverage Matrix
+
+[cols="3,2,1,3"]
+|===
+| Declared limit (file:line) | Enforcing component | Status | Asserting test
+
+| `anchors.upload.security_filter.max_body_bytes: 67108864`
+  `gateway.yaml` ×4 -- base:155, cookie:64, mtls:71, ws:69
+| `ThoroughChecksStage` (per-route body cap)
+| COVERED
+| `LargeBodyIT` (runtime 413) + `BodyLimitActivationWiringTest` (framework-floor coupling)
+
+| `httpbin-minimal-mode.max_body_bytes: 1024`
+  `sheriff-config/endpoints/httpbin.yaml:55`
+| `ThoroughChecksStage` (enforced under `minimal` unchanged)
+| COVERED
+| `SecurityProfileModeIT` (`bodyCapStillRejectsOverCapBody` + `bodyWithinCapIsForwarded` control)
+
+| `httpbin-minimal-mode.allowed_paths`
+  `sheriff-config/endpoints/httpbin.yaml:58`
+| `ThoroughChecksStage` (path allowlist)
+| COVERED
+| `SecurityProfileModeIT` (`allowedPathsStillRejectsPathOutsideAllowlist`)
+
+| `security_defaults.profile: strict`
+  `sheriff-config/gateway.yaml:49`
+| Resolved `SecurityConfiguration` for every route omitting a profile
+| COVERED
+| `SecurityProfileModeIT` (strict-vs-minimal contrast on two routes)
+
+| Strict preset query-parameter *count* cap (20)
+  Layer 2 -- resolved, in no yaml
+| `BasicChecksStage` (pre-route floor; a collection cap is a DoS guard)
+| COVERED
+| `SecurityProfileModeIT` (`preRouteCollectionCapStillRejectsParameterCount`)
+
+| `security_defaults.allow_get_with_content_length_body: true`
+  `sheriff-config/gateway.yaml:51`
+| The framing gate in `BasicChecksStage`
+| COVERED
+| `GetWithBodyIT` + `GetWithBodyActivationWiringTest`
+
+| `allowed_methods`
+  `sheriff-config/gateway.yaml:20` (global), `:144` (graphql), `:149` (upload), `:178`
+  (assets-public), `:188` (assets-secure)
+| Route selection / method gate
+| COVERED
+| `PipelineVerbIT` (405 plus four positive controls)
+
+| `oidc.session.csrf.trusted_origins`
+  `gateway.yaml` ×4 -- base:295, cookie:163, mtls:156, ws:135
+| BFF CSRF origin gate
+| COVERED
+| `BffCsrfIT` (403 / 403 with a 401 control)
+
+| `websocket.allowed_origins`
+  `sheriff-config/endpoints/websocket.yaml:31,44`
+| `OriginValidationStage` (fail-closed, before the upstream dial)
+| COVERED
+| `WebSocketProxyIT` (CSWSH rejection, GW-09)
+
+| `websocket.idle_timeout_seconds: 2`
+  `sheriff-config/endpoints/websocket.yaml:55`
+| Relay idle reclaim (WebSocket close 1001)
+| COVERED
+| `WebSocketProxyIT` (idle reclaim vs heartbeat-kept-warm control)
+
+| `edge_hardening.admission_cap: 8` / `websocket_relay_cap: 2`
+  `sheriff-config-ws-admission/gateway.yaml:35,36`
+| Admission budget (general permit + relay sub-budget)
+| COVERED
+| `WebSocketProxyIT` (`WsAdmissionExhaustion`) + `WsAdmissionActivationWiringTest`
+
+| `tls.passthrough_sni`
+  `sheriff-config/gateway.yaml:87-89`
+| `SniFrontListener` via `TlsEdgeProducer` (accept-time L4/L7 split)
+| COVERED
+| `TlsPassthroughIT`, `HostSmuggleGuardIT`, `TlsEdgeActivationWiringTest`
+
+| `tls.mtls.enabled: true` / `client_ca`
+  `sheriff-config-mtls/gateway.yaml:29-31`
+| `MtlsServerCustomizer` (require-and-verify at the handshake)
+| COVERED
+| `MtlsHandshakeIT` (wrong-CA identity rejected; trusted identity admitted)
+
+| `asset_defaults.content_types`
+  `sheriff-config/gateway.yaml:101-103`
+| Asset response envelope (add-only map, boot-enforced)
+| WIRED
+| `AssetContentTypeActivationWiringTest` -- asserts the block is declared and collides with no
+  built-in; no served-asset content type is asserted at runtime
+
+| `oidc.session.refresh.leeway_seconds: 30`
+  `gateway.yaml` ×4 -- base:293, cookie:161, mtls:154, ws:133
+| Session refresh scheduling
+| WIRED
+| `BffCookieSessionIT`, `BffSessionMediationIT` -- exercise refresh, never the leeway boundary
+
+| *G1* `security_defaults.max_authorization_header_value_length: 8192`
+  `sheriff-config/gateway.yaml:50`
+| `BasicChecksStage` -- the non-skippable pre-route floor, *before* route selection
+| PARTIAL
+| `BearerValidationIT:120` asserts a real token exceeds 1024 and is still admitted, proving the
+  carve-out is *in force*. Nothing exercises the *8192 boundary*: no at-cap-admitted /
+  over-cap-rejected pair exists, and the literal `8192` appears nowhere in the corpus.
+
+| *G2* `token_validation.issuers[*].jwks.allowed_egress_hosts`
+  `gateway.yaml` ×4 -- base:222,245; cookie:97,110; mtls:104,121; ws:102,109
+| token-sheriff SSRF egress guard (GW-05 / BFF-07)
+| GAP
+| none
+
+| *G3* Strict preset header-value length cap (1024)
+  Layer 2 -- resolved, in no yaml
+| `BasicChecksStage` (pre-route floor, every header)
+| GAP
+| none -- and this is the exact cap G1 carves `Authorization` out of
+
+| *G4* Strict preset body cap (1 MiB) on an *inheriting* route
+  Layer 2 -- resolved, in no yaml
+| `ThoroughChecksStage` (GW-07 default body guard)
+| GAP
+| none -- only the deliberately raised (64 MiB) and deliberately lowered (1024) route caps are
+  asserted; the inherited default never is
+
+| *G5* `forward.headers_allow` / `query_allow` deny-by-default
+  `endpoints/httpbin.yaml:32-33,60-63,80,92,102` (5 routes);
+  `endpoints/bff-session.yaml:25` (1 route); `endpoints/grpc.yaml:48-50,67-69` (2 routes)
+| Forward stage 5 (deny-by-default allow-listing)
+| GAP
+| none -- positive echo is asserted throughout, but no test proves a *non*-allow-listed name is
+  stripped
+
+| *G6* Strict preset parameter-*value* length cap (1024)
+  Layer 2 -- resolved, in no yaml
+| `ThoroughChecksStage` (relocated url-parameter validation)
+| GAP
+| `SecurityProfileModeIT` asserts a *separator*-shaped rejection (`REJECTED_PARAMETER_VALUE =
+  "/home"`), never the length boundary
+
+| *G7* Strict preset path length cap (1024)
+  Layer 2 -- resolved, in no yaml
+| `BasicChecksStage.validatePath`
+| GAP
+| none
+
+| *G8* `tls.alpn: ["h2", "http/1.1"]`
+  `gateway.yaml` ×4 -- base:75, cookie:25, mtls:22, ws:26
+| `TlsServerCustomizer` (ALPN advertisement)
+| GAP
+| none -- the http2 benchmark aspect negotiates h2 but asserts no protocol
+
+| *G9* `oidc.session.ttl_seconds: 3600`
+  `gateway.yaml` ×4 -- base:290, cookie:158, mtls:151, ws:130
+| Session store expiry
+| GAP
+| none
+
+| *G10* `oidc.user_info.allowed_claims`
+  `gateway.yaml` ×4 -- base:298, cookie:166, mtls:159, ws:138
+| user_info claim projection
+| PARTIAL
+| `BffUserInfoIT` asserts the `default_view` projection; no negative leg proves a claim *outside*
+  the allowlist is withheld
+
+| *G11* `tls.min_version: "1.2"` / `tls.cipher_suites`
+  `sheriff-config/gateway.yaml:62,67-71`
+| `TlsServerCustomizer` (protocol floor + cipher allowlist)
+| PARTIAL
+| `CipherSuiteFixtureWiringTest` is descriptor-level only; no handshake asserts a below-floor
+  protocol is refused
+|===
+
+== The Gap Count and This Plan's Selection
+
+*Real gap count: 11* -- eight outright `GAP` (G2--G9) plus three `PARTIAL` (G1, G10, G11).
+
+The sweep's hard ceiling is five assertions, so *the cap binds at its ceiling*: five of the eleven
+are closed here, ranked by blast radius (a limit whose breach degrades the whole gateway outranks
+one that degrades a single request).
+
+[cols="1,1,1,4"]
+|===
+| Rank | Gap | Blast radius | Why it ranks here
+
+| 1 | G1 | gateway-wide
+| An ADR-0019 relaxation at the non-skippable pre-route floor. If the carve-out silently reverts,
+  *every bearer request is rejected 400 before bearer validation ever runs* -- the whole
+  authenticated surface degrades.
+
+| 2 | G2 | gateway-wide
+| The SSRF egress guard on JWKS fetch (GW-05 / BFF-07). Its loss unguards outbound fetches from a
+  security gateway.
+
+| 3 | G3 | gateway-wide
+| The resolved header-value floor every route inherits -- and the exact cap G1 carves out of.
+  Asserting both makes the relaxation's *scope* provable rather than assumed.
+
+| 4 | G4 | gateway-wide
+| The default body guard (GW-07) on every inheriting route. Today only the deliberately raised and
+  deliberately lowered route caps are proven; the inherited default never is.
+
+| 5 | G5 | per-request
+| Deny-by-default forward allow-listing. An information-flow defect (a header crossing to the
+  upstream that should not) rather than a gateway-wide degradation -- hence rank 5.
+|===
+
+=== The standing remainder
+
+*G6--G11 are deliberately not authored here*, and are recorded so the class stays countable rather
+than forgotten:
+
+* *G6* -- strict parameter-value length cap (1024)
+* *G7* -- strict path length cap (1024)
+* *G8* -- `tls.alpn`
+* *G9* -- `oidc.session.ttl_seconds`
+* *G10* -- `oidc.user_info.allowed_claims` negative leg
+* *G11* -- `tls.min_version` / `cipher_suites` runtime handshake leg
+
+Two of these are additionally *impractical to boundary-test at proportionate cost*: G9 would need a
+one-hour wait, and G11's runtime leg needs a handshake fixture matrix. A future plan should pick
+the *wiring* shape for those two rather than the boundary shape -- a descriptor guard that fails on
+drift is worth more than a boundary test nobody can afford to run.
+
+== Report-Only Finding: the body-cap guard does not reach the endpoints tree
+
+`BodyLimitActivationWiringTest` discovers descriptors with a `sheriff-config*` directory glob and
+then resolves `gateway.yaml` inside each match:
+
+[source,java]
+----
+try (DirectoryStream<Path> directories = Files.newDirectoryStream(DOCKER, "sheriff-config*")) {
+    for (Path directory : directories) {
+        Path descriptor = directory.resolve("gateway.yaml");
+        ...
+----
+
+It therefore *never reaches `sheriff-config/endpoints/`* -- where `endpoints/httpbin.yaml:55`
+already declares a `max_body_bytes: 1024`. That cap sits far below the framework floor, so nothing
+is broken today. But a *future* endpoint-level cap declared above the floor would push its instance
+into a fail-closed boot abort with the guard still green, because the guard never parsed the file
+that declares it.
+
+This is *reported, not fixed*: widening the glob is a change to a guard whose blast radius reaches
+every committed descriptor, and it belongs in its own plan with its own verification rather than
+riding a coverage sweep. It is recorded here so the hole is a known, countable item rather than a
+latent surprise.
+
+The same reasoning is why the bearer-protected `security_filter` route added by this plan declares
+`allowed_paths` rather than `max_body_bytes` -- adding a body cap in the endpoints tree would
+enlarge exactly the hole this note has chosen to report.
+
+== Keeping This Note Honest
+
+This table is prose, and prose drifts the moment a descriptor changes. Three properties limit that:
+
+. *Every row carries a `file:line` citation*, so a reviewer can check a row against the descriptor
+  in one step rather than re-deriving the surface.
+. *The enumerated surface is stated explicitly* (twelve files, named), so a new descriptor
+  directory is visibly absent from this note rather than silently uncovered.
+. *The wiring guards are the machine-enforced half.* `BodyLimitActivationWiringTest` and
+  `EgressAllowlistActivationWiringTest` both assert a `COMMITTED_DESCRIPTOR_COUNT` floor, so a
+  vacuous or mis-rooted glob fails loudly instead of passing over an empty set. This note indexes
+  those guards; it does not replace them.
+
+When you add a limit-shaped key to any of the twelve files, add its row here in the same change --
+and give it a status that is honest, including `GAP`.

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -152,7 +152,11 @@ declaration's *existence* is proven while its *boundary* is not.
   `sheriff-config/endpoints/httpbin.yaml:58`
 | `ThoroughChecksStage` (path allowlist)
 | COVERED
-| `SecurityProfileModeIT` (`allowedPathsStillRejectsPathOutsideAllowlist`)
+| `SecurityProfileModeIT` (`allowedPathsStillRejectsPathOutsideAllowlist` -- the two-segment
+  `/proxy/minimal-mode/deep/path` rejected 400 -- with the matched one-wildcard-segment control
+  `/proxy/minimal-mode/echo` admitted 200 by `bodyWithinCapIsForwarded` /
+  `minimalRouteAcceptsRejectedParameterValue`, proving the rejection follows the segment-count
+  mismatch rather than the route refusing the shape outright)
 
 | `security_defaults.profile: strict`
   `sheriff-config/gateway.yaml:49`
@@ -232,8 +236,13 @@ declaration's *existence* is proven while its *boundary* is not.
 | `oidc.session.refresh.leeway_seconds: 30`
   `gateway.yaml` ×4 -- base:293, cookie:161, mtls:154, ws:133
 | Session refresh scheduling
-| WIRED
-| `BffCookieSessionIT`, `BffSessionMediationIT` -- exercise refresh, never the leeway boundary
+| GAP
+| none -- no descriptor-parsing guard asserts the declaration is present
+  (`BffCookieActivationWiringTest` parses the `oidc.session` block but asserts only `mode`, `store`,
+  `encryption_key` and `logout.backchannel_path`; `DescriptorInventoryWiringTest` partitions files,
+  never keys), and `BffCookieSessionIT` / `BffSessionMediationIT` exercise session *continuity*
+  without forcing a refresh, let alone approaching the 30s leeway boundary. Neither half of `WIRED`
+  holds, which is why this row was corrected from `WIRED` to `GAP`.
 
 | *G1* `security_defaults.max_authorization_header_value_length: 8192`
   `sheriff-config/gateway.yaml:50`
@@ -317,8 +326,11 @@ declaration's *existence* is proven while its *boundary* is not.
 
 == The Gap Count and This Plan's Selection
 
-*Real gap count when this sweep began: 11* -- eight outright `GAP` (G2--G9) plus three `PARTIAL`
-(G1, G10, G11).
+*Real gap count when this sweep began: 12* -- eight outright `GAP` (G2--G9), three `PARTIAL`
+(G1, G10, G11), plus one row this note had itself mis-recorded:
+`oidc.session.refresh.leeway_seconds` was carried as `WIRED` while no descriptor-parsing guard
+asserted it, so neither half of the `WIRED` definition held. The PR #148 review corrected that row
+to `GAP`; it was a real gap at the sweep's start and is counted as one here.
 
 The sweep's hard ceiling is five assertions, so *the cap bound at its ceiling*: **G1--G5 each
 received one** (their rows above name the asserting test), ranked below by blast radius -- a limit
@@ -331,8 +343,8 @@ scoped to the host its own `jwks.url` names, but no runtime egress refusal is ex
 note's own vocabulary that is not `COVERED`, so G2's runtime leg is *still open* and is counted
 below rather than dropped.
 
-*Seven items remain* -- the G2 runtime egress-refusal leg plus G6--G11 -- and they are listed as
-the standing remainder so the class stays countable.
+*Eight items remain* -- the G2 runtime egress-refusal leg, G6--G11, plus the session-refresh leeway
+boundary -- and they are listed as the standing remainder so the class stays countable.
 
 [cols="1,1,1,4"]
 |===
@@ -363,8 +375,8 @@ the standing remainder so the class stays countable.
 
 === The standing remainder
 
-*The G2 runtime leg and G6--G11 are deliberately not authored*, and are recorded so the class stays
-countable rather than forgotten:
+*The G2 runtime leg, G6--G11 and the session-refresh leeway boundary are deliberately not authored*,
+and are recorded so the class stays countable rather than forgotten:
 
 * *G2* -- runtime egress-refusal leg: that a JWKS host *outside* `allowed_egress_hosts` is actually
   refused. The descriptor half is `WIRED` by `EgressAllowlistActivationWiringTest`; proving the
@@ -375,6 +387,12 @@ countable rather than forgotten:
 * *G9* -- `oidc.session.ttl_seconds`
 * *G10* -- `oidc.user_info.allowed_claims` negative leg
 * *G11* -- `tls.min_version` / `cipher_suites` runtime handshake leg
+* *Session-refresh leeway* -- `oidc.session.refresh.leeway_seconds: 30`: that a session is actually
+  refreshed the declared 30 seconds ahead of expiry. Neither leg exists -- no descriptor-parsing
+  guard asserts the declaration, and the BFF session ITs exercise continuity without forcing a
+  refresh. This row was carried as `WIRED` until the PR #148 review corrected it to `GAP`; it is
+  recorded here rather than assigned a G-number, because G1--G11 are the outline-time ranked
+  inventory that the matrix orders.
 
 Two of these are additionally *impractical to boundary-test at proportionate cost*: G9 would need a
 one-hour wait, and G11's runtime leg needs a handshake fixture matrix. A future plan should pick

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -19,45 +19,78 @@ neither.
 
 == The Enumerated Surface
 
-The declared surface is *twelve files* under `integration-tests/src/main/docker/`:
+The declared surface is *twelve files* under `integration-tests/src/main/docker/`.
 
+The table below is not decoration. `DescriptorInventoryWiringTest` parses the marked block at
+runtime and takes every monospaced path spelled inside it -- glob patterns excluded -- as its
+expected inventory. Move a descriptor here and the guard's expectation moves with it; move one on
+disk without touching this table and the guard fails.
+
+// tag::inventory[]
 [cols="2,1,3"]
 |===
 | Surface | Count | Files
 
 | `sheriff-config*/gateway.yaml`
 | 4
-| `sheriff-config` (base), `sheriff-config-cookie`, `sheriff-config-mtls`,
-  `sheriff-config-ws-admission`
+| `sheriff-config/gateway.yaml` (base), `sheriff-config-cookie/gateway.yaml`,
+  `sheriff-config-mtls/gateway.yaml`, `sheriff-config-ws-admission/gateway.yaml`
 
 | `sheriff-config/endpoints/*.yaml`
 | 7
-| `assets.yaml`, `assets-secure.yaml`, `bff-session.yaml`, `grpc.yaml`, `httpbin.yaml`,
-  `secure.yaml`, `websocket.yaml`
+| `sheriff-config/endpoints/assets.yaml`, `sheriff-config/endpoints/assets-secure.yaml`,
+  `sheriff-config/endpoints/bff-session.yaml`, `sheriff-config/endpoints/grpc.yaml`,
+  `sheriff-config/endpoints/httpbin.yaml`, `sheriff-config/endpoints/secure.yaml`,
+  `sheriff-config/endpoints/websocket.yaml`
 
 | `sheriff-config/topology.properties`
 | 1
 | Alias bindings only -- declares *no* limit-shaped key
 |===
+// end::inventory[]
 
 Only the base directory carries `endpoints/` and `topology.properties`; the three overlay
 directories replace `gateway.yaml` and nothing else, which is why the endpoints tree resolves
 identically for all six booted gateway instances.
 
-*No limit-shaped key lives outside this surface.* A key-shaped sweep
-(`max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold|budget|quota|window|depth`)
-over all twelve files returns hits only in the four `gateway.yaml` documents and in
-`endpoints/httpbin.yaml`, `endpoints/websocket.yaml`, `endpoints/bff-session.yaml`,
-`endpoints/grpc.yaml` and `endpoints/secure.yaml`. `assets.yaml`, `assets-secure.yaml` and
-`topology.properties` declare none.
+*No limit-shaped key lives outside this surface.* The sweep is a key-name pattern, applied to
+declared key names only -- never to raw file text, so the descriptors' extensive prose comments
+cannot manufacture a hit:
 
-*Both claims above are machine-checked*, not merely asserted here in prose.
-`DescriptorInventoryWiringTest` (in `integration-tests/src/test/java/.../gateway/integration/`)
-asserts the twelve-file inventory as an *exact set* -- so an added descriptor fails as loudly as a
-removed one, unlike the *at-least* floor the sibling wiring guards use -- and runs the same key
-sweep over that inventory, asserting the set of limit-declaring files is exactly the nine named
-above. Add a descriptor or a limit-shaped key and that guard fails until this section and the
-matrix below are updated in the same change.
+// tag::limit-key-regex[]
+`max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold|budget|quota|window|depth`
+// end::limit-key-regex[]
+
+Over all twelve files it returns hits in exactly nine of them:
+
+// tag::limit-bearing[]
+* `sheriff-config/gateway.yaml`
+* `sheriff-config-cookie/gateway.yaml`
+* `sheriff-config-mtls/gateway.yaml`
+* `sheriff-config-ws-admission/gateway.yaml`
+* `sheriff-config/endpoints/bff-session.yaml`
+* `sheriff-config/endpoints/grpc.yaml`
+* `sheriff-config/endpoints/httpbin.yaml`
+* `sheriff-config/endpoints/secure.yaml`
+* `sheriff-config/endpoints/websocket.yaml`
+// end::limit-bearing[]
+
+The remaining three -- `sheriff-config/endpoints/assets.yaml`,
+`sheriff-config/endpoints/assets-secure.yaml` and `sheriff-config/topology.properties` -- declare
+none. That complement is the other half of the same claim, so asserting the nine exactly asserts
+both halves at once.
+
+*Both claims above are machine-checked against this note itself*, not merely asserted here in
+prose. `DescriptorInventoryWiringTest` (in
+`integration-tests/src/test/java/.../gateway/integration/`) reads the three marked blocks above at
+runtime -- the inventory table, the sweep pattern and the nine limit-bearing paths -- and uses them
+as its expected values. It hardcodes none of them, so editing the test's expectations without
+editing this note is not possible: the note *is* the expectation. It then asserts the committed
+inventory equals the parsed inventory as an *exact set* -- so an added descriptor fails as loudly
+as a removed one, unlike the *at-least* floor the sibling wiring guards use -- and re-runs the
+parsed sweep over that inventory, asserting the set of limit-declaring files equals the parsed
+nine. If this note cannot be located, or a marked block is missing or empty, the guard fails loudly
+rather than deriving an empty expectation and passing.
 
 === Citation notation
 
@@ -382,10 +415,12 @@ This table is prose, and prose drifts the moment a descriptor changes. Three pro
 
 . *Every row carries a `file:line` citation*, so a reviewer can check a row against the descriptor
   in one step rather than re-deriving the surface.
-. *The enumerated surface is stated explicitly* (twelve files, named) *and machine-checked*.
-  `DescriptorInventoryWiringTest` asserts that inventory as an exact set and re-runs the
-  limit-shaped key sweep over it, so a new descriptor directory, a new `endpoints/*.yaml` or a new
-  limit-shaped key fails the build rather than leaving this note silently stale.
+. *The enumerated surface is stated explicitly* (twelve files, named) *and machine-checked against
+  this note*. `DescriptorInventoryWiringTest` parses the marked blocks in "The Enumerated Surface"
+  -- the inventory table, the sweep pattern and the nine limit-bearing paths -- and uses them as its
+  expected values instead of carrying its own copy, so a new descriptor directory, a new
+  `endpoints/*.yaml` or a new limit-shaped key fails the build until this note is updated. Updating
+  the test alone cannot make the build green: the test has no expectation of its own to update.
 . *The wiring guards are the machine-enforced half.* `BodyLimitActivationWiringTest` and
   `EgressAllowlistActivationWiringTest` both assert a `COMMITTED_DESCRIPTOR_COUNT` floor, so a
   vacuous or mis-rooted glob fails loudly instead of passing over an empty set. This note indexes

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -51,6 +51,14 @@ over all twelve files returns hits only in the four `gateway.yaml` documents and
 `endpoints/grpc.yaml` and `endpoints/secure.yaml`. `assets.yaml`, `assets-secure.yaml` and
 `topology.properties` declare none.
 
+*Both claims above are machine-checked*, not merely asserted here in prose.
+`DescriptorInventoryWiringTest` (in `integration-tests/src/test/java/.../gateway/integration/`)
+asserts the twelve-file inventory as an *exact set* -- so an added descriptor fails as loudly as a
+removed one, unlike the *at-least* floor the sibling wiring guards use -- and runs the same key
+sweep over that inventory, asserting the set of limit-declaring files is exactly the nine named
+above. Add a descriptor or a limit-shaped key and that guard fails until this section and the
+matrix below are updated in the same change.
+
 === Citation notation
 
 Paths below are relative to `integration-tests/src/main/docker/`. Because a key declared in all
@@ -206,9 +214,11 @@ declaration's *existence* is proven while its *boundary* is not.
   `gateway.yaml` ×4 -- base:222,245; cookie:97,110; mtls:104,121; ws:102,109
 | token-sheriff SSRF egress guard (GW-05 / BFF-07)
 | WIRED
-| `EgressAllowlistActivationWiringTest` -- every http-sourced issuer declares a non-empty allowlist
-  and every file-sourced issuer declares none. Descriptor-parsing only; no runtime egress refusal is
-  exercised, which is why this is `WIRED` and not `COVERED`.
+| `EgressAllowlistActivationWiringTest` -- every http-sourced issuer's allowlist is *exactly* the
+  host its own `jwks.url` names (no extra host, every entry a `String`), every file-sourced issuer
+  declares none, and every issuer's `jwks.source` is one of the two recognised values so none is
+  silently skipped. Descriptor-parsing only; no runtime egress refusal is exercised, which is why
+  this is `WIRED` and not `COVERED`.
 
 | *G3* Strict preset header-value length cap (1024)
   Layer 2 -- resolved, in no yaml
@@ -277,10 +287,19 @@ declaration's *existence* is proven while its *boundary* is not.
 *Real gap count when this sweep began: 11* -- eight outright `GAP` (G2--G9) plus three `PARTIAL`
 (G1, G10, G11).
 
-The sweep's hard ceiling is five assertions, so *the cap bound at its ceiling*: **G1--G5 are now
-closed** (their rows above name the asserting tests), ranked below by blast radius -- a limit whose
-breach degrades the whole gateway outranks one that degrades a single request. *Six remain*, and
-they are listed as the standing remainder so the class stays countable.
+The sweep's hard ceiling is five assertions, so *the cap bound at its ceiling*: **G1--G5 each
+received one** (their rows above name the asserting test), ranked below by blast radius -- a limit
+whose breach degrades the whole gateway outranks one that degrades a single request.
+
+*They did not all reach the same status.* **G1, G3, G4 and G5 reached `COVERED`** -- each is
+asserted at its boundary with a matched positive control. **G2 reached `WIRED` only**:
+`EgressAllowlistActivationWiringTest` proves the allowlist declaration is present and exactly
+scoped to the host its own `jwks.url` names, but no runtime egress refusal is exercised. By this
+note's own vocabulary that is not `COVERED`, so G2's runtime leg is *still open* and is counted
+below rather than dropped.
+
+*Seven items remain* -- the G2 runtime egress-refusal leg plus G6--G11 -- and they are listed as
+the standing remainder so the class stays countable.
 
 [cols="1,1,1,4"]
 |===
@@ -293,7 +312,8 @@ they are listed as the standing remainder so the class stays countable.
 
 | 2 | G2 | gateway-wide
 | The SSRF egress guard on JWKS fetch (GW-05 / BFF-07). Its loss unguards outbound fetches from a
-  security gateway.
+  security gateway. *Landed `WIRED`, not `COVERED`* -- the descriptor guard fails on drift, the
+  runtime refusal is still unasserted and is carried in the standing remainder.
 
 | 3 | G3 | gateway-wide
 | The resolved header-value floor every route inherits -- and the exact cap G1 carves out of.
@@ -310,9 +330,12 @@ they are listed as the standing remainder so the class stays countable.
 
 === The standing remainder
 
-*G6--G11 are deliberately not authored*, and are recorded so the class stays countable rather
-than forgotten:
+*The G2 runtime leg and G6--G11 are deliberately not authored*, and are recorded so the class stays
+countable rather than forgotten:
 
+* *G2* -- runtime egress-refusal leg: that a JWKS host *outside* `allowed_egress_hosts` is actually
+  refused. The descriptor half is `WIRED` by `EgressAllowlistActivationWiringTest`; proving the
+  refusal needs a rogue-host fixture the sweep's assertion budget could not fund.
 * *G6* -- strict parameter-value length cap (1024)
 * *G7* -- strict path length cap (1024)
 * *G8* -- `tls.alpn`
@@ -359,8 +382,10 @@ This table is prose, and prose drifts the moment a descriptor changes. Three pro
 
 . *Every row carries a `file:line` citation*, so a reviewer can check a row against the descriptor
   in one step rather than re-deriving the surface.
-. *The enumerated surface is stated explicitly* (twelve files, named), so a new descriptor
-  directory is visibly absent from this note rather than silently uncovered.
+. *The enumerated surface is stated explicitly* (twelve files, named) *and machine-checked*.
+  `DescriptorInventoryWiringTest` asserts that inventory as an exact set and re-runs the
+  limit-shaped key sweep over it, so a new descriptor directory, a new `endpoints/*.yaml` or a new
+  limit-shaped key fails the build rather than leaving this note silently stale.
 . *The wiring guards are the machine-enforced half.* `BodyLimitActivationWiringTest` and
   `EgressAllowlistActivationWiringTest` both assert a `COMMITTED_DESCRIPTOR_COUNT` floor, so a
   vacuous or mis-rooted glob fails loudly instead of passing over an empty set. This note indexes

--- a/doc/development/declared-limit-assertion-coverage.adoc
+++ b/doc/development/declared-limit-assertion-coverage.adoc
@@ -277,8 +277,9 @@ declaration's *existence* is proven while its *boundary* is not.
   envelope (not the framework's bare 413), one byte under is forwarded and echoed
 
 | *G5* `forward.headers_allow` / `query_allow` deny-by-default
-  `endpoints/httpbin.yaml:32-33,60-63,80,92,102` (5 routes);
-  `endpoints/bff-session.yaml:25` (1 route); `endpoints/grpc.yaml:48-50,67-69` (2 routes)
+  `sheriff-config/endpoints/httpbin.yaml:32-33,60-63,80,92,102` (5 routes);
+  `sheriff-config/endpoints/bff-session.yaml:25` (1 route);
+  `sheriff-config/endpoints/grpc.yaml:48-50,67-69` (2 routes)
 | Forward stage 5 (deny-by-default allow-listing)
 | COVERED
 | `DeclaredLimitBoundaryIT` -- one request carrying both an allow-listed and a non-allow-listed
@@ -458,8 +459,14 @@ a latent surprise.
 
 This table is prose, and prose drifts the moment a descriptor changes. Three properties limit that:
 
-. *Every row carries a `file:line` citation*, so a reviewer can check a row against the descriptor
-  in one step rather than re-deriving the surface.
+. *Every Layer 1 row carries a `file:line` citation*, so a reviewer can check a row against the
+  descriptor in one step rather than re-deriving the surface. The rule binds only to rows that have
+  a descriptor location. The five Layer 2 rows -- one per resolved cap enumerated in "The Two
+  Declaration Layers" -- carry the marker "Layer 2 -- resolved, in no yaml" in that slot instead,
+  because there is no descriptor line to cite. That marker is a claim rather than an excuse: it
+  asserts the value appears in *no* committed descriptor, which is precisely why such a limit is the
+  one most likely to lose its assertion unnoticed. A row carrying neither a citation nor that marker
+  is the drift this property exists to catch.
 . *The enumerated surface is stated explicitly* (twelve files, named) *and machine-checked against
   this note*. `DescriptorInventoryWiringTest` parses the marked blocks in "The Enumerated Surface"
   -- the inventory table, the sweep pattern and the nine limit-bearing paths -- and uses them as its

--- a/integration-tests/src/main/docker/sheriff-config/endpoints/secure.yaml
+++ b/integration-tests/src/main/docker/sheriff-config/endpoints/secure.yaml
@@ -14,3 +14,44 @@ endpoint:
     - id: secure-proxy
       match:
         path_prefix: /secure
+
+    # --- The bearer x security_filter interaction route -----------------------
+    # Until this route landed, the bearer-protected surface declared NO explicit
+    # security_filter anywhere, so the interaction of the two gates — auth and the
+    # inbound filter — was never exercised on a route carrying both. This route
+    # inherits `auth.require: bearer` from the 'secure' anchor (gateway.yaml:131-136)
+    # and adds its own filter block, so a single request can violate one gate, the
+    # other, or both. BearerSecurityFilterInteractionIT drives that full matrix and
+    # asserts WHICH gate wins when a request violates both.
+    #
+    # secure-proxy above is deliberately left untouched: BearerValidationIT measures
+    # it, and a route-shape change there would move that suite's fixture. The two
+    # prefixes are statically disjoint by specificity, exactly as /proxy and
+    # /proxy/minimal-mode coexist in endpoints/httpbin.yaml.
+    #
+    # Two design decisions here are load-bearing:
+    #
+    #   1. The block declares `profile: strict`, NOT `minimal`. Per ADR-0024 a
+    #      `minimal` profile on an effectively-authenticated route is refused
+    #      FAIL-CLOSED AT BOOT — declaring it here would abort this instance's boot
+    #      and take the whole IT stack down rather than produce a test result.
+    #
+    #   2. The block declares `allowed_paths` and deliberately NOT `max_body_bytes`.
+    #      A body cap declared here would land in the endpoints/ tree, which
+    #      BodyLimitActivationWiringTest's `sheriff-config*` glob resolves
+    #      gateway.yaml only and therefore never reaches (recorded as a report-only
+    #      finding in doc/development/declared-limit-assertion-coverage.adoc). The
+    #      new cap would sit outside the framework-floor guard entirely. An
+    #      allowed_paths allowlist probes the gate interaction just as sharply with
+    #      no framework-floor coupling, so this plan does not widen a hole it has
+    #      deliberately chosen to report rather than fix.
+    #
+    # The allowlist admits exactly one wildcard segment — /secure/filtered/<action>
+    # is admitted, a deeper path is a segment-count mismatch and is rejected —
+    # matching the httpbin-minimal-mode pattern the suite already proves.
+    - id: secure-filtered
+      match:
+        path_prefix: /secure/filtered
+      security_filter:
+        profile: strict
+        allowed_paths: ["/secure/filtered/{action}"]

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerSecurityFilterInteractionIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerSecurityFilterInteractionIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves how the two request gates <em>interact</em> on a route that carries both — an inherited
+ * bearer auth floor and its own explicit {@code security_filter} — rather than proving either gate in
+ * isolation.
+ * <p>
+ * The {@code secure-filtered} route ({@code endpoints/secure.yaml}) inherits {@code auth.require:
+ * bearer} from the {@code secure} anchor and declares a {@code security_filter} with
+ * {@code profile: strict} and a one-wildcard-segment {@code allowed_paths} allowlist. Before it
+ * existed, the bearer-protected surface declared no explicit filter anywhere, so no request could
+ * violate both gates at once and their ordering was never observable.
+ * <p>
+ * <strong>Which gate wins, and why that is the load-bearing assertion.</strong> The filter does. The
+ * pipeline runs {@code ThoroughChecksStage} (stage 3, per-route thorough checks — the
+ * {@code allowed_paths} allowlist) <em>before</em> {@code AuthenticationStage} (stage 4, offline
+ * bearer validation), so a request that violates both is rejected {@code 400 PATH_NOT_ALLOWED} and
+ * bearer validation never runs. The two tokenless cases below differ in <em>nothing but the path</em>
+ * and land on different statuses — {@code 401} when the path is allow-listed and the request survives
+ * to auth, {@code 400} when it does not — and that delta is what makes the ordering observable rather
+ * than assumed.
+ * <p>
+ * The {@code WWW-Authenticate: Bearer} header is the second, independent discriminator: stage 4
+ * attaches it to every auth rejection, so its <em>absence</em> on the 400s proves those rejections
+ * came from the filter and not from a differently-shaped auth failure. Status alone could not
+ * separate them.
+ * <p>
+ * The authenticated-but-disallowed case is what proves the filter is genuinely <em>active</em> on an
+ * authenticated route rather than shadowed by the auth gate, and the fully-valid case is the matched
+ * positive control proving the route works at all — without it every rejection above would be
+ * consistent with a route that is simply broken.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+class BearerSecurityFilterInteractionIT extends BaseIntegrationTest {
+
+    /**
+     * Matches the route's {@code allowed_paths} pattern {@code /secure/filtered/{action}} — exactly
+     * one wildcard segment.
+     */
+    private static final String ALLOWED_PATH = "/secure/filtered/echo";
+
+    /**
+     * One segment deeper than the allowlist pattern admits. The matcher compares segment counts
+     * exactly, so this is a {@code PATH_NOT_ALLOWED} miss and not a route-selection miss: it still
+     * resolves to the {@code secure-filtered} route via its {@code /secure/filtered} prefix.
+     */
+    private static final String DENIED_PATH = "/secure/filtered/deep/path";
+
+    private static final String PROBLEM_JSON = "application/problem+json";
+    private static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+
+    @Test
+    @DisplayName("no token on an allow-listed path is rejected 401 — the request survives the filter and reaches auth")
+    void tokenlessRequestOnAllowedPathIsRejectedByAuth() {
+        // Act
+        var response = given()
+                .when()
+                .get(ALLOWED_PATH)
+                .then()
+                .statusCode(401)
+                .header(WWW_AUTHENTICATE, "Bearer")
+                .extract();
+
+        // Assert — the path cleared stage 3, so stage 4 is what rejected this. Paired with the case
+        // below (identical request, deeper path) this is half of the ordering proof.
+        assertTrue(response.contentType().contains(PROBLEM_JSON));
+        assertNull(response.path("method"), "a rejected request must not reach the go-httpbin upstream");
+    }
+
+    @Test
+    @DisplayName("no token on a path outside allowed_paths is rejected 400 — the filter wins over auth")
+    void tokenlessRequestOnDeniedPathIsRejectedByTheFilter() {
+        // Act — identical to the case above in every respect except the path.
+        var response = given()
+                .when()
+                .get(DENIED_PATH)
+                .then()
+                .statusCode(400)
+                .extract();
+
+        // Assert — THE ordering assertion. This request violates BOTH gates, and the 400 (not 401)
+        // shows the per-route filter rejected it at stage 3 before bearer validation ran at stage 4.
+        // The absent WWW-Authenticate is the independent confirmation: stage 4 attaches that header to
+        // every auth rejection, so its absence means stage 4 was never reached.
+        assertTrue(response.contentType().contains(PROBLEM_JSON));
+        assertNull(response.header(WWW_AUTHENTICATE),
+                "a filter rejection must not carry WWW-Authenticate — its presence would mean the auth"
+                        + " stage ran and the gate ordering is the reverse of what this asserts");
+        assertNull(response.path("method"), "a rejected request must not reach the go-httpbin upstream");
+    }
+
+    @Test
+    @DisplayName("a valid token on a path outside allowed_paths is still rejected 400 by the filter")
+    void authenticatedRequestOnDeniedPathIsRejectedByTheFilter() {
+        // Arrange — a real token from the trusted integration realm, so auth would admit this request.
+        String authorization = "Bearer " + BearerValidationIT.mintIntegrationRealmAccessToken();
+
+        // Act
+        var response = given()
+                .header("Authorization", authorization)
+                .when()
+                .get(DENIED_PATH)
+                .then()
+                .statusCode(400)
+                .extract();
+
+        // Assert — proves the filter is genuinely ACTIVE on an authenticated route and not shadowed by
+        // the auth gate. Without this case, the 400 above would be equally consistent with a filter
+        // that only ever fires on requests auth would have rejected anyway.
+        assertTrue(response.contentType().contains(PROBLEM_JSON));
+        assertNull(response.path("method"), "a rejected request must not reach the go-httpbin upstream");
+    }
+
+    @Test
+    @DisplayName("a valid token on an allow-listed path is admitted and forwarded to the upstream")
+    void authenticatedRequestOnAllowedPathIsForwarded() {
+        // Arrange
+        String authorization = "Bearer " + BearerValidationIT.mintIntegrationRealmAccessToken();
+
+        // Act
+        var response = given()
+                .header("Authorization", authorization)
+                .when()
+                .get(ALLOWED_PATH)
+                .then()
+                .statusCode(200)
+                .extract();
+
+        // Assert — the matched positive control for the whole matrix: both gates pass and the request
+        // actually reaches go-httpbin. Every rejection above is therefore a decision by a specific
+        // gate, not evidence of a route that never worked.
+        assertEquals("GET", response.path("method"),
+                "an admitted request must reach the upstream and echo its method");
+    }
+}

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
@@ -143,9 +143,14 @@ class BearerValidationIT extends BaseIntegrationTest {
      * minted token carries the container-internal {@code iss} the gateway's {@code integration-keycloak}
      * issuer declares — the host-published mint port does not change the issuer claim.
      *
+     * <p>
+     * Package-private rather than private so {@code BearerSecurityFilterInteractionIT} drives the same
+     * acquisition instead of introducing a second token helper — one realm/client/user fixture, one
+     * place to fix when the realm import changes.
+     *
      * @return the raw access token
      */
-    private static String mintIntegrationRealmAccessToken() {
+    static String mintIntegrationRealmAccessToken() {
         Response response = given()
                 .contentType(ContentType.URLENC)
                 .formParam("grant_type", "password")

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BodyLimitActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BodyLimitActivationWiringTest.java
@@ -50,10 +50,11 @@ import org.junit.jupiter.api.Test;
  * unit test — only to a descriptor assertion like this one, or to the expensive container suite.
  * <p>
  * The coverage is deliberately <strong>all committed descriptors, not just the base one</strong>:
- * the compose stack boots five native gateway instances over four {@code sheriff-config*} gateway
+ * the compose stack boots six native gateway instances over four {@code sheriff-config*} gateway
  * descriptors ({@code api-sheriff}, {@code api-sheriff-mtls}, {@code api-sheriff-cookie},
- * {@code api-sheriff-cookie-2} and {@code api-sheriff-ws-admission}), so a cap raised in any sibling
- * descriptor pushes that instance into a boot abort. The descriptors are discovered by glob rather
+ * {@code api-sheriff-cookie-2}, {@code api-sheriff-ws-admission} and
+ * {@code api-sheriff-plain-mgmt}), so a cap raised in any sibling descriptor pushes that instance
+ * into a boot abort. The descriptors are discovered by glob rather
  * than hard-coded, so a new {@code sheriff-config-*} directory comes under the assertion
  * automatically — and a glob that matches fewer than the four present today fails rather than
  * passing vacuously.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DeclaredLimitBoundaryIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DeclaredLimitBoundaryIT.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Boundary assertions for declared gateway limits that the landed corpus names but never exercises
+ * <em>at their boundary</em>. Each case proves a cap rejects <strong>because of the value</strong>,
+ * so every negative leg is paired with a matched positive control one unit the other side of the
+ * cap.
+ * <p>
+ * The coverage matrix this suite closes five rows of is
+ * {@code doc/development/declared-limit-assertion-coverage.adoc}.
+ * <p>
+ * <strong>Two of the caps asserted here appear in no descriptor.</strong> {@code /proxy} declares no
+ * {@code security_filter.profile}, so it resolves the gateway-wide
+ * {@code security_defaults.profile: strict} and inherits that preset's <em>resolved</em> caps — a
+ * 1 MiB body and 1024-character header values. Those numbers are written in no yaml file, which is
+ * precisely why they are the limits most likely to lose their guard unnoticed.
+ * <p>
+ * <strong>What the Authorization pair really proves.</strong> {@code G1} and {@code G3} are one
+ * assertion split in two, and neither means much alone. {@code security_defaults
+ * .max_authorization_header_value_length: 8192} is an ADR-0019 carve-out from the strict preset's
+ * 1024-character header-value floor, taken at the non-skippable pre-route floor
+ * ({@code BasicChecksStage}) that runs <em>before</em> route selection. Asserting only the carve-out
+ * would pass equally well against a relaxation that had silently widened to <em>every</em> header;
+ * asserting only the 1024 floor would pass against a gateway with no carve-out at all — under which
+ * every bearer request is rejected 400 before bearer validation ever runs. Together they pin the
+ * relaxation's <em>scope</em>: {@code Authorization} gets 8192, everything else still gets 1024.
+ * <p>
+ * The existing {@code BearerValidationIT} proves the carve-out is <em>in force</em> (a real token
+ * above 1024 characters is admitted). It never probes 8192 itself, which is the gap this suite
+ * closes.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+class DeclaredLimitBoundaryIT extends BaseIntegrationTest {
+
+    /**
+     * The declared {@code security_defaults.max_authorization_header_value_length} — the carve-out
+     * bounding the {@code Authorization} header VALUE at the pre-route floor.
+     */
+    private static final int AUTHORIZATION_VALUE_CAP = 8192;
+
+    /** The strict preset's resolved header-value cap, applying to every OTHER header name. */
+    private static final int STRICT_HEADER_VALUE_CAP = 1024;
+
+    /** The strict preset's resolved body cap (1 MiB) inherited by every route omitting its own. */
+    private static final int STRICT_BODY_CAP_BYTES = 1048576;
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String PROBLEM_JSON = "application/problem+json";
+    private static final String INPUT_VALIDATION_TYPE = "urn:api-sheriff:problem:input-validation";
+
+    /** The bearer-protected route: only here does an admitted header reach bearer validation. */
+    private static final String SECURE_PATH = "/secure/get";
+
+    /** The strict, public route inheriting the gateway-wide preset. */
+    private static final String PROXY_GET_PATH = "/proxy/get";
+    private static final String PROXY_POST_PATH = "/proxy/post";
+
+    @Nested
+    @DisplayName("G1 — the Authorization carve-out admits up to its declared 8192-character cap")
+    class AuthorizationHeaderValueCap {
+
+        @Test
+        @DisplayName("an Authorization value at the 8192 cap is admitted and reaches bearer validation")
+        void authorizationValueAtCapReachesBearerValidation() {
+            // Arrange — exactly AUTHORIZATION_VALUE_CAP characters, syntactically a bearer credential
+            // but not a valid token.
+            String atCap = BEARER_PREFIX + "a".repeat(AUTHORIZATION_VALUE_CAP - BEARER_PREFIX.length());
+            assertEquals(AUTHORIZATION_VALUE_CAP, atCap.length(), "the at-cap probe must measure exactly the cap");
+
+            // Act
+            var response = given()
+                    .header("Authorization", atCap)
+                    .when()
+                    .get(SECURE_PATH)
+                    .then()
+                    .statusCode(401)
+                    .extract();
+
+            // Assert — 401 (not 400) is the load-bearing discriminator: the header was ADMITTED by the
+            // pre-route floor and rejected later, by stage-4 bearer validation, for being an invalid
+            // token. A 400 here would mean the floor refused the header outright and the carve-out is
+            // gone or narrower than declared.
+            assertTrue(response.contentType().contains(PROBLEM_JSON),
+                    "a bearer rejection carries the gateway's RFC 9457 envelope");
+            assertNull(response.path("method"), "a rejected request must not reach the go-httpbin upstream");
+        }
+
+        @Test
+        @DisplayName("an Authorization value one character over the cap is rejected 400 at the pre-route floor")
+        void authorizationValueOverCapIsRejectedAtTheFloor() {
+            // Arrange — one character past the cap; everything else identical to the admitted case.
+            String overCap = BEARER_PREFIX + "a".repeat(AUTHORIZATION_VALUE_CAP - BEARER_PREFIX.length() + 1);
+            assertEquals(AUTHORIZATION_VALUE_CAP + 1, overCap.length(),
+                    "the over-cap probe must measure exactly one over the cap");
+
+            // Act + Assert — 400 from BasicChecksStage, before route selection and before bearer
+            // validation. The single-character delta from the case above is what proves the rejection
+            // is about the LENGTH and not about the credential.
+            given()
+                    .header("Authorization", overCap)
+                    .when()
+                    .get(SECURE_PATH)
+                    .then()
+                    .statusCode(400);
+        }
+    }
+
+    @Nested
+    @DisplayName("G3 — the strict preset's 1024-character floor still binds every other header")
+    class StrictHeaderValueCap {
+
+        private static final String PROBE_HEADER = "X-Sheriff-Length-Probe";
+
+        @Test
+        @DisplayName("a non-Authorization header value at 1024 characters is admitted and forwarded")
+        void headerValueAtStrictCapIsAdmitted() {
+            // Arrange
+            String atCap = "a".repeat(STRICT_HEADER_VALUE_CAP);
+
+            // Act
+            var response = given()
+                    .header(PROBE_HEADER, atCap)
+                    .when()
+                    .get(PROXY_GET_PATH)
+                    .then()
+                    .statusCode(200)
+                    .extract();
+
+            // Assert — 200 plus an echo body is the whole assertion, deliberately. The probe header is
+            // NOT allow-listed by /proxy's forward.headers_allow (which carries Content-Type only), so
+            // the deny-by-default forward stage strips it before the upstream — asserting it appears in
+            // the echoed headers map would be asserting the opposite of what G5 below proves. The echo
+            // is what shows the request actually reached go-httpbin rather than being answered by some
+            // earlier gate; the 400-vs-200 delta against the case below is what makes this a cap test.
+            assertNotNull(response.path("method"),
+                    "an admitted request must reach the upstream — its echo carries the method");
+        }
+
+        @Test
+        @DisplayName("a non-Authorization header value at 1025 characters is rejected 400")
+        void headerValueOverStrictCapIsRejected() {
+            // Arrange — one character past the strict floor.
+            String overCap = "a".repeat(STRICT_HEADER_VALUE_CAP + 1);
+
+            // Act + Assert — the carve-out is scoped to Authorization by name, so this header gets the
+            // preset floor and nothing else. Paired with G1's admitted 8192-character Authorization,
+            // this is what proves the relaxation did not silently widen to every header.
+            given()
+                    .header(PROBE_HEADER, overCap)
+                    .when()
+                    .get(PROXY_GET_PATH)
+                    .then()
+                    .statusCode(400);
+        }
+    }
+
+    @Nested
+    @DisplayName("G4 — the inherited strict body cap (1 MiB) binds a route that declares none")
+    class StrictInheritedBodyCap {
+
+        @Test
+        @DisplayName("a body one byte over the inherited 1 MiB cap is rejected 413 by the gateway")
+        void bodyOverInheritedCapIsRejectedByTheGateway() {
+            // Arrange
+            byte[] overCap = new byte[STRICT_BODY_CAP_BYTES + 1];
+            Arrays.fill(overCap, (byte) 'x');
+
+            // Act
+            var response = given()
+                    .contentType("text/plain")
+                    .body(overCap)
+                    .when()
+                    .post(PROXY_POST_PATH)
+                    .then()
+                    .statusCode(413)
+                    .extract();
+
+            // Assert — the envelope, not just the status, is what proves the GATEWAY rejected this. The
+            // compose stack raises the framework floor to 128M (docker-compose.yml:242), far above this
+            // 1 MiB cap, so the Quarkus root handler cannot shadow the gateway here — and its own
+            // pre-check would answer a bare 413 carrying no problem+json body at all.
+            assertTrue(response.contentType().contains(PROBLEM_JSON),
+                    "the gateway must render its own RFC 9457 envelope, not the framework's bare 413");
+            String problemType = response.path("type");
+            assertTrue(String.valueOf(problemType).contains(INPUT_VALIDATION_TYPE),
+                    "an oversize body is an input-validation rejection, type was: " + problemType);
+            assertEquals("Input Validation", response.path("title"));
+            assertNull(response.path("method"), "a rejected request must not reach the go-httpbin upstream");
+        }
+
+        @Test
+        @DisplayName("a body one byte under the inherited cap is forwarded and echoed")
+        void bodyUnderInheritedCapIsForwarded() {
+            // Arrange — the matched positive control: one byte the other side of the same cap, proving
+            // the rejection above is about the SIZE and not about POST or a body being refused on this
+            // route outright.
+            byte[] underCap = new byte[STRICT_BODY_CAP_BYTES - 1];
+            Arrays.fill(underCap, (byte) 'x');
+
+            // Act
+            var response = given()
+                    .contentType("text/plain")
+                    .body(underCap)
+                    .when()
+                    .post(PROXY_POST_PATH)
+                    .then()
+                    .statusCode(200)
+                    .extract();
+
+            // Assert
+            assertEquals("POST", response.path("method"),
+                    "an accepted body must reach the go-httpbin upstream and echo its method");
+        }
+    }
+
+    @Nested
+    @DisplayName("G5 — the forward stage is deny-by-default for headers and query parameters")
+    class ForwardAllowlistDenyByDefault {
+
+        /** Allow-listed by endpoints/httpbin.yaml's forward.query_allow on the /proxy route. */
+        private static final String ALLOWED_QUERY = "probe";
+
+        /** Deliberately absent from that allowlist. */
+        private static final String DENIED_QUERY = "smuggled";
+
+        /** Allow-listed by that route's forward.headers_allow. */
+        private static final String ALLOWED_HEADER = "Content-Type";
+
+        /** Deliberately absent from that allowlist. */
+        private static final String DENIED_HEADER = "X-Sheriff-Smuggled";
+
+        @Test
+        @DisplayName("one request: the allow-listed header and query cross, the non-allow-listed pair is stripped")
+        void nonAllowListedHeaderAndQueryAreStripped() {
+            // Arrange + Act — a SINGLE request carrying both pairs, so the positive control and the
+            // negative assertion observe the same forward decision rather than two separate requests
+            // that could differ for unrelated reasons.
+            var response = given()
+                    .contentType("text/plain")
+                    .header(DENIED_HEADER, "must-not-cross")
+                    .queryParam(ALLOWED_QUERY, "allow-listed-value")
+                    .queryParam(DENIED_QUERY, "must-not-cross")
+                    .when()
+                    .get(PROXY_GET_PATH)
+                    .then()
+                    .statusCode(200)
+                    .extract();
+
+            // Assert — the allow-listed query crossed (positive control: the stage forwards what it is
+            // told to forward, so a stripped denied name is a DECISION and not a broken stage) ...
+            assertEquals("allow-listed-value", response.path("args." + ALLOWED_QUERY + "[0]"),
+                    "the allow-listed query parameter must reach the upstream");
+
+            // ... and the non-allow-listed one did not.
+            assertNull(response.path("args." + DENIED_QUERY),
+                    "a query parameter absent from query_allow must be stripped before the upstream");
+
+            Map<String, ?> forwardedHeaders = response.path("headers");
+            assertNotNull(forwardedHeaders, "go-httpbin echoes the headers it received");
+            assertTrue(containsIgnoringCase(forwardedHeaders, ALLOWED_HEADER),
+                    "the allow-listed header must reach the upstream, echoed headers were: "
+                            + forwardedHeaders.keySet());
+            assertFalse(containsIgnoringCase(forwardedHeaders, DENIED_HEADER),
+                    "a header absent from headers_allow must be stripped before the upstream, echoed headers were: "
+                            + forwardedHeaders.keySet());
+        }
+
+        /**
+         * Case-insensitive key lookup. HTTP header names are case-insensitive and both the gateway and
+         * the upstream may canonicalise them, so an exact-key check could report a smuggled header as
+         * absent merely because its casing changed in transit.
+         *
+         * @param headers the echoed header map
+         * @param name the header name to look for
+         * @return {@code true} when any key matches ignoring case
+         */
+        private static boolean containsIgnoringCase(Map<String, ?> headers, String name) {
+            return headers.keySet().stream().anyMatch(key -> key.equalsIgnoreCase(name));
+        }
+    }
+}

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
@@ -17,6 +17,8 @@ package de.cuioss.sheriff.gateway.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.yaml.snakeyaml.Yaml;
 
@@ -37,8 +40,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Fast, no-Docker <em>surefire</em> guard that makes the descriptor inventory claimed in prose by
- * {@code doc/development/declared-limit-assertion-coverage.adoc} machine-checked.
+ * Fast, no-Docker <em>surefire</em> guard that makes the descriptor inventory claimed by
+ * {@code doc/development/declared-limit-assertion-coverage.adoc} machine-checked
+ * <em>against that note</em>.
  * <p>
  * That note opens by enumerating the declared surface as <em>twelve files</em> — four
  * {@code gateway.yaml} documents, one per {@code sheriff-config*} directory, seven
@@ -49,18 +53,23 @@ import org.junit.jupiter.api.Test;
  * descriptor the note never enumerated is not merely undocumented, it is <em>invisible</em> to the
  * whole coverage index.
  * <p>
- * Nothing machine-checked either claim before this guard. The sibling wiring guards glob the
- * {@code sheriff-config*} directories and resolve one {@code gateway.yaml} inside each — they never
- * reach {@code endpoints/} or {@code topology.properties} — and their descriptor assertion is an
- * <em>at-least</em> floor
- * ({@code size() >= COMMITTED_DESCRIPTOR_COUNT}), which a newly added file satisfies without
- * complaint. So an added overlay directory, an added endpoint document, or a new limit-shaped key
- * in a file the note records as declaring none would all leave the checked-in note quietly wrong
- * with a green build.
+ * <strong>This guard owns no copy of either claim.</strong> It reads three AsciiDoc tagged blocks
+ * out of the note at runtime — {@code inventory}, {@code limit-key-regex} and
+ * {@code limit-bearing} — and uses the parsed values as its expected sets. That direction matters:
+ * with the expectations transcribed into constants instead, adding a descriptor would fail the
+ * test, a developer would update the constants, the build would go green, and the note would never
+ * be touched — the very drift this guard exists to prevent. Deriving from the note makes the note
+ * the only place the expectation can be changed.
  * <p>
- * This guard asserts <strong>exact set equality</strong> rather than a floor, in both directions:
- * an addition and a removal each fail loudly, and the failure message names the note so the fix is
- * obvious — update the note in the same change that touches the surface.
+ * It asserts <strong>exact set equality</strong> rather than a floor, in both directions: an
+ * addition and a removal each fail loudly, and the failure message names the note so the fix is
+ * obvious.
+ * <p>
+ * <strong>Anti-vacuity.</strong> A derivation that silently yields an empty expected set and then
+ * passes would be strictly worse than the transcribed constants it replaces, so every failure of
+ * the derivation itself is loud: a note that cannot be located, a missing or unterminated marker, a
+ * block with no content, a block that yields no path, and a sweep block that does not hold exactly
+ * one pattern each fail with a message naming the resolved note path.
  * <p>
  * It parses the committed descriptors only — it starts no container and reaches no network. It is
  * deliberately <em>additive</em>: it does not widen the sibling guards' globs, whose narrower reach
@@ -75,62 +84,26 @@ class DescriptorInventoryWiringTest {
     private static final Path MODULE = Path.of(System.getProperty("user.dir"));
     private static final Path DOCKER = MODULE.resolve("src/main/docker");
 
-    /** The prose claim this guard machine-checks; named in every failure message. */
+    /** The note this guard derives from, relative to the repository root. */
     private static final String NOTE = "doc/development/declared-limit-assertion-coverage.adoc";
 
-    /** The four gateway documents the note's "Enumerated Surface" section names. */
-    private static final Set<String> DECLARED_GATEWAY_DESCRIPTORS = Set.of(
-            "sheriff-config/gateway.yaml",
-            "sheriff-config-cookie/gateway.yaml",
-            "sheriff-config-mtls/gateway.yaml",
-            "sheriff-config-ws-admission/gateway.yaml");
+    /** The note's tagged block holding the enumerated-surface table. */
+    private static final String TAG_INVENTORY = "inventory";
 
-    /** The seven endpoint documents the note's "Enumerated Surface" section names. */
-    private static final Set<String> DECLARED_ENDPOINT_DESCRIPTORS = Set.of(
-            "sheriff-config/endpoints/assets.yaml",
-            "sheriff-config/endpoints/assets-secure.yaml",
-            "sheriff-config/endpoints/bff-session.yaml",
-            "sheriff-config/endpoints/grpc.yaml",
-            "sheriff-config/endpoints/httpbin.yaml",
-            "sheriff-config/endpoints/secure.yaml",
-            "sheriff-config/endpoints/websocket.yaml");
+    /** The note's tagged block holding the limit-shaped key sweep pattern. */
+    private static final String TAG_LIMIT_KEY_REGEX = "limit-key-regex";
 
-    /** The single alias file; declares no limit-shaped key, which the sweep below re-proves. */
-    private static final String DECLARED_TOPOLOGY = "sheriff-config/topology.properties";
+    /** The note's tagged block holding the files recorded as declaring a limit-shaped key. */
+    private static final String TAG_LIMIT_BEARING = "limit-bearing";
 
-    /**
-     * The note's limit-shaped key sweep, transcribed verbatim from its "Enumerated Surface"
-     * section. It is applied to declared KEY NAMES only — never to raw file text — so the
-     * descriptors' extensive prose comments cannot manufacture a hit.
-     */
-    private static final Pattern LIMIT_SHAPED_KEY = Pattern.compile(
-            "max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold"
-                    + "|budget|quota|window|depth");
-
-    /**
-     * The nine files the note records as declaring at least one limit-shaped key. Its complement
-     * within the inventory — {@code assets.yaml}, {@code assets-secure.yaml} and
-     * {@code topology.properties} — is the "declare none" half of the same claim, so asserting this
-     * set exactly asserts both halves at once.
-     */
-    private static final Set<String> DECLARED_LIMIT_BEARING_FILES = Set.of(
-            "sheriff-config/gateway.yaml",
-            "sheriff-config-cookie/gateway.yaml",
-            "sheriff-config-mtls/gateway.yaml",
-            "sheriff-config-ws-admission/gateway.yaml",
-            "sheriff-config/endpoints/bff-session.yaml",
-            "sheriff-config/endpoints/grpc.yaml",
-            "sheriff-config/endpoints/httpbin.yaml",
-            "sheriff-config/endpoints/secure.yaml",
-            "sheriff-config/endpoints/websocket.yaml");
+    /** Backtick-delimited span — the note writes every path and the sweep pattern as monospace. */
+    private static final Pattern MONOSPACE_SPAN = Pattern.compile("`([^`]+)`");
 
     @Test
-    @DisplayName("the committed descriptor inventory is exactly the twelve files the note enumerates")
+    @DisplayName("the committed descriptor inventory is exactly the surface the note enumerates")
     void descriptorInventoryIsExactlyTheEnumeratedSurface() throws Exception {
-        // Arrange — the note's claim, assembled from the three surfaces it lists separately
-        Set<String> declared = new TreeSet<>(DECLARED_GATEWAY_DESCRIPTORS);
-        declared.addAll(DECLARED_ENDPOINT_DESCRIPTORS);
-        declared.add(DECLARED_TOPOLOGY);
+        // Arrange — the note's own claim, parsed rather than transcribed
+        Set<String> declared = declaredPaths(TAG_INVENTORY);
 
         // Act
         Set<String> committed = committedInventory();
@@ -138,33 +111,156 @@ class DescriptorInventoryWiringTest {
         // Assert — exact equality, so an ADDED descriptor fails just as loudly as a removed one.
         // A floor would let a new overlay directory or a new endpoints/*.yaml slip in unrecorded.
         assertEquals(declared, committed, "the committed descriptor inventory under " + DOCKER
-                + " no longer matches the twelve files enumerated in " + NOTE
+                + " no longer matches the surface enumerated in " + note()
                 + ". Every status row in that note is scoped to this surface, so a descriptor it does"
                 + " not enumerate is invisible to the whole coverage index — add or remove the row in"
-                + " the same change that adds or removes the file.");
+                + " the same change that adds or removes the file. This guard reads its expectation"
+                + " from the note's '" + TAG_INVENTORY + "' block, so the note is the only place the"
+                + " expectation can be corrected.");
     }
 
     @Test
     @DisplayName("no limit-shaped key lives outside the surfaces the note records as declaring one")
     void limitShapedKeysLiveOnlyInTheRecordedSurfaces() throws Exception {
-        // Arrange
+        // Arrange — both the sweep and the expected partition come from the note
+        Pattern sweep = declaredLimitShapedKeyPattern();
+        Set<String> declaredLimitBearing = declaredPaths(TAG_LIMIT_BEARING);
         Set<String> committed = committedInventory();
 
         // Act — partition the inventory on "declares at least one limit-shaped key"
         Set<String> limitBearing = new TreeSet<>();
         for (String relative : committed) {
-            if (declaresLimitShapedKey(relative)) {
+            if (declaresLimitShapedKey(relative, sweep)) {
                 limitBearing.add(relative);
             }
         }
 
         // Assert — exact equality asserts both halves of the note's claim in one step: the files it
         // says declare limits still do, and the files it says declare none still declare none.
-        assertEquals(DECLARED_LIMIT_BEARING_FILES, limitBearing,
-                "the set of descriptors declaring a limit-shaped key no longer matches " + NOTE
+        assertEquals(declaredLimitBearing, limitBearing,
+                "the set of descriptors declaring a limit-shaped key no longer matches " + note()
                         + ". A newly limit-bearing file has no status row and is therefore an unasserted"
                         + " declared limit; a file that lost its keys leaves a stale row behind. Update"
-                        + " the note's Coverage Matrix in the same change.");
+                        + " the note's '" + TAG_LIMIT_BEARING + "' block and its Coverage Matrix in the"
+                        + " same change.");
+    }
+
+    @Test
+    @DisplayName("the note's three marked blocks are present, non-empty and mutually consistent")
+    void theDerivationFromTheNoteIsNotVacuous() throws Exception {
+        // Arrange + Act — each accessor fails loudly on an absent note, a missing or unterminated
+        // marker, an empty block, or a block that yields nothing usable
+        Set<String> inventory = declaredPaths(TAG_INVENTORY);
+        Set<String> limitBearing = declaredPaths(TAG_LIMIT_BEARING);
+        Pattern sweep = declaredLimitShapedKeyPattern();
+
+        // Assert — a derived expectation is only worth having if it is non-empty and self-consistent
+        assertFalse(sweep.pattern().isBlank(),
+                "the '" + TAG_LIMIT_KEY_REGEX + "' block in " + note() + " yields a blank pattern,"
+                        + " which would match nothing and make the sweep assertion vacuous");
+        assertTrue(inventory.containsAll(limitBearing),
+                "the '" + TAG_LIMIT_BEARING + "' block in " + note() + " names paths that its '"
+                        + TAG_INVENTORY + "' block does not enumerate: "
+                        + difference(limitBearing, inventory)
+                        + ". A limit-bearing file outside the enumerated surface cannot be asserted,"
+                        + " because the sweep only ever partitions the enumerated surface.");
+    }
+
+    /**
+     * The note's location, resolved explicitly from the module working directory. Surefire runs with
+     * the {@code integration-tests} module root as the working directory and the note lives at the
+     * repository root, hence the step up to the parent.
+     *
+     * @return the note's absolute path
+     */
+    private static Path note() {
+        Path repositoryRoot = MODULE.getParent();
+        assertNotNull(repositoryRoot, "the module directory " + MODULE + " has no parent, so the"
+                + " repository root — and with it " + NOTE + ", from which this guard derives every"
+                + " expectation — cannot be resolved");
+        Path note = repositoryRoot.resolve(NOTE);
+        assertTrue(Files.isRegularFile(note), "the note this guard derives its expectations from was"
+                + " not found at " + note + " (resolved from the module working directory " + MODULE
+                + "). It was moved, renamed or removed: point this guard at the new location in the"
+                + " same change, rather than leaving it to derive nothing and pass.");
+        return note;
+    }
+
+    /**
+     * The lines strictly between an AsciiDoc {@code tag::NAME[]} / {@code end::NAME[]} marker pair in
+     * the note. The markers are line comments, so they do not affect the rendered document.
+     *
+     * @param tag the marker name
+     * @return the block's lines, guaranteed to contain at least one non-blank line
+     * @throws IOException when the note cannot be read
+     */
+    private static List<String> taggedBlock(String tag) throws IOException {
+        Path note = note();
+        List<String> lines = Files.readAllLines(note);
+        String open = "// tag::" + tag + "[]";
+        String close = "// end::" + tag + "[]";
+        int from = lines.indexOf(open);
+        int to = lines.indexOf(close);
+        assertTrue(from >= 0, "the marker '" + open + "' is absent from " + note
+                + ", so this guard has no expectation to derive. Restore the marker (it must stand"
+                + " alone on its own line, unindented) rather than leaving the guard vacuous.");
+        assertTrue(to > from, "the marker '" + close + "' is absent from " + note
+                + " or precedes its opening marker, so the '" + tag + "' block cannot be read.");
+        List<String> block = new ArrayList<>(lines.subList(from + 1, to));
+        assertTrue(block.stream().anyMatch(line -> !line.isBlank()), "the '" + tag + "' block in "
+                + note + " is empty. An empty block would derive an empty expectation and pass"
+                + " vacuously, which is why it fails here instead.");
+        return block;
+    }
+
+    /**
+     * Every descriptor path a tagged block spells. Paths are written as monospace spans; glob
+     * patterns (spans containing {@code *}) are the note's surface labels rather than files and are
+     * skipped.
+     *
+     * @param tag the marker name of the block to read
+     * @return the parsed paths, sorted for a readable assertion diff and guaranteed non-empty
+     * @throws IOException when the note cannot be read
+     */
+    private static Set<String> declaredPaths(String tag) throws IOException {
+        Set<String> paths = new TreeSet<>();
+        for (String line : taggedBlock(tag)) {
+            Matcher matcher = MONOSPACE_SPAN.matcher(line);
+            while (matcher.find()) {
+                String span = matcher.group(1).trim();
+                if (span.indexOf('*') < 0 && !span.isEmpty()) {
+                    paths.add(span);
+                }
+            }
+        }
+        assertFalse(paths.isEmpty(), "the '" + tag + "' block in " + note() + " spells no descriptor"
+                + " path (paths are written as monospace spans; glob patterns are skipped). An empty"
+                + " expected set would pass against anything, so it fails here instead.");
+        return paths;
+    }
+
+    /**
+     * The note's limit-shaped key sweep, compiled from the pattern the note states. The pattern is
+     * repository-controlled prose from a checked-in document — never external or request-supplied
+     * input — and is applied to declared KEY NAMES only, never to raw file text, so the descriptors'
+     * extensive prose comments cannot manufacture a hit.
+     *
+     * @return the compiled sweep
+     * @throws IOException when the note cannot be read
+     */
+    private static Pattern declaredLimitShapedKeyPattern() throws IOException {
+        List<String> spans = new ArrayList<>();
+        for (String line : taggedBlock(TAG_LIMIT_KEY_REGEX)) {
+            Matcher matcher = MONOSPACE_SPAN.matcher(line);
+            while (matcher.find()) {
+                spans.add(matcher.group(1).trim());
+            }
+        }
+        assertEquals(1, spans.size(), "the '" + TAG_LIMIT_KEY_REGEX + "' block in " + note()
+                + " must hold exactly one monospace span — the sweep pattern — but holds " + spans.size()
+                + ": " + spans + ". Anything else is ambiguous, and guessing would risk deriving a"
+                + " pattern that matches nothing.");
+        return Pattern.compile(spans.getFirst());
     }
 
     /**
@@ -204,10 +300,11 @@ class DescriptorInventoryWiringTest {
      * keys and therefore no limit.
      *
      * @param relative the file's docker-relative path
+     * @param sweep the note's limit-shaped key pattern
      * @return {@code true} when at least one declared key name matches the note's sweep
      * @throws IOException when the file cannot be read
      */
-    private static boolean declaresLimitShapedKey(String relative) throws IOException {
+    private static boolean declaresLimitShapedKey(String relative, Pattern sweep) throws IOException {
         Set<String> keys = new TreeSet<>();
         Path file = DOCKER.resolve(relative);
         if (relative.endsWith(".yaml")) {
@@ -216,7 +313,7 @@ class DescriptorInventoryWiringTest {
             keys.addAll(loadProperties(file).stringPropertyNames());
         }
         return keys.stream()
-                .anyMatch(key -> LIMIT_SHAPED_KEY.matcher(key.toLowerCase(Locale.ROOT)).find());
+                .anyMatch(key -> sweep.matcher(key.toLowerCase(Locale.ROOT)).find());
     }
 
     /**
@@ -237,6 +334,19 @@ class DescriptorInventoryWiringTest {
                 collectKeys(item, keys);
             }
         }
+    }
+
+    /**
+     * The members of {@code candidate} absent from {@code reference}, for a legible failure message.
+     *
+     * @param candidate the set whose surplus members are wanted
+     * @param reference the set to subtract
+     * @return the difference, sorted
+     */
+    private static Set<String> difference(Set<String> candidate, Set<String> reference) {
+        Set<String> surplus = new TreeSet<>(candidate);
+        surplus.removeAll(reference);
+        return surplus;
     }
 
     private static Object loadYaml(Path path) throws IOException {

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.yaml.snakeyaml.Yaml;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fast, no-Docker <em>surefire</em> guard that makes the descriptor inventory claimed in prose by
+ * {@code doc/development/declared-limit-assertion-coverage.adoc} machine-checked.
+ * <p>
+ * That note opens by enumerating the declared surface as <em>twelve files</em> — four
+ * {@code gateway.yaml} documents, one per {@code sheriff-config*} directory, seven
+ * {@code sheriff-config/endpoints/*.yaml} files and one
+ * {@code sheriff-config/topology.properties} — and then states that a limit-shaped key sweep over
+ * those twelve returns hits only in the four gateway documents and in five of the seven endpoint
+ * files. Both are load-bearing claims: every status row in the note is scoped to that surface, so a
+ * descriptor the note never enumerated is not merely undocumented, it is <em>invisible</em> to the
+ * whole coverage index.
+ * <p>
+ * Nothing machine-checked either claim before this guard. The sibling wiring guards glob the
+ * {@code sheriff-config*} directories and resolve one {@code gateway.yaml} inside each — they never
+ * reach {@code endpoints/} or {@code topology.properties} — and their descriptor assertion is an
+ * <em>at-least</em> floor
+ * ({@code size() >= COMMITTED_DESCRIPTOR_COUNT}), which a newly added file satisfies without
+ * complaint. So an added overlay directory, an added endpoint document, or a new limit-shaped key
+ * in a file the note records as declaring none would all leave the checked-in note quietly wrong
+ * with a green build.
+ * <p>
+ * This guard asserts <strong>exact set equality</strong> rather than a floor, in both directions:
+ * an addition and a removal each fail loudly, and the failure message names the note so the fix is
+ * obvious — update the note in the same change that touches the surface.
+ * <p>
+ * It parses the committed descriptors only — it starts no container and reaches no network. It is
+ * deliberately <em>additive</em>: it does not widen the sibling guards' globs, whose narrower reach
+ * is a separate, report-only finding recorded in the note.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+class DescriptorInventoryWiringTest {
+
+    /** The module base directory (surefire runs with the module root as the working directory). */
+    private static final Path MODULE = Path.of(System.getProperty("user.dir"));
+    private static final Path DOCKER = MODULE.resolve("src/main/docker");
+
+    /** The prose claim this guard machine-checks; named in every failure message. */
+    private static final String NOTE = "doc/development/declared-limit-assertion-coverage.adoc";
+
+    /** The four gateway documents the note's "Enumerated Surface" section names. */
+    private static final Set<String> DECLARED_GATEWAY_DESCRIPTORS = Set.of(
+            "sheriff-config/gateway.yaml",
+            "sheriff-config-cookie/gateway.yaml",
+            "sheriff-config-mtls/gateway.yaml",
+            "sheriff-config-ws-admission/gateway.yaml");
+
+    /** The seven endpoint documents the note's "Enumerated Surface" section names. */
+    private static final Set<String> DECLARED_ENDPOINT_DESCRIPTORS = Set.of(
+            "sheriff-config/endpoints/assets.yaml",
+            "sheriff-config/endpoints/assets-secure.yaml",
+            "sheriff-config/endpoints/bff-session.yaml",
+            "sheriff-config/endpoints/grpc.yaml",
+            "sheriff-config/endpoints/httpbin.yaml",
+            "sheriff-config/endpoints/secure.yaml",
+            "sheriff-config/endpoints/websocket.yaml");
+
+    /** The single alias file; declares no limit-shaped key, which the sweep below re-proves. */
+    private static final String DECLARED_TOPOLOGY = "sheriff-config/topology.properties";
+
+    /**
+     * The note's limit-shaped key sweep, transcribed verbatim from its "Enumerated Surface"
+     * section. It is applied to declared KEY NAMES only — never to raw file text — so the
+     * descriptors' extensive prose comments cannot manufacture a hit.
+     */
+    private static final Pattern LIMIT_SHAPED_KEY = Pattern.compile(
+            "max|min|limit|cap|_bytes|_seconds|timeout|ttl|leeway|length|allow|deny|threshold"
+                    + "|budget|quota|window|depth");
+
+    /**
+     * The nine files the note records as declaring at least one limit-shaped key. Its complement
+     * within the inventory — {@code assets.yaml}, {@code assets-secure.yaml} and
+     * {@code topology.properties} — is the "declare none" half of the same claim, so asserting this
+     * set exactly asserts both halves at once.
+     */
+    private static final Set<String> DECLARED_LIMIT_BEARING_FILES = Set.of(
+            "sheriff-config/gateway.yaml",
+            "sheriff-config-cookie/gateway.yaml",
+            "sheriff-config-mtls/gateway.yaml",
+            "sheriff-config-ws-admission/gateway.yaml",
+            "sheriff-config/endpoints/bff-session.yaml",
+            "sheriff-config/endpoints/grpc.yaml",
+            "sheriff-config/endpoints/httpbin.yaml",
+            "sheriff-config/endpoints/secure.yaml",
+            "sheriff-config/endpoints/websocket.yaml");
+
+    @Test
+    @DisplayName("the committed descriptor inventory is exactly the twelve files the note enumerates")
+    void descriptorInventoryIsExactlyTheEnumeratedSurface() throws Exception {
+        // Arrange — the note's claim, assembled from the three surfaces it lists separately
+        Set<String> declared = new TreeSet<>(DECLARED_GATEWAY_DESCRIPTORS);
+        declared.addAll(DECLARED_ENDPOINT_DESCRIPTORS);
+        declared.add(DECLARED_TOPOLOGY);
+
+        // Act
+        Set<String> committed = committedInventory();
+
+        // Assert — exact equality, so an ADDED descriptor fails just as loudly as a removed one.
+        // A floor would let a new overlay directory or a new endpoints/*.yaml slip in unrecorded.
+        assertEquals(declared, committed, "the committed descriptor inventory under " + DOCKER
+                + " no longer matches the twelve files enumerated in " + NOTE
+                + ". Every status row in that note is scoped to this surface, so a descriptor it does"
+                + " not enumerate is invisible to the whole coverage index — add or remove the row in"
+                + " the same change that adds or removes the file.");
+    }
+
+    @Test
+    @DisplayName("no limit-shaped key lives outside the surfaces the note records as declaring one")
+    void limitShapedKeysLiveOnlyInTheRecordedSurfaces() throws Exception {
+        // Arrange
+        Set<String> committed = committedInventory();
+
+        // Act — partition the inventory on "declares at least one limit-shaped key"
+        Set<String> limitBearing = new TreeSet<>();
+        for (String relative : committed) {
+            if (declaresLimitShapedKey(relative)) {
+                limitBearing.add(relative);
+            }
+        }
+
+        // Assert — exact equality asserts both halves of the note's claim in one step: the files it
+        // says declare limits still do, and the files it says declare none still declare none.
+        assertEquals(DECLARED_LIMIT_BEARING_FILES, limitBearing,
+                "the set of descriptors declaring a limit-shaped key no longer matches " + NOTE
+                        + ". A newly limit-bearing file has no status row and is therefore an unasserted"
+                        + " declared limit; a file that lost its keys leaves a stale row behind. Update"
+                        + " the note's Coverage Matrix in the same change.");
+    }
+
+    /**
+     * Every committed file under a {@code sheriff-config*} directory, as slash-separated paths
+     * relative to the docker directory. The walk is recursive and unfiltered on purpose — filtering
+     * by extension would hide exactly the kind of unrecorded companion file this guard exists to
+     * catch.
+     *
+     * @return the committed inventory, sorted for a readable assertion diff
+     * @throws IOException when the docker tree cannot be listed
+     */
+    private static Set<String> committedInventory() throws IOException {
+        Set<String> inventory = new TreeSet<>();
+        List<Path> roots = new ArrayList<>();
+        try (DirectoryStream<Path> directories = Files.newDirectoryStream(DOCKER, "sheriff-config*")) {
+            for (Path directory : directories) {
+                roots.add(directory);
+            }
+        }
+        assertFalse(roots.isEmpty(), "no sheriff-config* directory was found under " + DOCKER
+                + " — this guard would compare against an empty inventory; check the module working"
+                + " directory and the glob");
+        for (Path root : roots) {
+            try (var walk = Files.walk(root)) {
+                walk.filter(Files::isRegularFile)
+                        .map(path -> DOCKER.relativize(path).toString().replace('\\', '/'))
+                        .forEach(inventory::add);
+            }
+        }
+        return inventory;
+    }
+
+    /**
+     * Whether one inventory file declares at least one limit-shaped key. YAML documents are parsed
+     * and every declared key name — at every nesting depth, including inside sequences — is matched;
+     * {@code .properties} files contribute their property names. Any other file kind declares no
+     * keys and therefore no limit.
+     *
+     * @param relative the file's docker-relative path
+     * @return {@code true} when at least one declared key name matches the note's sweep
+     * @throws IOException when the file cannot be read
+     */
+    private static boolean declaresLimitShapedKey(String relative) throws IOException {
+        Set<String> keys = new TreeSet<>();
+        Path file = DOCKER.resolve(relative);
+        if (relative.endsWith(".yaml")) {
+            collectKeys(loadYaml(file), keys);
+        } else if (relative.endsWith(".properties")) {
+            keys.addAll(loadProperties(file).stringPropertyNames());
+        }
+        return keys.stream()
+                .anyMatch(key -> LIMIT_SHAPED_KEY.matcher(key.toLowerCase(Locale.ROOT)).find());
+    }
+
+    /**
+     * Collects every declared key name of a parsed YAML node, recursing through nested maps and
+     * sequences.
+     *
+     * @param node the parsed node; anything that is neither a map nor a sequence declares no key
+     * @param keys the accumulator to add the discovered key names to
+     */
+    private static void collectKeys(Object node, Set<String> keys) {
+        if (node instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                keys.add(String.valueOf(entry.getKey()));
+                collectKeys(entry.getValue(), keys);
+            }
+        } else if (node instanceof List<?> sequence) {
+            for (Object item : sequence) {
+                collectKeys(item, keys);
+            }
+        }
+    }
+
+    private static Object loadYaml(Path path) throws IOException {
+        try (InputStream in = Files.newInputStream(path)) {
+            return new Yaml().load(in);
+        }
+    }
+
+    private static Properties loadProperties(Path path) throws IOException {
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(path)) {
+            properties.load(in);
+        }
+        return properties;
+    }
+}

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.sheriff.gateway.integration;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -202,12 +203,12 @@ class EgressAllowlistActivationWiringTest {
     private static Map<String, Object> jwks(Map<String, Object> issuer) {
         Object jwks = issuer.get("jwks");
         assertNotNull(jwks, "issuer '" + issuer.get("name") + "' declares no jwks block");
-        assertTrue(jwks instanceof Map, "issuer '" + issuer.get("name") + "' declares a non-map jwks block");
+        assertInstanceOf(Map.class, jwks, "issuer '" + issuer.get("name") + "' declares a non-map jwks block");
         return (Map<String, Object>) jwks;
     }
 
     private static void assertInstanceOfList(Object allowlist, Path descriptor, Map<String, Object> issuer) {
-        assertTrue(allowlist instanceof List, descriptor + " issuer '" + issuer.get("name") + "' declares "
+        assertInstanceOf(List.class, allowlist, descriptor + " issuer '" + issuer.get("name") + "' declares "
                 + ALLOWLIST_KEY + " as " + allowlist.getClass().getSimpleName() + ", expected a list");
     }
 

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
@@ -83,10 +83,6 @@ class EgressAllowlistActivationWiringTest {
     void httpSourcedIssuersDeclareAnEgressAllowlist() throws Exception {
         // Arrange
         List<Path> descriptors = committedGatewayDescriptors();
-        assertTrue(descriptors.size() >= COMMITTED_DESCRIPTOR_COUNT,
-                "expected at least " + COMMITTED_DESCRIPTOR_COUNT
-                        + " committed sheriff-config*/gateway.yaml descriptors under " + DOCKER
-                        + ", found " + descriptors.size() + ": " + descriptors);
         int httpIssuersSeen = 0;
 
         // Act + Assert
@@ -102,8 +98,9 @@ class EgressAllowlistActivationWiringTest {
                         + "' fetches its JWKS over http but declares no " + ALLOWLIST_KEY
                         + ". The egress guard then refuses the compose-internal address, the key set never"
                         + " loads, and every bearer request is rejected 401.");
-                assertInstanceOfList(allowlist, descriptor, issuer);
-                List<?> hosts = (List<?>) allowlist;
+                List<?> hosts = assertInstanceOf(List.class, allowlist, descriptor + " issuer '"
+                        + issuer.get("name") + "' declares " + ALLOWLIST_KEY + " as "
+                        + allowlist.getClass().getSimpleName() + ", expected a list");
                 assertFalse(hosts.isEmpty(), descriptor + " issuer '" + issuer.get("name")
                         + "' declares an EMPTY " + ALLOWLIST_KEY + ", which guards nothing");
                 for (Object host : hosts) {
@@ -125,10 +122,6 @@ class EgressAllowlistActivationWiringTest {
     void fileSourcedIssuersDeclareNoEgressAllowlist() throws Exception {
         // Arrange
         List<Path> descriptors = committedGatewayDescriptors();
-        assertTrue(descriptors.size() >= COMMITTED_DESCRIPTOR_COUNT,
-                "expected at least " + COMMITTED_DESCRIPTOR_COUNT
-                        + " committed sheriff-config*/gateway.yaml descriptors under " + DOCKER
-                        + ", found " + descriptors.size() + ": " + descriptors);
         int fileIssuersSeen = 0;
 
         // Act + Assert — an offline issuer loads from a mounted file and performs no outbound fetch, so
@@ -154,7 +147,9 @@ class EgressAllowlistActivationWiringTest {
 
     /**
      * Every committed gateway descriptor under a {@code sheriff-config} directory, discovered by glob
-     * so a new instance directory is covered automatically.
+     * so a new instance directory is covered automatically. The
+     * {@link #COMMITTED_DESCRIPTOR_COUNT} floor is asserted here rather than at each call site, so an
+     * empty or mis-rooted glob fails loudly instead of satisfying a per-descriptor loop vacuously.
      *
      * @return the descriptor paths, in directory-stream order
      * @throws IOException when the docker directory cannot be listed
@@ -169,6 +164,10 @@ class EgressAllowlistActivationWiringTest {
                 }
             }
         }
+        assertTrue(descriptors.size() >= COMMITTED_DESCRIPTOR_COUNT,
+                "expected at least " + COMMITTED_DESCRIPTOR_COUNT
+                        + " committed sheriff-config*/gateway.yaml descriptors under " + DOCKER
+                        + ", found " + descriptors.size() + ": " + descriptors);
         return descriptors;
     }
 
@@ -205,11 +204,6 @@ class EgressAllowlistActivationWiringTest {
         assertNotNull(jwks, "issuer '" + issuer.get("name") + "' declares no jwks block");
         assertInstanceOf(Map.class, jwks, "issuer '" + issuer.get("name") + "' declares a non-map jwks block");
         return (Map<String, Object>) jwks;
-    }
-
-    private static void assertInstanceOfList(Object allowlist, Path descriptor, Map<String, Object> issuer) {
-        assertInstanceOf(List.class, allowlist, descriptor + " issuer '" + issuer.get("name") + "' declares "
-                + ALLOWLIST_KEY + " as " + allowlist.getClass().getSimpleName() + ", expected a list");
     }
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fast, no-Docker <em>surefire</em> guard that every committed deployment descriptor keeps the SSRF
+ * egress allowlist on the JWKS fetches that need one — and, just as importantly, does <em>not</em>
+ * widen it on the fetches that do not.
+ * <p>
+ * token-sheriff's egress guard (GW-05 / BFF-07) refuses a JWKS URL resolving to a private address
+ * unless its host is named in {@code jwks.allowed_egress_hosts}. Every {@code source: http} issuer
+ * in this stack points at the compose-internal {@code keycloak} service, which resolves to a
+ * site-local bridge address — so dropping that allowlist entry does not fail loudly at boot. The key
+ * set simply never loads, every bearer request is rejected 401, and a suite measuring bearer
+ * throughput would report the <em>rejection</em> path as a success. That silent-degradation shape is
+ * why this needs a descriptor assertion rather than a runtime one.
+ * <p>
+ * <strong>The negative half is the load-bearing one.</strong> Asserting only "every http issuer
+ * declares an allowlist" would pass equally well against a descriptor that had widened the allowlist
+ * onto <em>every</em> issuer, including the offline {@code source: file} one that needs no egress at
+ * all. An unjustified widening on a security gateway is exactly the drift worth catching, so the
+ * file-sourced issuers are asserted to declare no allowlist — and the issuer counters below keep
+ * either half from passing vacuously against a descriptor set that happened to contain none of that
+ * kind.
+ * <p>
+ * It parses the committed descriptors only and asserts the activation is present — it starts no
+ * container and reaches no network. The sibling guard covering the body-size floor the same way is
+ * {@code BodyLimitActivationWiringTest}.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+class EgressAllowlistActivationWiringTest {
+
+    /** The module base directory (surefire runs with the module root as the working directory). */
+    private static final Path MODULE = Path.of(System.getProperty("user.dir"));
+    private static final Path DOCKER = MODULE.resolve("src/main/docker");
+
+    /**
+     * The descriptor count committed today. The glob must match at least this many, so an empty or
+     * mis-rooted glob fails loudly instead of satisfying the per-descriptor loop vacuously.
+     */
+    private static final int COMMITTED_DESCRIPTOR_COUNT = 4;
+
+    private static final String HTTP_SOURCE = "http";
+    private static final String FILE_SOURCE = "file";
+    private static final String ALLOWLIST_KEY = "allowed_egress_hosts";
+
+    @Test
+    @DisplayName("every http-sourced JWKS issuer declares a non-empty egress allowlist")
+    void httpSourcedIssuersDeclareAnEgressAllowlist() throws Exception {
+        // Arrange
+        List<Path> descriptors = committedGatewayDescriptors();
+        assertTrue(descriptors.size() >= COMMITTED_DESCRIPTOR_COUNT,
+                "expected at least " + COMMITTED_DESCRIPTOR_COUNT
+                        + " committed sheriff-config*/gateway.yaml descriptors under " + DOCKER
+                        + ", found " + descriptors.size() + ": " + descriptors);
+        int httpIssuersSeen = 0;
+
+        // Act + Assert
+        for (Path descriptor : descriptors) {
+            for (Map<String, Object> issuer : issuers(descriptor)) {
+                Map<String, Object> jwks = jwks(issuer);
+                if (!HTTP_SOURCE.equals(String.valueOf(jwks.get("source")))) {
+                    continue;
+                }
+                httpIssuersSeen++;
+                Object allowlist = jwks.get(ALLOWLIST_KEY);
+                assertNotNull(allowlist, descriptor + " issuer '" + issuer.get("name")
+                        + "' fetches its JWKS over http but declares no " + ALLOWLIST_KEY
+                        + ". The egress guard then refuses the compose-internal address, the key set never"
+                        + " loads, and every bearer request is rejected 401.");
+                assertInstanceOfList(allowlist, descriptor, issuer);
+                List<?> hosts = (List<?>) allowlist;
+                assertFalse(hosts.isEmpty(), descriptor + " issuer '" + issuer.get("name")
+                        + "' declares an EMPTY " + ALLOWLIST_KEY + ", which guards nothing");
+                for (Object host : hosts) {
+                    assertFalse(String.valueOf(host).isBlank(), descriptor + " issuer '" + issuer.get("name")
+                            + "' declares a blank host in " + ALLOWLIST_KEY);
+                }
+            }
+        }
+
+        // The anti-vacuity control: a descriptor set with no http issuer at all would satisfy the loop
+        // above without asserting anything.
+        assertTrue(httpIssuersSeen > 0,
+                "no http-sourced JWKS issuer was found in any committed descriptor — this guard would pass"
+                        + " vacuously; check the glob and the token_validation block");
+    }
+
+    @Test
+    @DisplayName("a file-sourced JWKS issuer declares no egress allowlist")
+    void fileSourcedIssuersDeclareNoEgressAllowlist() throws Exception {
+        // Arrange
+        List<Path> descriptors = committedGatewayDescriptors();
+        assertTrue(descriptors.size() >= COMMITTED_DESCRIPTOR_COUNT,
+                "expected at least " + COMMITTED_DESCRIPTOR_COUNT
+                        + " committed sheriff-config*/gateway.yaml descriptors under " + DOCKER
+                        + ", found " + descriptors.size() + ": " + descriptors);
+        int fileIssuersSeen = 0;
+
+        // Act + Assert — an offline issuer loads from a mounted file and performs no outbound fetch, so
+        // an allowlist entry here would be an unjustified widening of the egress guard.
+        for (Path descriptor : descriptors) {
+            for (Map<String, Object> issuer : issuers(descriptor)) {
+                Map<String, Object> jwks = jwks(issuer);
+                if (!FILE_SOURCE.equals(String.valueOf(jwks.get("source")))) {
+                    continue;
+                }
+                fileIssuersSeen++;
+                assertNull(jwks.get(ALLOWLIST_KEY), descriptor + " issuer '" + issuer.get("name")
+                        + "' loads its JWKS from a mounted file yet declares " + ALLOWLIST_KEY
+                        + ". It performs no outbound fetch, so that entry widens the SSRF egress guard for"
+                        + " nothing — remove it rather than carrying an unjustified allowance.");
+            }
+        }
+
+        assertTrue(fileIssuersSeen > 0,
+                "no file-sourced JWKS issuer was found in any committed descriptor — this control would pass"
+                        + " vacuously; check the glob and the token_validation block");
+    }
+
+    /**
+     * Every committed gateway descriptor under a {@code sheriff-config} directory, discovered by glob
+     * so a new instance directory is covered automatically.
+     *
+     * @return the descriptor paths, in directory-stream order
+     * @throws IOException when the docker directory cannot be listed
+     */
+    private static List<Path> committedGatewayDescriptors() throws IOException {
+        List<Path> descriptors = new ArrayList<>();
+        try (DirectoryStream<Path> directories = Files.newDirectoryStream(DOCKER, "sheriff-config*")) {
+            for (Path directory : directories) {
+                Path descriptor = directory.resolve("gateway.yaml");
+                if (Files.isRegularFile(descriptor)) {
+                    descriptors.add(descriptor);
+                }
+            }
+        }
+        return descriptors;
+    }
+
+    /**
+     * The {@code token_validation.issuers} list of a descriptor.
+     *
+     * @param descriptor the gateway descriptor to parse
+     * @return the declared issuers, or an empty list when the block is absent
+     * @throws IOException when the descriptor cannot be read
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> issuers(Path descriptor) throws IOException {
+        Map<String, Object> document = loadYaml(descriptor);
+        Object tokenValidation = document.get("token_validation");
+        if (!(tokenValidation instanceof Map<?, ?> block)) {
+            return List.of();
+        }
+        Object declared = block.get("issuers");
+        if (!(declared instanceof List<?> list)) {
+            return List.of();
+        }
+        return (List<Map<String, Object>>) list;
+    }
+
+    /**
+     * The {@code jwks} block of one issuer.
+     *
+     * @param issuer the parsed issuer node
+     * @return the jwks block; never {@code null} — a missing block fails the assertion instead
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> jwks(Map<String, Object> issuer) {
+        Object jwks = issuer.get("jwks");
+        assertNotNull(jwks, "issuer '" + issuer.get("name") + "' declares no jwks block");
+        assertTrue(jwks instanceof Map, "issuer '" + issuer.get("name") + "' declares a non-map jwks block");
+        return (Map<String, Object>) jwks;
+    }
+
+    private static void assertInstanceOfList(Object allowlist, Path descriptor, Map<String, Object> issuer) {
+        assertTrue(allowlist instanceof List, descriptor + " issuer '" + issuer.get("name") + "' declares "
+                + ALLOWLIST_KEY + " as " + allowlist.getClass().getSimpleName() + ", expected a list");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> loadYaml(Path path) throws IOException {
+        try (InputStream in = Files.newInputStream(path)) {
+            return new Yaml().loadAs(in, Map.class);
+        }
+    }
+}

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.gateway.integration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,12 +24,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.yaml.snakeyaml.Yaml;
 
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +58,21 @@ import org.junit.jupiter.api.Test;
  * either half from passing vacuously against a descriptor set that happened to contain none of that
  * kind.
  * <p>
+ * <strong>The positive half is exact, not shape-only.</strong> An http issuer's allowlist is
+ * asserted to be precisely {@code [host-of-its-own-jwks.url]}: each entry must be a
+ * {@link String} instance (not merely something {@code String.valueOf} can render) and the set as a
+ * whole must name no host beyond the one that issuer actually fetches from. A shape-only predicate —
+ * non-null, a list, non-empty, no blank entry — would wave through
+ * {@code ["keycloak", "untrusted.example"]}, which widens the SSRF egress exception onto a host no
+ * issuer in this stack ever contacts. Adding a second host is therefore a deliberate act that must
+ * update this guard, never a silent descriptor edit.
+ * <p>
+ * <strong>Every issuer is classified, none is skipped.</strong> Both halves partition on
+ * {@code jwks.source}, so an issuer whose source is absent or misspelled would match neither branch
+ * and go unchecked — the very issuer most likely to be misconfigured. The source is therefore
+ * asserted to be one of the two recognised values <em>before</em> the partition, and an unrecognised
+ * one fails both tests loudly instead of falling through them.
+ * <p>
  * It parses the committed descriptors only and asserts the activation is present — it starts no
  * container and reaches no network. The sibling guard covering the body-size floor the same way is
  * {@code BodyLimitActivationWiringTest}.
@@ -77,9 +95,11 @@ class EgressAllowlistActivationWiringTest {
     private static final String HTTP_SOURCE = "http";
     private static final String FILE_SOURCE = "file";
     private static final String ALLOWLIST_KEY = "allowed_egress_hosts";
+    private static final String SOURCE_KEY = "source";
+    private static final Set<String> RECOGNISED_SOURCES = Set.of(HTTP_SOURCE, FILE_SOURCE);
 
     @Test
-    @DisplayName("every http-sourced JWKS issuer declares a non-empty egress allowlist")
+    @DisplayName("every http-sourced JWKS issuer allows egress to exactly the host its jwks.url names")
     void httpSourcedIssuersDeclareAnEgressAllowlist() throws Exception {
         // Arrange
         List<Path> descriptors = committedGatewayDescriptors();
@@ -89,7 +109,7 @@ class EgressAllowlistActivationWiringTest {
         for (Path descriptor : descriptors) {
             for (Map<String, Object> issuer : issuers(descriptor)) {
                 Map<String, Object> jwks = jwks(issuer);
-                if (!HTTP_SOURCE.equals(String.valueOf(jwks.get("source")))) {
+                if (!HTTP_SOURCE.equals(jwksSource(descriptor, issuer, jwks))) {
                     continue;
                 }
                 httpIssuersSeen++;
@@ -103,10 +123,22 @@ class EgressAllowlistActivationWiringTest {
                         + allowlist.getClass().getSimpleName() + ", expected a list");
                 assertFalse(hosts.isEmpty(), descriptor + " issuer '" + issuer.get("name")
                         + "' declares an EMPTY " + ALLOWLIST_KEY + ", which guards nothing");
+                List<String> declaredHosts = new ArrayList<>();
                 for (Object host : hosts) {
-                    assertFalse(String.valueOf(host).isBlank(), descriptor + " issuer '" + issuer.get("name")
+                    String entry = assertInstanceOf(String.class, host, descriptor + " issuer '"
+                            + issuer.get("name") + "' declares a non-String entry in " + ALLOWLIST_KEY + ": "
+                            + host + ". The egress guard matches host names, so a non-String scalar names no"
+                            + " host at all.");
+                    assertFalse(entry.isBlank(), descriptor + " issuer '" + issuer.get("name")
                             + "' declares a blank host in " + ALLOWLIST_KEY);
+                    declaredHosts.add(entry);
                 }
+                String expectedHost = egressHostOf(descriptor, issuer, jwks);
+                assertEquals(List.of(expectedHost), declaredHosts, descriptor + " issuer '"
+                        + issuer.get("name") + "' declares " + ALLOWLIST_KEY + " " + declaredHosts
+                        + ", expected exactly [" + expectedHost + "] — the host its own jwks.url fetches"
+                        + " from. Any other entry widens the SSRF egress exception onto a host this issuer"
+                        + " never contacts; a genuinely needed one must be justified by updating this guard.");
             }
         }
 
@@ -129,7 +161,7 @@ class EgressAllowlistActivationWiringTest {
         for (Path descriptor : descriptors) {
             for (Map<String, Object> issuer : issuers(descriptor)) {
                 Map<String, Object> jwks = jwks(issuer);
-                if (!FILE_SOURCE.equals(String.valueOf(jwks.get("source")))) {
+                if (!FILE_SOURCE.equals(jwksSource(descriptor, issuer, jwks))) {
                     continue;
                 }
                 fileIssuersSeen++;
@@ -204,6 +236,55 @@ class EgressAllowlistActivationWiringTest {
         assertNotNull(jwks, "issuer '" + issuer.get("name") + "' declares no jwks block");
         assertInstanceOf(Map.class, jwks, "issuer '" + issuer.get("name") + "' declares a non-map jwks block");
         return (Map<String, Object>) jwks;
+    }
+
+    /**
+     * The {@code jwks.source} of one issuer, asserted to be one of the two recognised values. Both
+     * tests partition on this value, so an issuer whose source is absent, non-textual or misspelled
+     * would match neither branch and never be checked for an egress allowlist at all. Failing here —
+     * before the partition — turns that silent skip into a loud failure.
+     *
+     * @param descriptor the descriptor being parsed, for the failure message
+     * @param issuer the parsed issuer node
+     * @param jwks the issuer's jwks block
+     * @return the declared source, guaranteed to be {@code http} or {@code file}
+     */
+    private static String jwksSource(Path descriptor, Map<String, Object> issuer, Map<String, Object> jwks) {
+        Object declared = jwks.get(SOURCE_KEY);
+        assertNotNull(declared, descriptor + " issuer '" + issuer.get("name") + "' declares no jwks."
+                + SOURCE_KEY + ". This guard partitions issuers on that key, so an issuer without one is"
+                + " checked by neither half.");
+        String source = assertInstanceOf(String.class, declared, descriptor + " issuer '"
+                + issuer.get("name") + "' declares a non-String jwks." + SOURCE_KEY + ": " + declared);
+        assertTrue(RECOGNISED_SOURCES.contains(source), descriptor + " issuer '" + issuer.get("name")
+                + "' declares jwks." + SOURCE_KEY + " '" + source + "', which is neither '" + HTTP_SOURCE
+                + "' nor '" + FILE_SOURCE + "'. It would fall through both halves of this guard and never"
+                + " be checked for an egress allowlist.");
+        return source;
+    }
+
+    /**
+     * The host an http-sourced issuer actually fetches its key set from, derived from its own
+     * {@code jwks.url}. That derived host — not a hard-coded name — is the single entry its
+     * {@code allowed_egress_hosts} is allowed to contain.
+     *
+     * @param descriptor the descriptor being parsed, for the failure message
+     * @param issuer the parsed issuer node
+     * @param jwks the issuer's jwks block, already known to declare {@code source: http}
+     * @return the non-blank host component of the declared JWKS URL
+     */
+    private static String egressHostOf(Path descriptor, Map<String, Object> issuer, Map<String, Object> jwks) {
+        Object declared = jwks.get("url");
+        assertNotNull(declared, descriptor + " issuer '" + issuer.get("name")
+                + "' fetches its JWKS over http but declares no jwks.url");
+        String url = assertInstanceOf(String.class, declared, descriptor + " issuer '" + issuer.get("name")
+                + "' declares a non-String jwks.url: " + declared);
+        String host = URI.create(url).getHost();
+        assertNotNull(host, descriptor + " issuer '" + issuer.get("name")
+                + "' declares a jwks.url with no host component: " + url);
+        assertFalse(host.isBlank(), descriptor + " issuer '" + issuer.get("name")
+                + "' declares a jwks.url with a blank host component: " + url);
+        return host;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Closes the "declared control with no boundary assertion" defect class on the gateway's
integration-test descriptor surface: every limit-shaped value the surface declares is now
enumerated with its enforcing component and its assertion status, and the five
highest-blast-radius gaps that survived that enumeration are closed with matched
positive controls.

**The plan's seed premise was FALSIFIED at HEAD.** The spec asserted that "zero files under
`integration-tests/src/test/java/` reference `max_body_bytes` or `413`" and that the suite
"never asserts that a declared configuration value is actually enforced at its boundary".
Both were already false at `36508b2` — `LargeBodyIT`, `SecurityProfileModeIT` and
`BodyLimitActivationWiringTest` had landed real boundary assertions. Deliverable D1
therefore shipped as a **gap analysis crediting the landed corpus**, not as a greenfield
sweep, and D2's cap of 5 was **derived from the real gap count** rather than assumed:
11 gaps (8 outright `GAP`, 3 `PARTIAL`) against a ceiling of 5, so the cap bound at its
ceiling.

## Changes

- **`doc/development/declared-limit-assertion-coverage.adoc`** (new, 370 lines) — the
  checked-in enumeration note. Declares the surface explicitly (twelve files), separates
  the two declaration layers (literal descriptor keys vs the strict preset's resolved
  effective caps that appear in no yaml), carries a `file:line` citation per row, ranks
  the closed gaps by blast radius, and records the standing remainder so the class stays
  countable. Also carries one report-only finding (below).
- **`doc/development/README.adoc`** — indexes the new note.
- **`integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DeclaredLimitBoundaryIT.java`**
  (new) — boundary assertions for G1, G3, G4 and G5, each with a matched positive control.
- **`integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java`**
  (new) — descriptor guard for G2: every http-sourced issuer declares a non-empty JWKS
  egress allowlist, every file-sourced issuer declares none, with a
  `COMMITTED_DESCRIPTOR_COUNT` floor so a vacuous glob fails loudly.
- **`integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerSecurityFilterInteractionIT.java`**
  (new) — D3: the four-case gate-interaction matrix over a route that carries bearer auth
  **and** an explicitly declared `security_filter`, including which gate wins when a
  request violates both.
- **`integration-tests/src/main/docker/sheriff-config/endpoints/secure.yaml`** — the
  `secure-filtered` route D3 exercises: bearer-protected **and** carrying an explicit
  `security_filter` block.
- **`integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java`**,
  **`.../BodyLimitActivationWiringTest.java`** — small corrections (an independent
  carve-out assertion; a stale descriptor-count doc comment).

## Declared-limit enumeration (deliverable D1)

Every limit-shaped value the descriptor surface declares, its enforcing component, and its
assertion status **at this PR's HEAD**. Full `file:line` citations for every row live in
the checked-in note `doc/development/declared-limit-assertion-coverage.adoc`.

Status vocabulary: **COVERED** = asserted at its boundary with a matched positive control ·
**WIRED** = a descriptor-parsing guard proves the declaration is present, no runtime
boundary exercised · **PARTIAL** = one leg landed (control or negative boundary missing,
or existence proven but not the boundary) · **GAP** = no test names or exercises it.

| # | Declared limit | Enforcing component | Status | Asserting test |
|---|---|---|---|---|
| | `anchors.upload.security_filter.max_body_bytes: 67108864` (all 4 descriptors) | `ThoroughChecksStage` per-route body cap | COVERED | `LargeBodyIT` + `BodyLimitActivationWiringTest` |
| | `httpbin-minimal-mode.max_body_bytes: 1024` (httpbin endpoint) | `ThoroughChecksStage` under `minimal` | COVERED | `SecurityProfileModeIT` (cap+1 → 413, within-cap control) |
| | `httpbin-minimal-mode.allowed_paths` (httpbin endpoint) | `ThoroughChecksStage` path allowlist | COVERED | `SecurityProfileModeIT` |
| | `security_defaults.profile: strict` (base) | Resolved `SecurityConfiguration` for every profile-omitting route | COVERED | `SecurityProfileModeIT` (strict-vs-minimal contrast) |
| | Strict preset query-parameter **count** cap (20) — layer 2, in no yaml | `BasicChecksStage` pre-route floor | COVERED | `SecurityProfileModeIT` |
| | `security_defaults.allow_get_with_content_length_body: true` (base) | Framing gate in `BasicChecksStage` | COVERED | `GetWithBodyIT` + `GetWithBodyActivationWiringTest` |
| | `allowed_methods` (global + 4 routes) | Route selection / method gate | COVERED | `PipelineVerbIT` (405 + four positive controls) |
| | `oidc.session.csrf.trusted_origins` (all 4 descriptors) | BFF CSRF origin gate | COVERED | `BffCsrfIT` |
| | `websocket.allowed_origins` (websocket endpoint) | `OriginValidationStage`, fail-closed pre-dial | COVERED | `WebSocketProxyIT` (CSWSH, GW-09) |
| | `websocket.idle_timeout_seconds: 2` (websocket endpoint) | Relay idle reclaim (close 1001) | COVERED | `WebSocketProxyIT` (reclaim vs heartbeat control) |
| | `edge_hardening.admission_cap: 8` / `websocket_relay_cap: 2` (ws-admission overlay) | Admission budget + relay sub-budget | COVERED | `WebSocketProxyIT` + `WsAdmissionActivationWiringTest` |
| | `tls.passthrough_sni` (base) | `SniFrontListener` via `TlsEdgeProducer` | COVERED | `TlsPassthroughIT`, `HostSmuggleGuardIT`, `TlsEdgeActivationWiringTest` |
| | `tls.mtls.enabled: true` / `client_ca` (mTLS overlay) | `MtlsServerCustomizer` handshake require-and-verify | COVERED | `MtlsHandshakeIT` |
| | `secure-filtered.security_filter.profile: strict` / `allowed_paths` (secure endpoint) — **added by this PR** | `ThoroughChecksStage` on a route that also inherits a bearer floor | COVERED | **`BearerSecurityFilterInteractionIT`** (D3, four-case matrix) |
| | `asset_defaults.content_types` (base) | Asset response envelope, boot-enforced | WIRED | `AssetContentTypeActivationWiringTest` (declaration only) |
| | `oidc.session.refresh.leeway_seconds: 30` (all 4 descriptors) | Session refresh scheduling | WIRED | `BffCookieSessionIT`, `BffSessionMediationIT` — refresh exercised, leeway boundary never |
| **G1** | `security_defaults.max_authorization_header_value_length: 8192` (base) | `BasicChecksStage` non-skippable pre-route floor | COVERED *(was PARTIAL)* | **`DeclaredLimitBoundaryIT`** — 8192 → 401 at bearer validation, 8193 → 400 at the floor; `BearerValidationIT` proves the carve-out on a real token |
| **G2** | `token_validation.issuers[*].jwks.allowed_egress_hosts` (all 4 descriptors) | token-sheriff SSRF egress guard (GW-05 / BFF-07) | WIRED *(was GAP)* | **`EgressAllowlistActivationWiringTest`** — descriptor-parsing only; no runtime egress refusal, hence WIRED not COVERED |
| **G3** | Strict preset header-value length cap (1024) — layer 2, in no yaml | `BasicChecksStage`, every header | COVERED *(was GAP)* | **`DeclaredLimitBoundaryIT`** — non-`Authorization` header admitted at 1024, 400 at 1025; pairs with G1 to prove the carve-out did not widen |
| **G4** | Strict preset body cap (1 MiB) on an **inheriting** route — layer 2, in no yaml | `ThoroughChecksStage` GW-07 default body guard | COVERED *(was GAP)* | **`DeclaredLimitBoundaryIT`** — one byte over → 413 with the gateway's own RFC 9457 envelope; one byte under forwarded and echoed |
| **G5** | `forward.headers_allow` / `query_allow` deny-by-default (8 routes across 3 endpoint descriptors) | Forward stage 5 allow-listing | COVERED *(was GAP)* | **`DeclaredLimitBoundaryIT`** — allow-listed header+param echoed, non-allow-listed pair stripped |
| **G6** | Strict preset parameter-**value** length cap (1024) — layer 2, in no yaml | `ThoroughChecksStage` url-parameter validation | GAP | `SecurityProfileModeIT` asserts a *separator*-shaped rejection, never the length boundary |
| **G7** | Strict preset path length cap (1024) — layer 2, in no yaml | `BasicChecksStage.validatePath` | GAP | none |
| **G8** | `tls.alpn: ["h2", "http/1.1"]` (all 4 descriptors) | `TlsServerCustomizer` ALPN advertisement | GAP | none — the http2 benchmark negotiates h2 but asserts no protocol |
| **G9** | `oidc.session.ttl_seconds: 3600` (all 4 descriptors) | Session store expiry | GAP | none |
| **G10** | `oidc.user_info.allowed_claims` (all 4 descriptors) | user_info claim projection | PARTIAL | `BffUserInfoIT` asserts the `default_view` projection; no negative leg proves an out-of-allowlist claim is withheld |
| **G11** | `tls.min_version: "1.2"` / `tls.cipher_suites` (base) | `TlsServerCustomizer` protocol floor + cipher allowlist | PARTIAL | `CipherSuiteFixtureWiringTest` is descriptor-level only; no handshake asserts a below-floor protocol is refused |

### The gap count and the derived cap (deliverable D2)

Real gap count when the sweep began: **11** — eight outright `GAP` (G2–G9) plus three
`PARTIAL` (G1, G10, G11). The spec's hard ceiling is five assertions, so the cap **bound at
its ceiling**: G1–G5 are closed here, ranked by blast radius (a limit whose breach degrades
the whole gateway outranks one that degrades a single request):

| Rank | Gap | Blast radius | Why it ranks here |
|---|---|---|---|
| 1 | G1 | gateway-wide | An ADR-0019 relaxation at the non-skippable pre-route floor. If the carve-out silently reverts, every bearer request is rejected 400 *before* bearer validation runs. |
| 2 | G2 | gateway-wide | The SSRF egress guard on JWKS fetch. Its loss unguards outbound fetches from a security gateway. |
| 3 | G3 | gateway-wide | The resolved header-value floor every route inherits — and the exact cap G1 carves out of. Asserting both makes the relaxation's *scope* provable. |
| 4 | G4 | gateway-wide | The default body guard on every inheriting route. Previously only the deliberately raised and lowered route caps were proven; the inherited default never was. |
| 5 | G5 | per-request | Deny-by-default forward allow-listing — an information-flow defect rather than a gateway-wide degradation. |

**G6–G11 are deliberately not authored** and are recorded as the standing remainder. Two of
them are additionally impractical to boundary-test at proportionate cost — G9 would need a
one-hour wait and G11's runtime leg needs a handshake fixture matrix — so a future plan
should pick the *wiring* shape for those rather than the boundary shape.

## Report-only finding (not fixed here)

`BodyLimitActivationWiringTest` discovers descriptors with a `sheriff-config*` directory
glob and then resolves `gateway.yaml` inside each match, so it **never reaches the
`endpoints/` tree** — where a `max_body_bytes: 1024` already lives. Nothing is broken
today (that cap sits far below the framework floor), but a future endpoint-level cap
declared *above* the floor would push its instance into a fail-closed boot abort with the
guard still green. Widening the glob touches a guard whose blast radius reaches every
committed descriptor, so it belongs in its own plan with its own verification rather than
riding a coverage sweep. This is also why the D3 route declares `allowed_paths` rather
than `max_body_bytes` — a body cap in the endpoints tree would enlarge exactly the hole
this note reports.

## Test Plan

- [x] Quality gate — `verify -Ppre-commit`
- [x] Full verify — `verify`
- [x] Containerised integration tests — `verify -Pintegration-tests -pl integration-tests -am`
      (every new assertion runs in a real container, per the activate-IT-in-an-IT rule;
      compilation alone is not verification)
- [x] Every new boundary assertion carries a matched positive control, so each cap is
      proven to reject because of the *value* and not because the route refuses the shape
      outright

## Related Issues

None — this plan is orchestrator-staged and closes no standalone issue. D3 closes the
structural half of epic Open Defect (8).

---
Generated by plan-finalize skill

## Intent

**The problem.** The gateway declares its security posture in configuration and enforces it in code. A declared limit that no test exercises at its boundary can be silently weakened: the descriptor still reads correctly, the build stays green, and the guard is gone. Nobody could say how many such limits existed, because the class was never enumerated.

**The chosen approach.** Enumerate the whole declared surface first, then close only the top of the ranked gap list. The enumeration spans two layers deliberately — literal descriptor keys, *and* the strict preset's resolved effective caps, which apply to every route and appear in no yaml file at all. That second layer is exactly where a limit is most likely to lose its assertion unnoticed. The enumeration lands as a checked-in note (a human-readable index over machine-enforced guards, not a replacement for them) with a `file:line` citation per row, so a reviewer can check any row in one step.

The plan's seed premise was falsified at HEAD before any code was written: boundary assertions for `max_body_bytes` and 413 already existed. The enumeration therefore credits the landed corpus by name per row rather than pretending to a greenfield, and the number of new assertions was derived from the real surviving gap count (11: eight GAP, three PARTIAL) against the spec's ceiling of 5 — so the cap bound at its ceiling rather than at

_[Intent truncated — 1396 of 2416 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure filtered route with strict path-based access controls and bearer authentication.
* **Bug Fixes**
  * Ensured unauthorized or disallowed requests are rejected before reaching upstream services.
* **Tests**
  * Added coverage for authentication, path filtering, request-size boundaries, forwarding rules, limit enforcement, descriptor inventories, and JWKS allowlists.
* **Documentation**
  * Added comprehensive documentation covering declared gateway limits, enforcement coverage, known gaps, and maintenance guidance.
  * Linked the new declared-limit coverage documentation from the contributor guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->