### PR TITLE
feat(deployment): add production-shaped docker-compose sample module

### DIFF
--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -11,6 +11,7 @@
     "benchmarks": {},
     "demo-client-maven": {},
     "demo-client-npm": {},
+    "deployment": {},
     "documentation": {},
     "integration-tests": {}
   },

--- a/.plan/project-architecture/deployment/enriched.json
+++ b/.plan/project-architecture/deployment/enriched.json
@@ -1,0 +1,15 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "",
+  "purpose_reasoning": "",
+  "responsibility": "",
+  "responsibility_reasoning": "",
+  "skills_by_profile": {},
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/deployment/compose-sample/.env
+++ b/deployment/compose-sample/.env
@@ -1,0 +1,14 @@
+# Compose auto-loads this file from the project directory, so it is the SINGLE place the sample's
+# gateway image default is written. docker-compose.yml references ${API_SHERIFF_IMAGE} with no
+# inline fallback, and start-sample.sh reads the value back out of the resolved Compose model
+# rather than restating it -- the same derive-don't-restate rule wait-for-ready.sh follows for the
+# readiness probe (ADR-0031).
+#
+# An exported API_SHERIFF_IMAGE in the environment WINS over this file, which is how the
+# local-build override documented in doc/user/compose-sample.adoc works:
+#
+#   API_SHERIFF_IMAGE=api-sheriff:distroless ./scripts/start-sample.sh
+#
+# 0.1.0 is not published yet. Until it is, the local-build override above is the working route;
+# see doc/user/compose-sample.adoc for the one-time native build that produces the local image.
+API_SHERIFF_IMAGE=ghcr.io/cuioss/api-sheriff:0.1.0

--- a/deployment/compose-sample/docker-compose.yml
+++ b/deployment/compose-sample/docker-compose.yml
@@ -1,0 +1,215 @@
+# API Sheriff — production-shaped docker-compose sample
+#
+# THREE services on one bridge network, and nothing else:
+#
+#   api-sheriff  the gateway, running the PUBLISHED image (never a local build)
+#   keycloak     the identity provider whose realm mints the bearer tokens the gateway validates
+#   demo-api     a stand-in upstream serving a canned JSON document, reached only on the internal network
+#
+# This is a SAMPLE, not a test harness. It deliberately carries none of the integration-tests
+# scaffolding — no toxiproxy, no go-httpbin, no passthrough backend, no asset origin, no gRPC echo —
+# because every one of those exists to exercise a test, not to show an operator how the gateway is
+# deployed. What it does carry is the deployment shape: the image is pulled by tag, all configuration
+# arrives through read-only mounts, and every runtime-hardening directive a production deployment
+# should set is set here explicitly rather than left to a default.
+#
+# See doc/user/compose-sample.adoc for the operator walkthrough and
+# doc/development/compose-sample.adoc for the rationale behind each decision below.
+
+services:
+
+  # --- The identity provider ----------------------------------------------------------------------
+  # Pinned BY DIGEST, not by tag alone: a tag is mutable, so a digest is what makes this sample
+  # reproducible. Dependabot cannot update this automatically — check https://quay.io/keycloak/keycloak
+  # and update the digest together with the version.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.5.4@sha256:ae8efb0d218d8921334b03a2dbee7069a0b868240691c50a3ffc9f42fabba8b4
+    command:
+      - start-dev
+      - --import-realm
+      - --https-certificate-file=/opt/keycloak/certificates/localhost.crt
+      - --https-certificate-key-file=/opt/keycloak/certificates/localhost.key
+      - --https-port=8443
+    environment:
+      # SAMPLE CREDENTIALS. Change both before this stack is reachable by anything you care about.
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+      # Enables the management interface on port 9000, which the TCP readiness probe below gates on.
+      - KC_HEALTH_ENABLED=true
+      - KC_LOG_LEVEL=INFO
+      # TLS is the only listener: the gateway reaches this IdP over HTTPS on the internal network,
+      # so the JWKS fetch it performs is not a plaintext hop even inside the bridge.
+      - KC_HTTP_ENABLED=false
+      - KC_HTTPS_PORT=8443
+      - KC_HOSTNAME=localhost
+      - KC_HOSTNAME_STRICT=false
+    ports:
+      # Published so an operator can reach the admin console and mint a token from the host. The
+      # gateway does NOT use this published port — it reaches Keycloak container-internally as
+      # keycloak:8443, which is why the realm below pins that URL as its frontend.
+      - "1443:8443"
+    volumes:
+      - ./docker/keycloak:/opt/keycloak/data/import:ro
+      - ./docker/certificates:/opt/keycloak/certificates:ro
+      # /opt/keycloak/data must be writable under read_only: true — Keycloak writes its
+      # transaction/state there during the realm import. A NAMED VOLUME rather than a tmpfs so the
+      # imported realm survives a restart. The read-only import bind above nests inside it: Compose
+      # orders mounts by path depth, so the volume lands first and the bind lands within it.
+      - keycloak-data:/opt/keycloak/data
+      # `start-dev` RE-AUGMENTS Quarkus on every boot ("Updating the configuration and installing
+      # your custom providers") and writes the rebuilt runner into /opt/keycloak/lib/quarkus. Under
+      # read_only: true that write fails with ReadOnlyFileSystemException and Keycloak never starts —
+      # so this mount is what makes the hardening block above survivable rather than fatal.
+      #
+      # A NAMED VOLUME, not a tmpfs, and the distinction is load-bearing: Docker seeds a named volume
+      # from the image's content at that path on first use, whereas a tmpfs would mask the shipped
+      # Quarkus libraries with an empty directory and break the augmentation a different way.
+      - keycloak-quarkus:/opt/keycloak/lib/quarkus
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    networks:
+      - api-sheriff
+    restart: unless-stopped
+    # A TCP accept probe on the management port, deliberately CURL-FREE: the Keycloak image ships
+    # neither curl nor wget, so a probe naming either would fail permanently and be indistinguishable
+    # from a service that never came up. bash IS present, so /dev/tcp is the available primitive.
+    # This is an ACCEPT-LEVEL probe only — it proves the management listener is bound, not that the
+    # realm finished importing. That is sufficient here: it exists to order the gateway's start
+    # behind the IdP's, and the gateway's own readiness gate (scripts/wait-for-ready.sh) is what
+    # asserts the stack is actually usable.
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo -n > /dev/tcp/127.0.0.1/9000'"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 20s
+    # OWASP container hardening — the same posture every service in this file carries.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+
+  # --- The upstream the gateway proxies to --------------------------------------------------------
+  # A canned JSON responder standing in for a real backend API. It publishes NO host port: the whole
+  # point of the sample is that the gateway is the only way in, so reaching this service directly
+  # from the host must not be possible.
+  demo-api:
+    # Pinned to the 1.27 MINOR line rather than the floating :alpine tag, so a sample that worked
+    # yesterday still works today. Bump deliberately, not implicitly.
+    image: nginx:1.27-alpine
+    # Bypasses docker-entrypoint.sh entirely. That script's 10-listen-on-ipv6-only.sh step rewrites
+    # /etc/nginx/conf.d/default.conf in place, which fails under read_only: true and takes the whole
+    # container down with it. Executing nginx directly skips every entrypoint step; none of the rest
+    # is needed here because the configuration is mounted complete.
+    entrypoint: ["nginx", "-g", "daemon off;"]
+    # The stock nginx image's unprivileged uid/gid. Declared explicitly because the image's default
+    # is root (it drops to nginx only for workers), and with cap_drop: ALL a root master process
+    # cannot bind or chown anything anyway — so running as the unprivileged user from the start is
+    # both safer and closer to what actually happens.
+    user: "101:101"
+    volumes:
+      - ./docker/nginx/demo-api.conf:/etc/nginx/conf.d/default.conf:ro
+    # nginx needs three writable paths and gets no more than three. Sized small on purpose: this is
+    # a canned responder, not a cache.
+    #
+    # uid/gid 101 is LOAD-BEARING, not decoration. A tmpfs is created root-owned and mode 755, so
+    # with `user: "101:101"` above nginx cannot create /var/cache/nginx/client_temp and dies at
+    # startup with "mkdir() ... failed (13: Permission denied)" — a crash loop, not a slow start.
+    # Handing each mount to the running uid is what makes read_only + non-root actually work here.
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m,uid=101,gid=101
+      - /var/cache/nginx:rw,noexec,nosuid,size=16m,uid=101,gid=101
+      - /var/run:rw,noexec,nosuid,size=1m,uid=101,gid=101
+    networks:
+      - api-sheriff
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+
+  # --- The gateway ---------------------------------------------------------------------------------
+  api-sheriff:
+    # The PUBLISHED image, by tag, overridable for a local build or a newer release. This sample
+    # never builds an image: it demonstrates deploying a released artifact, which is what an operator
+    # actually does.
+    image: ${API_SHERIFF_IMAGE:-ghcr.io/cuioss/api-sheriff:0.1.0}
+    # Declares the scheme this instance's MANAGEMENT interface speaks. scripts/wait-for-ready.sh
+    # derives its entire probe URL from this label plus the host port published against container
+    # port 9000 — so the readiness gate restates neither scheme nor port, and renumbering the
+    # published port below needs no script edit (ADR-0031).
+    labels:
+      de.cuioss.sheriff.management-scheme: "https"
+    ports:
+      - "8443:8443"  # Public TLS listener — the only way into the stack
+      - "9000:9000"  # Management interface (health/metrics), HTTPS
+    environment:
+      # This block is the DEPLOYMENT DOOR, and it is deliberately the same door the release smoke
+      # test drives in .github/workflows/release.yml. The shipped artifact declares nothing about
+      # where its configuration or its key material lives (ADR-0032); the deployment supplies both.
+      #
+      # Where the gateway's own configuration is mounted.
+      - SHERIFF_CONFIG_DIR=/app/sheriff-config
+      # The public TLS listener's certificate and key.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/app/certificates/localhost.crt
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/app/certificates/localhost.key
+      # The management interface's certificate and key. Quarkus' management interface has exactly ONE
+      # port, so supplying these converts port 9000 itself to HTTPS — which is why the label above
+      # says https and why the readiness probe passes -k against the self-signed bundle.
+      - QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES=/app/certificates/localhost.crt
+      - QUARKUS_MANAGEMENT_SSL_CERTIFICATE_KEY_FILES=/app/certificates/localhost.key
+      # NOTE: QUARKUS_HTTP_SSL_PORT is deliberately ABSENT. The integration stack sets it to move the
+      # terminated listener off 8443 because its gateway.yaml declares a passthrough_sni block that
+      # claims the public port for the SNI front listener. This sample declares no passthrough_sni,
+      # so Quarkus terminates directly on 8443 and an override here would only mis-address it.
+    volumes:
+      # Both mounts are READ-ONLY. Configuration and key material are supplied by the deployment and
+      # are never written by the gateway; a writable mount would be surface for no benefit.
+      - ./docker/sheriff-config:/app/sheriff-config:ro
+      - ./docker/certificates:/app/certificates:ro
+    # The gateway eagerly loads the issuer's key set at boot. Starting it before Keycloak accepts
+    # connections makes that load fail, and the issuer then stays unhealthy for the whole run — so
+    # this gate is load-bearing, not cosmetic.
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    networks:
+      - api-sheriff
+    restart: unless-stopped
+    # NO healthcheck: key. The distroless image ships neither a shell nor curl, so every in-container
+    # probe form is unavailable by construction — a healthcheck here could only ever fail. Readiness
+    # is gated HOST-side by scripts/wait-for-ready.sh against the published management port.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=100m
+    # No user: key — the image already declares USER nonroot (uid 65532) in its Dockerfile, so the
+    # container never runs as root and re-stating the uid here would only risk drifting from it.
+    #
+    # Resource limits: a starting point sized for the sample, not a tuning recommendation. Real
+    # values follow from measured load.
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '2.0'
+        reservations:
+          memory: 256M
+          cpus: '0.5'
+
+volumes:
+  # Keycloak's writable state. Named rather than anonymous so `docker compose down` keeps it and the
+  # realm import is not re-run on every restart; `docker compose down -v` is the deliberate reset.
+  keycloak-data:
+  # Keycloak's re-augmented Quarkus runner (see the mount above). Derived content, not state — it is
+  # rebuilt from the image on any boot whose configuration changed, and `down -v` discards it.
+  keycloak-quarkus:
+
+networks:
+  api-sheriff:
+    driver: bridge

--- a/deployment/compose-sample/docker-compose.yml
+++ b/deployment/compose-sample/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   # reproducible. Dependabot cannot update this automatically — check https://quay.io/keycloak/keycloak
   # and update the digest together with the version.
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.4@sha256:ae8efb0d218d8921334b03a2dbee7069a0b868240691c50a3ffc9f42fabba8b4
+    image: quay.io/keycloak/keycloak:26.5.7@sha256:45ae20191531eb608ddb0b775d012b40d3e4f942697f3214694887dd7c108d13
     command:
       - start-dev
       - --import-realm
@@ -135,7 +135,11 @@ services:
     # The PUBLISHED image, by tag, overridable for a local build or a newer release. This sample
     # never builds an image: it demonstrates deploying a released artifact, which is what an operator
     # actually does.
-    image: ${API_SHERIFF_IMAGE:-ghcr.io/cuioss/api-sheriff:0.1.0}
+    #
+    # No inline `:-default` here on purpose. The default lives in exactly one place, the sibling
+    # .env file, which Compose auto-loads; start-sample.sh reads the value back out of the resolved
+    # model rather than restating it. An inline fallback would be a second copy to keep in lockstep.
+    image: ${API_SHERIFF_IMAGE}
     # Declares the scheme this instance's MANAGEMENT interface speaks. scripts/wait-for-ready.sh
     # derives its entire probe URL from this label plus the host port published against container
     # port 9000 — so the readiness gate restates neither scheme nor port, and renumbering the

--- a/deployment/compose-sample/docker/certificates/.gitignore
+++ b/deployment/compose-sample/docker/certificates/.gitignore
@@ -1,0 +1,12 @@
+# NO KEY MATERIAL IS EVER COMMITTED.
+#
+# generate-certificates.sh is the source of truth for everything in this directory; the artifacts it
+# produces are local, disposable and — in the case of the key — secret. Ignoring them by pattern
+# rather than by name means a future addition (a truststore, a client bundle) is covered the moment
+# it appears, instead of the first time someone remembers to add it here.
+*.crt
+*.key
+*.p12
+
+# The script's own intermediate keystore, in case a run is interrupted before it is cleaned up.
+temp-keystore.p12

--- a/deployment/compose-sample/docker/certificates/.gitignore
+++ b/deployment/compose-sample/docker/certificates/.gitignore
@@ -6,7 +6,5 @@
 # it appears, instead of the first time someone remembers to add it here.
 *.crt
 *.key
+# Covers the script's own intermediate keystore too, including a run interrupted before cleanup.
 *.p12
-
-# The script's own intermediate keystore, in case a run is interrupted before it is cleaned up.
-temp-keystore.p12

--- a/deployment/compose-sample/docker/certificates/generate-certificates.sh
+++ b/deployment/compose-sample/docker/certificates/generate-certificates.sh
@@ -18,8 +18,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CERT_DIR="${SCRIPT_DIR}"
+CERT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # CN=localhost so a browser on the host addresses the gateway as https://localhost:8443. The SAN list
 # is what actually matters to a modern client, and it carries BOTH the host-facing name and the two

--- a/deployment/compose-sample/docker/certificates/generate-certificates.sh
+++ b/deployment/compose-sample/docker/certificates/generate-certificates.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Generate the self-signed TLS material this compose sample runs on.
+#
+# ###############################################################################################
+# #                                                                                             #
+# #   SAMPLE MATERIAL ONLY — NEVER USE THE OUTPUT OF THIS SCRIPT IN PRODUCTION.                 #
+# #                                                                                             #
+# #   It mints a self-signed certificate with no CA behind it, and writes the private key next  #
+# #   to it, unencrypted, in a directory the compose stack mounts. That is the right trade for  #
+# #   a sample you bring up and tear down on one machine, and the wrong one for anything else.  #
+# #   A real deployment supplies certificate and key from its own PKI and mounts them at the    #
+# #   same two paths — the gateway does not care where they came from.                          #
+# #                                                                                             #
+# ###############################################################################################
+#
+# NO KEY MATERIAL IS COMMITTED. This script is the source of truth; the .gitignore beside it keeps
+# every artifact the script produces out of the repository. Run it once before the first bring-up.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CERT_DIR="${SCRIPT_DIR}"
+
+# CN=localhost so a browser on the host addresses the gateway as https://localhost:8443. The SAN list
+# is what actually matters to a modern client, and it carries BOTH the host-facing name and the two
+# compose service names — the gateway reaches Keycloak as `keycloak` on the internal network, so a
+# certificate without that name would fail hostname verification on the JWKS fetch.
+CERT_DNAME="CN=localhost, OU=Compose Sample, O=API-Sheriff, L=Berlin, ST=Berlin, C=DE"
+CERT_SAN="dns:localhost,dns:keycloak,dns:api-sheriff,dns:demo-api,ip:127.0.0.1"
+CERT_VALIDITY=365
+
+TEMP_KEYSTORE="${CERT_DIR}/temp-keystore.p12"
+TEMP_PASSWORD="temp-$(date +%s)"
+
+echo "Generating SAMPLE self-signed TLS material for the API Sheriff compose sample..."
+echo "  Directory: ${CERT_DIR}"
+
+# Start from a clean slate so a re-run never leaves a half-replaced pair behind.
+rm -f "${CERT_DIR}/localhost.crt" "${CERT_DIR}/localhost.key" "${TEMP_KEYSTORE}"
+
+echo "  Generating key pair and self-signed certificate..."
+keytool -genkeypair \
+  -alias localhost \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity "${CERT_VALIDITY}" \
+  -dname "${CERT_DNAME}" \
+  -ext "san=${CERT_SAN}" \
+  -keystore "${TEMP_KEYSTORE}" \
+  -storetype PKCS12 \
+  -storepass "${TEMP_PASSWORD}" \
+  -keypass "${TEMP_PASSWORD}"
+
+echo "  Exporting the certificate (PEM)..."
+keytool -exportcert \
+  -alias localhost \
+  -file "${CERT_DIR}/localhost.crt" \
+  -keystore "${TEMP_KEYSTORE}" \
+  -storetype PKCS12 \
+  -storepass "${TEMP_PASSWORD}" \
+  -rfc
+
+echo "  Exporting the private key (PEM, unencrypted)..."
+openssl pkcs12 -in "${TEMP_KEYSTORE}" \
+  -passin pass:"${TEMP_PASSWORD}" \
+  -nodes \
+  -nocerts \
+  -out "${CERT_DIR}/localhost.key"
+
+# BOTH files are world-readable, and the key deliberately so. Read this before "tightening" it:
+#
+# The two containers that mount this directory run as DIFFERENT non-root uids — the gateway as
+# nonroot (65532, from its Dockerfile) and Keycloak as 1000 — while these files are owned by
+# whichever host user ran this script. Neither uid can be matched from the host without root, so
+# mode 600 makes the key unreadable inside the container and the gateway dies at boot with
+# `AccessDeniedException: /app/certificates/localhost.key`. World-read is what makes a non-root,
+# read_only, cap_drop-ALL container able to serve TLS at all.
+#
+# That trade is acceptable here and ONLY here: this key is self-signed, git-ignored, regenerated on
+# demand and never leaves this machine. It protects nothing, so exposing it to other local accounts
+# costs nothing. A real deployment does the opposite — it supplies key material from its own PKI
+# with restrictive ownership matched to the runtime uid, and mounts it at these same two paths.
+#
+# (integration-tests/src/main/docker/certificates/generate-certificates.sh still chmods its key to
+# 600, but that mode is nominal: those certificates are COMMITTED, and git records only the exec
+# bit, so a fresh checkout materialises them world-readable anyway. The sample commits no key
+# material, so the mode it is created with is the mode the container actually sees.)
+chmod 644 "${CERT_DIR}/localhost.crt"
+chmod 644 "${CERT_DIR}/localhost.key"
+
+rm -f "${TEMP_KEYSTORE}"
+
+echo ""
+echo "Done. Generated (both git-ignored):"
+echo "  localhost.crt  the certificate, mounted into api-sheriff and keycloak"
+echo "  localhost.key  the private key  — sample only, never leaves this machine"
+echo ""
+echo "Valid ${CERT_VALIDITY} days. Subject: ${CERT_DNAME}"
+echo "SAN: ${CERT_SAN}"
+echo ""
+echo "Because the certificate is self-signed, every client must be told to accept it:"
+echo "  curl -k https://localhost:8443/api"
+echo "A browser will show a warning. That is correct, and it is the reason this is a sample."

--- a/deployment/compose-sample/docker/certificates/generate-certificates.sh
+++ b/deployment/compose-sample/docker/certificates/generate-certificates.sh
@@ -31,6 +31,13 @@ CERT_VALIDITY=365
 TEMP_KEYSTORE="${CERT_DIR}/temp-keystore.p12"
 TEMP_PASSWORD="temp-$(date +%s)"
 
+# Remove the intermediate keystore on EVERY exit path, not just the success one. Under `set -e` a
+# failing keytool or openssl aborts the script before the explicit cleanup at the end, which would
+# otherwise strand a PKCS#12 file holding the private key in a directory an operator is told to
+# treat as generated-and-disposable. The trap is armed here, immediately after the path is defined,
+# so no failure between this line and the cleanup can escape it.
+trap 'rm -f "${TEMP_KEYSTORE}"' EXIT
+
 echo "Generating SAMPLE self-signed TLS material for the API Sheriff compose sample..."
 echo "  Directory: ${CERT_DIR}"
 
@@ -87,7 +94,8 @@ openssl pkcs12 -in "${TEMP_KEYSTORE}" \
 chmod 644 "${CERT_DIR}/localhost.crt"
 chmod 644 "${CERT_DIR}/localhost.key"
 
-rm -f "${TEMP_KEYSTORE}"
+# No explicit keystore removal here — the EXIT trap armed above owns that, on this path and on every
+# failure path alike. A second copy would only be a second thing to keep in step.
 
 echo ""
 echo "Done. Generated (both git-ignored):"

--- a/deployment/compose-sample/docker/keycloak/sample-realm.json
+++ b/deployment/compose-sample/docker/keycloak/sample-realm.json
@@ -1,0 +1,73 @@
+{
+  "realm": "sample",
+  "displayName": "API Sheriff Compose Sample",
+  "enabled": true,
+
+  "attributes": {
+    "frontendUrl": "https://keycloak:8443"
+  },
+
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "defaultSignatureAlgorithm": "RS256",
+
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "The one role the sample grants. Map it to whatever a real deployment authorizes on."
+      }
+    ]
+  },
+
+  "clients": [
+    {
+      "clientId": "sample-client",
+      "name": "API Sheriff Sample Client",
+      "description": "Sample client. Its secret is the placeholder CHANGE-ME-BEFORE-PRODUCTION and MUST be replaced, from the deployment rather than from this file, before this realm is reachable by anything you care about.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "CHANGE-ME-BEFORE-PRODUCTION",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "https://localhost:8443/*"
+      ],
+      "webOrigins": [
+        "https://localhost:8443"
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "sample-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sample",
+      "lastName": "User",
+      "email": "sample-user@example.com",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "CHANGE-ME-BEFORE-PRODUCTION",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "user"
+      ]
+    }
+  ]
+}

--- a/deployment/compose-sample/docker/nginx/demo-api.conf
+++ b/deployment/compose-sample/docker/nginx/demo-api.conf
@@ -1,0 +1,19 @@
+# The demo upstream: a canned JSON responder standing in for a real backend API.
+#
+# Mounted at /etc/nginx/conf.d/default.conf. It is intentionally the smallest thing that can stand
+# in for a backend — no proxying, no filesystem access, no state — so that anything observed at the
+# gateway's edge is attributable to the gateway and not to this service.
+server {
+    # 8080, not 80: the container runs as the unprivileged uid 101, which cannot bind a privileged
+    # port once cap_drop: ALL has removed CAP_NET_BIND_SERVICE. The gateway reaches this on the
+    # internal network as demo-api:8080 (topology.properties), and no host port is published.
+    listen 8080;
+    server_name demo-api;
+
+    # Nothing is served from disk, so no root is declared and the container's filesystem stays
+    # irrelevant to the response.
+    location / {
+        add_header Content-Type application/json always;
+        return 200 '{"service":"demo-api","message":"Reached the upstream through API Sheriff."}';
+    }
+}

--- a/deployment/compose-sample/docker/sheriff-config/endpoints/demo-api.yaml
+++ b/deployment/compose-sample/docker/sheriff-config/endpoints/demo-api.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=../../../../../api-sheriff/src/main/resources/schema/endpoint.schema.json
+# The single endpoint this sample proxies.
+#
+# One endpoint, one route. A request to https://localhost:8443/api reaches the gateway, is filtered
+# under the strict inbound profile, and is forwarded to the UPSTREAM alias — which topology.properties
+# resolves to the demo-api responder on the internal network. The response comes back through the
+# gateway's own envelope. That round trip is the whole demonstration.
+endpoint:
+  id: demo-api
+  enabled: true
+  # Resolved through topology.properties. Never a literal address here.
+  base_url: UPSTREAM
+  # Joins the public proxy namespace declared in gateway.yaml.
+  anchor: api
+  # The `api` anchor is access: public, so a public anchor carries no auth block and the endpoint
+  # declares the posture itself. Every route inherits it.
+  #
+  # THIS IS THE FIRST THING TO CHANGE when adapting the sample: switch to `require: bearer` and the
+  # route below is gated on a token from the issuer gateway.yaml declares.
+  auth:
+    require: none
+  routes:
+    - id: demo-api-get
+      match:
+        path_prefix: /api
+      # The forward stage is DENY-BY-DEFAULT: a request header or query parameter crosses to the
+      # upstream only if it is named here. That is the posture, not a restriction to work around —
+      # an allowlist is what stops a header the gateway does not understand from becoming the
+      # upstream's problem. Nothing is allowed through here because the demo upstream serves a canned
+      # document and reads neither; add the exact names a real backend needs, and no others.
+      forward:
+        headers_allow: []
+        query_allow: []

--- a/deployment/compose-sample/docker/sheriff-config/gateway.yaml
+++ b/deployment/compose-sample/docker/sheriff-config/gateway.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=../../../../api-sheriff/src/main/resources/schema/gateway.schema.json
+# API Sheriff — global gateway document for the compose sample.
+#
+# Mounted read-only at /app/sheriff-config (SHERIFF_CONFIG_DIR). This is the whole of the gateway's
+# own configuration language: what it listens for, how strictly it filters, which namespaces exist,
+# and which token issuers it trusts. Endpoints live in endpoints/, topology aliases in
+# topology.properties.
+#
+# The document is deliberately SMALL. It declares one public proxy namespace and one token issuer,
+# which is the minimum that still demonstrates the shape of a real deployment. Everything the
+# integration suite needs and an operator does not — passthrough SNI, BFF sessions, asset anchors,
+# mTLS — is absent rather than present-and-disabled.
+version: 1
+metadata:
+  config_version: "compose-sample"
+
+# The methods this gateway will admit at all. Anything outside this list is rejected before route
+# selection. Narrow it further for a real deployment: this list is what the demo endpoint needs.
+allowed_methods: ["GET", "HEAD"]
+
+# The gateway-wide inbound-filter baseline. Declared EXPLICITLY rather than left to the omitted-key
+# default, so the posture is visible in the document an operator reads rather than inherited
+# invisibly. `strict` is also the default — stating it is a statement of intent, not a change.
+#
+# strict caps a request at 1 MiB of body, 20 query parameters, 1024-character header values,
+# parameter values and paths. Every route below inherits it; none opts out.
+security_defaults:
+  profile: strict
+
+# TLS POLICY for the terminated listener. The certificate and key themselves are NOT here — they are
+# deployment-supplied through the environment (see docker-compose.yml) and this document stays free
+# of key material and paths, so it is safe to commit and to copy between environments.
+tls:
+  # 1.2 is the floor, which enables TLS 1.2 and 1.3. Raise to "1.3" when every client can reach it.
+  min_version: "1.2"
+  cipher_suites:
+    - TLS_AES_256_GCM_SHA384
+    - TLS_AES_128_GCM_SHA256
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  alpn: ["h2", "http/1.1"]
+
+# One namespace. `type: proxy` + `access: public` are the two mandatory classification axes, and a
+# public anchor carries NO auth block — public IS the absence of auth, so the require: none posture
+# lives on the endpoint instead (endpoints/demo-api.yaml).
+anchors:
+  api:
+    path_prefix: /api
+    type: proxy
+    access: public
+
+# The issuers whose tokens this gateway will validate. Declared even though the one endpoint below is
+# public, because an operator adapting this sample will make a route authenticated as their first
+# change — and the issuer block is the part that is easy to get wrong.
+token_validation:
+  issuers:
+    - name: sample-keycloak
+      # The CONTAINER-INTERNAL issuer URL, not the host-published one. The realm import pins
+      # frontendUrl to https://keycloak:8443, so every token this realm mints carries exactly this
+      # `iss` value regardless of which host port it was minted through. A host-published URL here
+      # would reject every token with a 401 that looks like a signature problem and is not.
+      issuer: https://keycloak:8443/realms/sample
+      jwks:
+        source: http
+        url: https://keycloak:8443/realms/sample/protocol/openid-connect/certs
+        # The SSRF egress guard refuses a JWKS URL resolving to a private address unless the host is
+        # named here. `keycloak` is a Compose service name resolving to the bridge network's
+        # site-local address, so without this entry the key set never loads. The allowlist is
+        # host-exact — no wildcard — and names ONLY this one trusted IdP. Widen it for no other
+        # reason than adding a genuinely trusted issuer.
+        allowed_egress_hosts: ["keycloak"]
+        # NOTE FOR A REAL DEPLOYMENT: this sample's Keycloak serves the same self-signed certificate
+        # the gateway does, so the JWKS fetch trusts it only because both sides share the generated
+        # bundle. Against an IdP with its own CA, bind a trust profile here (`tls_profile: <name>`)
+        # and supply the concrete trust anchors from the deployment — this document names the
+        # logical profile, never the store path or its password.

--- a/deployment/compose-sample/docker/sheriff-config/topology.properties
+++ b/deployment/compose-sample/docker/sheriff-config/topology.properties
@@ -1,0 +1,15 @@
+# Topology aliases for the compose sample.
+#
+# An alias is the ONE place a backend address is written down. Endpoints reference the alias by name
+# (endpoints/demo-api.yaml declares `base_url: UPSTREAM`), so repointing the gateway at a different
+# backend is a change here and nowhere else.
+#
+# The value uses the in-file placeholder form: only explicit ${VAR} / ${VAR:-default} placeholders
+# written in this file are substituted. There is NO convention-named environment path — an
+# environment variable binds if and only if this file names it, which is what keeps the set of
+# externally-influenced values readable from the file itself.
+#
+# UPSTREAM is the demo-api nginx responder, reached by the gateway on the internal compose network.
+# It publishes no host port, so this address is the only way to it. Override TOPOLOGY_UPSTREAM in the
+# environment to aim the same route at a real backend without editing this file.
+UPSTREAM=${TOPOLOGY_UPSTREAM:-http://demo-api:8080}

--- a/deployment/compose-sample/scripts/start-sample.sh
+++ b/deployment/compose-sample/scripts/start-sample.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Bring the API Sheriff compose sample up and hand off to the readiness gate.
+#
+# Three steps, in this order and no others:
+#
+#   1. PREFLIGHT the gateway image, so a missing image fails in seconds with an actionable message
+#      instead of as a compose pull error buried under three service startups.
+#   2. BRING THE STACK UP.
+#   3. DELEGATE to wait-for-ready.sh, which owns the readiness contract (ADR-0031). This script
+#      derives no probe URL, names no port and hard-codes no scheme — restating any of them here
+#      would be a second copy to keep in lockstep with docker-compose.yml.
+#
+# Invoked by the deployment module's opt-in `compose-sample` Maven profile at pre-integration-test,
+# and directly by an operator following doc/user/compose-sample.adoc. Both paths are the same path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAMPLE_DIR="$(dirname "${SCRIPT_DIR}")"
+
+# The effective gateway image. This default is the SAME literal docker-compose.yml carries for
+# api-sheriff; the two are read together and must stay identical, which is why the override variable
+# is named identically too — exporting API_SHERIFF_IMAGE steers this preflight and the compose model
+# as one.
+IMAGE_REF="${API_SHERIFF_IMAGE:-ghcr.io/cuioss/api-sheriff:0.1.0}"
+
+cd "${SAMPLE_DIR}"
+
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+else
+    echo "❌ Docker Compose not available (neither 'docker compose' nor 'docker-compose')"
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "❌ Docker daemon not running — start Docker/Rancher Desktop first"
+    exit 1
+fi
+
+# The TLS material is generated, never committed (docker/certificates/.gitignore). Both Keycloak and
+# the gateway mount it read-only, so without it Keycloak crash-loops and the readiness gate below
+# burns its whole budget against a stack that was never going to come up. Checking for it here turns
+# that into one line naming the one-time command that fixes it.
+if [[ ! -f "${SAMPLE_DIR}/docker/certificates/localhost.crt" \
+   || ! -f "${SAMPLE_DIR}/docker/certificates/localhost.key" ]]; then
+    echo "❌ The sample's TLS material is missing."
+    echo "   docker/certificates/localhost.crt and localhost.key are generated, never committed."
+    echo "   Generate them once, then re-run this script:"
+    echo "     ./docker/certificates/generate-certificates.sh"
+    exit 1
+fi
+
+# ---- 1. Image preflight ------------------------------------------------------------------------
+# Present locally is the common case for a local-build override; absent means exactly ONE pull
+# attempt. A pull that fails is terminal — falling through to `compose up` would surface the same
+# failure again, later, as a less legible error against a half-started stack.
+echo "🔎 Checking for the gateway image ${IMAGE_REF}..."
+if docker image inspect "${IMAGE_REF}" >/dev/null 2>&1; then
+    echo "✅ Found ${IMAGE_REF} locally."
+else
+    echo "⏬ Not present locally — pulling ${IMAGE_REF} (one attempt)..."
+    if ! docker pull "${IMAGE_REF}"; then
+        echo ""
+        echo "❌ The gateway image ${IMAGE_REF} is neither present locally nor pullable."
+        echo ""
+        echo "   Two routes, pick one:"
+        echo ""
+        echo "   (a) PUBLISHED IMAGE — the sample's default. Check the reference and your network"
+        echo "       access to ghcr.io, then re-run. If that release does not exist yet, point"
+        echo "       API_SHERIFF_IMAGE at one that does."
+        echo ""
+        echo "   (b) LOCAL BUILD — build the gateway yourself and point the sample at the result:"
+        echo "         python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args \"clean install -Pnative -pl api-sheriff -am -DskipTests\""
+        echo "         docker compose -f integration-tests/docker-compose.yml build api-sheriff"
+        echo "         export API_SHERIFF_IMAGE=api-sheriff:distroless"
+        echo "       Both commands run from the repository root."
+        echo ""
+        exit 1
+    fi
+fi
+
+# ---- 2. Bring the stack up ---------------------------------------------------------------------
+echo "🐳 Starting the compose sample (api-sheriff, keycloak, demo-api)..."
+"${COMPOSE_CMD[@]}" up -d
+
+# ---- 3. Hand off to the readiness gate ---------------------------------------------------------
+# exec, so the gate's exit code IS this script's exit code and the Maven execution above it fails
+# when the stack does not become ready.
+exec "${SCRIPT_DIR}/wait-for-ready.sh"

--- a/deployment/compose-sample/scripts/start-sample.sh
+++ b/deployment/compose-sample/scripts/start-sample.sh
@@ -18,12 +18,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SAMPLE_DIR="$(dirname "${SCRIPT_DIR}")"
 
-# The effective gateway image. This default is the SAME literal docker-compose.yml carries for
-# api-sheriff; the two are read together and must stay identical, which is why the override variable
-# is named identically too — exporting API_SHERIFF_IMAGE steers this preflight and the compose model
-# as one.
-IMAGE_REF="${API_SHERIFF_IMAGE:-ghcr.io/cuioss/api-sheriff:0.1.0}"
-
 cd "${SAMPLE_DIR}"
 
 if docker compose version >/dev/null 2>&1; then
@@ -54,6 +48,36 @@ if [[ ! -f "${SAMPLE_DIR}/docker/certificates/localhost.crt" \
 fi
 
 # ---- 1. Image preflight ------------------------------------------------------------------------
+# The effective gateway image is DERIVED from the resolved Compose model, never restated here. The
+# default lives once in .env; an exported API_SHERIFF_IMAGE overrides it. Compose has already
+# applied that precedence by the time it answers `config`, so reading the answer back is the only
+# way this preflight and the stack that actually starts cannot disagree — the same
+# derive-don't-restate rule wait-for-ready.sh follows for the readiness probe (ADR-0031).
+#
+# This must sit AFTER the COMPOSE_CMD block above: it dereferences that array.
+if ! IMAGE_REF="$("${COMPOSE_CMD[@]}" config --format json | python3 -c '
+import json, sys
+
+try:
+    model = json.load(sys.stdin)
+except ValueError as exc:
+    sys.exit("could not parse the resolved Compose model as JSON (%s). This script needs a Compose "
+             "version supporting `config --format json`." % exc)
+
+image = ((model.get("services") or {}).get("api-sheriff") or {}).get("image")
+if not image:
+    # Empty means API_SHERIFF_IMAGE resolved to nothing -- .env is missing or was emptied. Failing
+    # here is the point: falling through would preflight the empty string and then hand compose a
+    # service with no image at all.
+    sys.exit("the resolved Compose model carries no image for service api-sheriff. Check that "
+             ".env sets API_SHERIFF_IMAGE, or export it explicitly.")
+
+sys.stdout.write(image)
+')"; then
+    echo "❌ Could not derive the gateway image from docker-compose.yml (see above)"
+    exit 1
+fi
+
 # Present locally is the common case for a local-build override; absent means exactly ONE pull
 # attempt. A pull that fails is terminal — falling through to `compose up` would surface the same
 # failure again, later, as a less legible error against a half-started stack.

--- a/deployment/compose-sample/scripts/stop-sample.sh
+++ b/deployment/compose-sample/scripts/stop-sample.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Tear the API Sheriff compose sample down completely.
+#
+# `down -v --remove-orphans` — and unlike demo-client/scripts/stop-dev-environment.sh, that full
+# teardown is the RIGHT call here. That script must select services by name because it borrows
+# integration-tests/docker-compose.yml, a stack somebody else may also be running. This sample owns
+# its own compose file and therefore its own Compose project: everything `down` reaches is something
+# this sample started, so there is no collateral damage to avoid.
+#
+#   -v                removes the keycloak-data volume, so the next bring-up re-imports the realm
+#                     from scratch. A sample should start from a known state every time; persisting
+#                     it across runs is what makes "it worked yesterday" hard to reproduce.
+#   --remove-orphans  clears containers left behind by an earlier revision of the compose file.
+#
+# Runs at Maven's pre-clean and post-integration-test phases as best-effort cleanup, so a host with
+# no Docker at all exits cleanly rather than failing the build.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAMPLE_DIR="$(dirname "${SCRIPT_DIR}")"
+
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+else
+    echo "ℹ️  Docker Compose not available — nothing to stop, skipping cleanup."
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ℹ️  Docker daemon not running — nothing to stop, skipping cleanup."
+    exit 0
+fi
+
+cd "${SAMPLE_DIR}"
+
+# Nothing running is the normal case (an aborted run may have left nothing behind), not a failure.
+echo "🛑 Stopping the API Sheriff compose sample..."
+"${COMPOSE_CMD[@]}" down -v --remove-orphans
+
+echo "✅ Compose sample stopped; its containers, network and volume are removed."

--- a/deployment/compose-sample/scripts/wait-for-ready.sh
+++ b/deployment/compose-sample/scripts/wait-for-ready.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Block until the API Sheriff compose sample is READY to serve, or fail loudly with the diagnostics
+# needed to find out why it is not.
+#
+# The whole probe target is DERIVED from the resolved Compose model — never restated here (ADR-0031):
+#
+#   * WHICH services to probe   the services carrying the de.cuioss.sheriff.management-scheme label
+#   * WHICH scheme to speak     that label's value, http or https
+#   * WHICH host port to hit    the port published against the fixed container-port selector 9000
+#
+# Only the container-side management port is a literal, and deliberately so: it is a stable
+# platform-level fact used as the SELECTOR that picks the management binding out of a service's port
+# list, not a per-deployment value. Renumbering the published port in docker-compose.yml, or adding a
+# second gateway instance, therefore needs no edit to this script.
+#
+# It probes READINESS, not liveness. /q/health/live answers as soon as the process is up, which is
+# strictly earlier than the point at which the gateway can actually serve a request — gating on it
+# would clear this wait before the stack is usable, which is the exact race this script exists to
+# remove.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAMPLE_DIR="$(dirname "${SCRIPT_DIR}")"
+
+# The retry budget, as ONE constant read by every site that needs it — the loop bound, the
+# last-attempt comparison and the progress message. Three literals would drift apart; one cannot.
+#
+# 60 attempts at 1s. The measured worst case for this stack is the native gateway reaching readiness
+# a few seconds after Keycloak reports its management port bound; 60s is roughly a 5x headroom over
+# that on a machine under load. Re-measure before shrinking it — a budget that is too small turns a
+# slow machine into a spurious failure, which is worse than waiting.
+READY_ATTEMPTS=60
+
+SCHEME_LABEL="de.cuioss.sheriff.management-scheme"
+MANAGEMENT_CONTAINER_PORT="9000"
+
+cd "${SAMPLE_DIR}"
+
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+else
+    echo "❌ Docker Compose not available (neither 'docker compose' nor 'docker-compose')"
+    exit 1
+fi
+
+echo "⏳ Deriving the readiness probe targets from the Compose model..."
+if ! TARGETS="$("${COMPOSE_CMD[@]}" config --format json | python3 -c '
+import json
+import sys
+
+SCHEME_LABEL = sys.argv[1]
+MANAGEMENT_CONTAINER_PORT = sys.argv[2]
+
+try:
+    model = json.load(sys.stdin)
+except ValueError as exc:
+    sys.exit("could not parse the resolved Compose model as JSON (%s). This script needs a Compose "
+             "version supporting `config --format json`." % exc)
+
+services = model.get("services") or {}
+
+rows = []
+problems = []
+for name, spec in sorted(services.items()):
+    labels = spec.get("labels") or {}
+    scheme = labels.get(SCHEME_LABEL)
+    if scheme is None:
+        # Not a probe target. A service without the label is not part of the readiness contract --
+        # that is how the IdP and the demo upstream stay out of this loop without being named here.
+        continue
+    if scheme not in ("http", "https"):
+        problems.append("%s: invalid %s label (got %r, expected http or https)"
+                        % (name, SCHEME_LABEL, scheme))
+        continue
+    published = [port.get("published") for port in (spec.get("ports") or [])
+                 if str(port.get("target")) == MANAGEMENT_CONTAINER_PORT and port.get("published")]
+    if len(published) != 1:
+        problems.append("%s: expected exactly one host port published against the management "
+                        "container port %s, found %r" % (name, MANAGEMENT_CONTAINER_PORT, published))
+        continue
+    rows.append("%s %s %s" % (name, scheme, published[0]))
+
+if problems:
+    sys.exit("readiness target discovery failed:\n  " + "\n  ".join(problems))
+
+if not rows:
+    # An empty target set must be a HARD failure. Passing here would report the stack ready without
+    # having probed anything at all -- a vacuous green, and the most dangerous outcome available.
+    sys.exit("readiness target discovery found no service carrying the %s label. At least one is "
+             "required, or this gate proves nothing." % SCHEME_LABEL)
+
+sys.stdout.write("\n".join(rows) + "\n")
+' "${SCHEME_LABEL}" "${MANAGEMENT_CONTAINER_PORT}")"; then
+    echo "❌ Could not derive the readiness targets from docker-compose.yml (see above)"
+    exit 1
+fi
+
+while read -r SERVICE SCHEME PORT; do
+    [[ -z "$SERVICE" ]] && continue
+
+    # -f is load-bearing: the readiness endpoint answers 503 while the gateway is still starting, and
+    # WITHOUT -f curl exits 0 on that 503 -- so the wait would clear the moment the port ACCEPTED a
+    # connection rather than when the gateway was ready, reintroducing the very race this gate removes.
+    PROBE_OPTS=(-sf --connect-timeout 2 --max-time 5)
+    DIAG_OPTS=(-s --connect-timeout 2 --max-time 5)
+    if [[ "$SCHEME" == "https" ]]; then
+        # -k ONLY on https, and only because the sample's certificate is self-signed. Without it curl
+        # fails certificate validation and this wait degrades into a silent full-budget timeout
+        # against a perfectly healthy container. It is applied from the DERIVED scheme, so a service
+        # whose management interface is plain HTTP is probed without it and no branch on the service
+        # name is needed.
+        PROBE_OPTS+=(-k)
+        DIAG_OPTS+=(-k)
+    fi
+    MGMT_URL="${SCHEME}://localhost:${PORT}"
+
+    echo "⏳ Waiting for ${SERVICE} to be ready (management ${SCHEME} on ${PORT})..."
+    for ((i = 1; i <= READY_ATTEMPTS; i++)); do
+        if curl "${PROBE_OPTS[@]}" "${MGMT_URL}/q/health/ready" > /dev/null 2>&1; then
+            echo "✅ ${SERVICE} is ready!"
+            break
+        fi
+        if [ "$i" -eq "$READY_ATTEMPTS" ]; then
+            echo "❌ ${SERVICE} did not become ready within ${READY_ATTEMPTS} attempts"
+            # Print the container log and the full health payload. A readiness failure is almost
+            # always explained by one of these two, and a developer should not have to know which
+            # commands to run next.
+            echo "----- ${COMPOSE_CMD[*]} logs ${SERVICE} -----"
+            "${COMPOSE_CMD[@]}" logs --no-color "${SERVICE}" </dev/null 2>&1 || true
+            echo "----- ${MGMT_URL}/q/health -----"
+            curl "${DIAG_OPTS[@]}" "${MGMT_URL}/q/health" 2>&1 || true
+            echo ""
+            exit 1
+        fi
+        echo "⏳ Waiting for ${SERVICE}... (attempt $i/${READY_ATTEMPTS})"
+        sleep 1
+    done
+done <<< "$TARGETS"
+
+echo ""
+echo "🎉 The API Sheriff compose sample is ready."
+echo "   Try it:  curl -k https://localhost:8443/api"

--- a/deployment/compose-sample/scripts/wait-for-ready.sh
+++ b/deployment/compose-sample/scripts/wait-for-ready.sh
@@ -99,8 +99,6 @@ sys.stdout.write("\n".join(rows) + "\n")
 fi
 
 while read -r SERVICE SCHEME PORT; do
-    [[ -z "$SERVICE" ]] && continue
-
     # -f is load-bearing: the readiness endpoint answers 503 while the gateway is still starting, and
     # WITHOUT -f curl exits 0 on that 503 -- so the wait would clear the moment the port ACCEPTED a
     # connection rather than when the gateway was ready, reintroducing the very race this gate removes.

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -52,5 +52,104 @@
              this is. The same reasoning is recorded at integration-tests/pom.xml, where it was
              established, and at demo-client/pom.xml. -->
         <skipPublishing>true</skipPublishing>
+
+        <!-- ==== The opt-in switch ========================================================= -->
+        <!-- Defaults to SKIP. Every execution in the compose-sample profile carries this as its
+             <skip>, and the profile itself flips it to false. Two layers on purpose, exactly as
+             demo-client/pom.xml establishes for its e2e-demo profile: the profile means a default
+             build has no executions to skip at all, and the property means an accidentally
+             activated profile still needs a deliberate override to start containers. -->
+        <skipComposeSample>true</skipComposeSample>
     </properties>
+
+    <profiles>
+        <!-- The ONLY place the sample stack is brought up. Activated explicitly with
+             -Pcompose-sample; the standard pull-request build and 'verify -Ppre-commit' never enter
+             it, so neither pulls an image nor starts a container. A default reactor build of this
+             module stays the genuine no-op the header above promises.
+
+             Note there is no <skipTests>false</skipTests> here, and none is needed. demo-client's
+             e2e-demo profile requires that flip because frontend-maven-plugin's test execution is
+             bound to a TESTING phase and therefore honours the inherited skipTests. exec-maven-
+             plugin's exec goal honours only its own <skip>, so the module-level skipTests=true that
+             keeps inherited surefire off this Java-free module cannot silently hollow this profile
+             out into a vacuous green. -->
+        <profile>
+            <id>compose-sample</id>
+            <properties>
+                <skipComposeSample>false</skipComposeSample>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Tear down anything an aborted previous run left behind, before
+                                 clean. The sample publishes fixed host ports, so a leaked stack
+                                 from a previous run would fail the bring-up below with a port
+                                 conflict that looks like a defect in the sample. -->
+                            <execution>
+                                <id>stop-sample-pre-clean</id>
+                                <phase>pre-clean</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipComposeSample}</skip>
+                                    <executable>./compose-sample/scripts/stop-sample.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                    <!-- Nothing running is the normal case, not a failure. -->
+                                    <successCodes>
+                                        <successCode>0</successCode>
+                                        <successCode>1</successCode>
+                                    </successCodes>
+                                </configuration>
+                            </execution>
+                            <!-- The gate itself. start-sample.sh preflights the image, brings the
+                                 three services up and then delegates to wait-for-ready.sh — so the
+                                 ADR-0031 readiness derivation lives in exactly one place and this
+                                 POM restates neither a port nor a scheme. A non-zero exit here
+                                 fails the build, which is what makes -Pcompose-sample a real gate
+                                 rather than a bring-up convenience. -->
+                            <execution>
+                                <id>start-sample</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipComposeSample}</skip>
+                                    <executable>./compose-sample/scripts/start-sample.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                            <!-- The SUCCESS-path teardown, and deliberately only that — the same
+                                 decision demo-client/pom.xml records: Maven offers no always-runs
+                                 hook, so a FAILING gate never reaches this phase and leaves the
+                                 stack up. That is wanted: the containers hold the logs explaining
+                                 the failure being diagnosed. The pre-clean teardown above is the
+                                 remedy, and it fires on any subsequent 'clean' build. -->
+                            <execution>
+                                <id>stop-sample-post-integration-test</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipComposeSample}</skip>
+                                    <executable>./compose-sample/scripts/stop-sample.sh</executable>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                    <successCodes>
+                                        <successCode>0</successCode>
+                                        <successCode>1</successCode>
+                                    </successCodes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -99,11 +99,14 @@
                                     <skip>${skipComposeSample}</skip>
                                     <executable>./compose-sample/scripts/stop-sample.sh</executable>
                                     <workingDirectory>${project.basedir}</workingDirectory>
-                                    <!-- Nothing running is the normal case, not a failure. -->
-                                    <successCodes>
-                                        <successCode>0</successCode>
-                                        <successCode>1</successCode>
-                                    </successCodes>
+                                    <!-- No <successCodes> override. "Nothing running" already exits
+                                         0: `docker compose down` is idempotent on an empty project,
+                                         and stop-sample.sh returns 0 explicitly for a host with no
+                                         Compose and for a stopped daemon. So the only thing exit 1
+                                         can mean here is a teardown that genuinely failed, and
+                                         accepting it would let a leaked stack pass silently — the
+                                         exact port-conflict-looking-like-a-defect this execution
+                                         exists to prevent. -->
                                 </configuration>
                             </execution>
                             <!-- The gate itself. start-sample.sh preflights the image, brings the
@@ -140,10 +143,10 @@
                                     <skip>${skipComposeSample}</skip>
                                     <executable>./compose-sample/scripts/stop-sample.sh</executable>
                                     <workingDirectory>${project.basedir}</workingDirectory>
-                                    <successCodes>
-                                        <successCode>0</successCode>
-                                        <successCode>1</successCode>
-                                    </successCodes>
+                                    <!-- No <successCodes> override, for the same reason as the
+                                         pre-clean execution above: exit 1 here can only be a real
+                                         teardown failure, and swallowing it would report a green
+                                         build over containers and volumes that were left running. -->
                                 </configuration>
                             </execution>
                         </executions>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.cuioss.sheriff.gateway</groupId>
+        <artifactId>api-sheriff-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>deployment</artifactId>
+    <packaging>pom</packaging>
+    <name>API Sheriff Deployment</name>
+    <description>Deployment material for API Sheriff — a production-shaped docker-compose sample that shows how the
+        gateway is configured, fronted and bound to an identity provider. Sample and documentation material only —
+        never a shipped default, never part of the production image or the native build.
+    </description>
+
+    <!-- This module carries NO Java. It owns exactly ONE subtree, compose-sample/, holding the compose
+         file, the configuration it mounts, the certificate tooling and the bring-up scripts. Nothing here
+         is built, tested or published: a default reactor build of this module is a deliberate no-op, so the
+         sample costs the standard build nothing. See doc/user/compose-sample.adoc for the operator guide and
+         doc/development/compose-sample.adoc for the rationale. -->
+
+    <dependencies />
+
+    <properties>
+        <!-- ==== Java plugin suppression =================================================== -->
+        <!-- There is no Java here, so every inherited Java-oriented plugin is switched off. Without
+             these the module would still run compilation, javadoc, static analysis and coverage over
+             an empty source tree, costing time in every build for no signal. -->
+        <maven.compiler.skip>true</maven.compiler.skip>
+        <skipTests>true</skipTests>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+        <pmd.skip>true</pmd.skip>
+        <cpd.skip>true</cpd.skip>
+        <enforcer.skip>true</enforcer.skip>
+        <jacoco.skip>true</jacoco.skip>
+        <license.skip>true</license.skip>
+        <dependency-check.skip>true</dependency-check.skip>
+        <skip.openrewrite>true</skip.openrewrite>
+
+        <!-- Never publish this module to Maven Central: it is deployment sample material, not a
+             consumable artifact. The effective switch is skipPublishing, NOT maven.deploy.skip —
+             cui-java-parent publishes through central-publishing-maven-plugin, whose own user property
+             this is. The same reasoning is recorded at integration-tests/pom.xml, where it was
+             established, and at demo-client/pom.xml. -->
+        <skipPublishing>true</skipPublishing>
+    </properties>
+</project>

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -87,6 +87,17 @@ built* and *how the parts fit together*.
   link:user/container-image.adoc[operator guide] covers pulling, running and cryptographically
   verifying the image, and the link:development/release-process.adoc[release-artifact policy]
   covers the artifact set, the two-tag scheme, and why the image version equals the Maven version.
+
+| Compose Sample (two-layer topic)
+| The production-shaped Docker Compose sample under `deployment/compose-sample`, documented across
+  two layers. There is deliberately no reference layer: the sample introduces no runtime component
+  and no `gateway.yaml` key -- it is an *arrangement* of the artifact
+  link:architecture.adoc[Architecture] already describes, so neither that document nor
+  link:configuration.adoc[Configuration] has a surface for it. The
+  link:user/compose-sample.adoc[operator guide] covers bringing the stack up, the readiness gate and
+  the sample-only values that must change, and the
+  link:development/compose-sample.adoc[developer topic] covers its relationship to the
+  integration-test stack and the probe-derivation rules it is bound by.
 |===
 
 == Deployment Variants

--- a/doc/adr/0027-The_token-validation_extensions_unqualified_health_probes_are_excluded_not_accommodated.adoc
+++ b/doc/adr/0027-The_token-validation_extensions_unqualified_health_probes_are_excluded_not_accommodated.adoc
@@ -66,7 +66,7 @@ not configured into a green state.*
 The two extension probes are excluded at the CDI level by type pattern, scoped to exactly those two
 beans in that one package. The exclusion is declared unconditionally and in no profile, because a
 profile-scoped exclusion would itself be a branch in the shipped configuration surface, which
-link:0026-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc[ADR-0026]
+link:0032-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc[ADR-0032]
 forbids.
 
 === 1. The scope is the two beans, never a global switch
@@ -121,7 +121,7 @@ exclusion removed, and restoring the excluded probes would not close it.
   something this product does, rather than because a dependency happened to contribute it.
 * No configuration is maintained for machinery with no consumer. The alternative -- populating the
   extension's issuer namespace to satisfy its probes -- would have created exactly the redundant
-  parallel declaration ADR-0026 removes.
+  parallel declaration ADR-0032 removes.
 * The native image is unaffected: the reflection registration the gateway relies on is a
   deployment-time concern and is untouched by a runtime bean exclusion.
 
@@ -159,7 +159,7 @@ health surface.
 Rejected because it maintains configuration for machinery with no consumer, purely to satisfy a
 check. The probes would then report on a validator the request path never touches, so a green
 result would carry no information about the gateway while looking exactly like one that did. It also
-recreates the parallel declaration ADR-0026 removes, in the same file, for the same non-reason.
+recreates the parallel declaration ADR-0032 removes, in the same file, for the same non-reason.
 
 === Disable extension-contributed health checks globally
 
@@ -203,7 +203,7 @@ does, and a probe that observes nothing is removed rather than satisfied.
 
 == References
 
-* link:0026-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc[ADR-0026]
+* link:0032-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc[ADR-0032]
   -- the rule under which this exclusion is declared unconditionally rather than profile-scoped, and
   the masked-defect failure mode a profile-scoped health branch would have reproduced
 * link:0022-Upstream_security-hardening_default_changes_are_adopted_and_documented_never_locally_reverted.adoc[ADR-0022]

--- a/doc/adr/0032-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc
+++ b/doc/adr/0032-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc
@@ -1,4 +1,4 @@
-= ADR-0026: The shipped artifact declares nothing test-shaped; the deployment supplies what it names
+= ADR-0032: The shipped artifact declares nothing test-shaped; the deployment supplies what it names
 :toc: left
 :toclevels: 2
 :sectnums:

--- a/doc/adr/0033-Absence_in_the_production_type_model_is_a_Nullable_type_not_a_stored_Optional.adoc
+++ b/doc/adr/0033-Absence_in_the_production_type_model_is_a_Nullable_type_not_a_stored_Optional.adoc
@@ -1,4 +1,4 @@
-= ADR-0027: Absence in the production type model is a @Nullable type, not a stored Optional
+= ADR-0033: Absence in the production type model is a @Nullable type, not a stored Optional
 :toc: left
 :toclevels: 2
 :sectnums:

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -88,6 +88,15 @@ This tree is seeded here and grows as contributor-facing material lands.
   protocol-and-port edge labels, the trust-boundary visual that stays inside the theme-neutral
   palette, first-party vs external components, mounted material, and the container-run render
   check. Written in Markdown, deliberately, so it can graduate upstream unchanged.
+
+| link:compose-sample.adoc[Compose Sample -- Contributor Guide]
+| The `deployment` module's compose sample -- how it relates to the integration-test stack and why
+  it is a separate, smaller stack rather than a trimmed bring-up of that one; why the gateway carries
+  no `healthcheck:` key and Keycloak's probe is TCP-accept-level only; how `wait-for-ready.sh`
+  derives its entire probe target from the resolved Compose model under
+  link:../adr/0031-Host-side_readiness_gates_derive_the_probe_URL_from_the_resolved_Compose_model_and_assert_readiness.adoc[ADR-0031],
+  and where its retry budget comes from; and the opt-in `skipComposeSample` / `compose-sample` build
+  mechanism that keeps the whole thing out of the default lane.
 |===
 
 == Scope of This Layer

--- a/doc/development/compose-sample.adoc
+++ b/doc/development/compose-sample.adoc
@@ -1,0 +1,177 @@
+= Compose Sample -- Contributor Guide
+:toc:
+:toclevels: 3
+:sectnums:
+
+The `deployment` module owns one subtree, `compose-sample/`, holding a production-shaped Docker
+Compose stack. This document covers why it exists as a separate stack, the decisions inside it that
+look arbitrary until you know the constraint behind them, and the build mechanism that keeps it out
+of the default lane. The link:../user/compose-sample.adoc[operator guide] covers running it.
+
+== Topology
+
+image::../resources/diagrams/compose-sample-topology.svg[The compose sample topology,align="center"]
+
+Three containers on one bridge network. `api-sheriff` is the only one an operator can reach for
+traffic; `demo-api` publishes no host port at all, which is what makes "the gateway is the only way
+in" a property of the stack rather than a claim in prose. Keycloak's admin console is published
+because a sample is worth inspecting, and the gateway reaches it container-internally regardless.
+
+== Why this is not the integration-test stack
+
+`integration-tests/docker-compose.yml` already brings up a gateway, an identity provider and a set
+of upstreams. The sample deliberately does not reuse it, and equally deliberately does not trim it.
+
+The integration stack exists to *exercise tests*. It carries toxiproxy for fault injection, a
+TLS passthrough backend, an asset origin, a gRPC echo service and go-httpbin, plus six gateway
+instances differing only by overlaid configuration. Every one of those exists to make an assertion
+possible. None of them shows an operator how the gateway is deployed, and several would actively
+mislead -- a reader who copies a fault-injection proxy into a production topology has been
+misinformed by the documentation.
+
+`demo-client` faced a related problem and solved it differently: it needs a *subset* of the
+integration stack, so it uses explicit service selection against that same compose file rather than
+declaring a second stack. That is the right call there, because the demo drives the same gateway
+configuration the integration suite does. It is the wrong call here, because the sample's gateway
+configuration is deliberately *different* -- a small, readable `gateway.yaml` with one public proxy
+namespace, rather than the integration suite's much larger document. A trimmed bring-up would have
+forced the sample's configuration into a file whose job is to serve the tests, and the two would
+have drifted.
+
+The cost of a second stack is that the two files can diverge. That is accepted: they are answering
+different questions, and the sample's value is precisely that it contains nothing you would have to
+explain away.
+
+== Runtime hardening and what it costs
+
+All three services carry `security_opt: [no-new-privileges:true]`, `cap_drop: [ALL]` and
+`read_only: true`, and none of them runs as root. The hardening is the substance of the sample --
+that posture is what a production deployment should set, and setting it explicitly rather than
+inheriting a default is the whole point.
+
+`read_only: true` is the expensive one, and each service pays differently. These are the three
+findings, each of which was a crash loop before it was a line of configuration:
+
+`demo-api` (nginx):: Runs as `user: "101:101"` and writes to three paths. A tmpfs is created
+root-owned and mode 755, so the unprivileged process cannot create `/var/cache/nginx/client_temp`
+and nginx dies at startup with `mkdir() ... failed (13: Permission denied)`. Each tmpfs therefore
+carries `uid=101,gid=101`. The service also sets `entrypoint: ["nginx", "-g", "daemon off;"]`,
+bypassing `docker-entrypoint.sh` -- whose `10-listen-on-ipv6-only.sh` step rewrites
+`/etc/nginx/conf.d/default.conf` in place and fails under a read-only root.
+
+`keycloak`:: `start-dev` re-augments Quarkus on every boot and writes the rebuilt runner into
+`/opt/keycloak/lib/quarkus`. Under `read_only: true` that write raises
+`ReadOnlyFileSystemException` and the server never starts. The fix is a *named volume* at that path,
+not a tmpfs: Docker seeds a named volume from the image's content at that path on first use, whereas
+a tmpfs would mask the shipped libraries with an empty directory and break the augmentation a
+different way. `/opt/keycloak/data` gets its own named volume for the realm import.
+
+`api-sheriff`:: Needs only a tmpfs at `/tmp`. It declares no `user:` key because its image already
+declares `USER nonroot` (uid 65532); restating the uid here would only risk drifting from it.
+
+=== The certificate permission trap
+
+The certificate material is generated, never committed, and the generator writes the private key
+world-readable. That is a deliberate inversion of the usual rule, and the reason is structural: the
+two containers that mount the directory run as *different* non-root uids -- the gateway as 65532 and
+Keycloak as 1000 -- while the files are owned by whichever host user ran the script. Neither uid can
+be matched from the host without root, so mode 600 makes the key unreadable inside the container and
+the gateway dies with `AccessDeniedException: /app/certificates/localhost.key`.
+
+`integration-tests/src/main/docker/certificates/generate-certificates.sh` still chmods its key to
+600, and that stack works -- but the mode there is nominal. Those certificates are *committed*, and
+git records only the executable bit, so a fresh checkout materialises them world-readable anyway.
+The sample commits no key material, so the mode it is created with is the mode the container
+actually sees. Do not "restore" the 600 here by analogy with that script.
+
+== Probes: three different answers to the same question
+
+The stack contains three readiness-shaped mechanisms, and they are not interchangeable.
+
+The gateway carries *no* `healthcheck:` key. Its image is distroless -- no shell, no curl, no wget --
+so every in-container probe form is unavailable by construction, and a healthcheck declared here
+could only ever fail. Readiness is asserted host-side instead.
+
+Keycloak carries a TCP-accept probe, `bash -c 'echo -n > /dev/tcp/127.0.0.1/9000'`, and the form is
+forced: the Keycloak image ships neither curl nor wget, so a probe naming either would fail
+permanently and be indistinguishable from a service that never came up. `bash` is present, so
+`/dev/tcp` is the available primitive. It is deliberately *accept-level only* -- it proves the
+management listener is bound, not that the realm finished importing. That is sufficient for its one
+job, which is ordering the gateway's start behind the identity provider's; the gateway's own eager
+key-set load at boot is what makes that ordering load-bearing rather than cosmetic.
+
+`scripts/wait-for-ready.sh` is the actual readiness gate, and it is bound by
+link:../adr/0031-Host-side_readiness_gates_derive_the_probe_URL_from_the_resolved_Compose_model_and_assert_readiness.adoc[ADR-0031].
+It derives its whole probe target from `docker compose config --format json`:
+
+* *which services to probe* -- those carrying the `de.cuioss.sheriff.management-scheme` label;
+* *which scheme to speak* -- that label's value;
+* *which host port to hit* -- the port published against the container-port selector 9000.
+
+The only literal is the container-side management port, and deliberately so: it is a stable
+platform-level fact used as the *selector* that picks the management binding out of a service's port
+list, not a per-deployment value. Renumbering the published port, or adding a second gateway
+instance, therefore needs no edit to the script.
+
+ADR-0031's negative list is binding here, and each item is a real failure mode:
+
+* *No restated host port and no restated scheme.* A list in the script mirroring the compose file
+  becomes a defect the moment either changes.
+* *No liveness probe standing in for readiness.* `/q/health/live` answers as soon as the process is
+  up, which is strictly earlier than the point at which the gateway can serve a request. Gating on
+  it would clear the wait before the stack is usable -- the exact race the gate exists to remove.
+  `curl -sf` is equally load-bearing: without `-f`, curl exits 0 on the 503 the readiness endpoint
+  returns while starting, and the wait would clear as soon as the port *accepted*.
+* *One retry-budget constant, with a recorded origin.* `READY_ATTEMPTS=60` is read by the loop bound,
+  the last-attempt comparison and the progress message; three literals would drift apart. Sixty
+  attempts at one second is roughly 5x headroom over the measured worst case on a loaded machine.
+  Re-measure before shrinking it -- a budget that is too small turns a slow machine into a spurious
+  failure, which is worse than waiting.
+* *An empty target set is a hard failure.* Discovering no labelled service exits non-zero rather
+  than passing, because a gate that probes nothing and reports success is a vacuous green.
+
+`-k` is applied only when the derived scheme is `https`, so a plain-HTTP management interface is
+probed without it and no branch on the service name is needed.
+
+== The opt-in build mechanism
+
+`deployment/pom.xml` carries a single `compose-sample` profile with three `exec-maven-plugin`
+executions: teardown at `pre-clean` (accepting exit codes 0 and 1, because nothing running is the
+normal case), `start-sample.sh` at `pre-integration-test`, and teardown again at
+`post-integration-test`.
+
+The skip is *two layers*, matching the convention `demo-client` establishes: the profile means a
+default build has no executions to skip at all, and `skipComposeSample` -- defaulting to `true` at
+module level and flipped to `false` inside the profile -- means an accidentally activated profile
+still needs a deliberate override to start containers. A plain `verify` leaves the `deployment`
+module at a few milliseconds and starts nothing.
+
+Note that this profile needs no `<skipTests>false</skipTests>`, and that is not an oversight.
+`demo-client`'s `e2e-demo` profile requires that flip because `frontend-maven-plugin`'s test
+execution binds to a testing phase and therefore honours the inherited `skipTests`, which would
+otherwise hollow the profile into a vacuous green. `exec-maven-plugin`'s `exec` goal honours only
+its own `<skip>`, so the module-level `skipTests=true` that keeps inherited surefire off this
+Java-free module cannot silently disable this gate.
+
+Only the *success* path tears the stack down. Maven offers no always-runs hook, so a failing gate
+leaves the containers up -- which is wanted, because they hold the logs explaining the failure being
+diagnosed. The `pre-clean` teardown is the remedy, and it fires on any subsequent `clean` build.
+
+== Standing constraints
+
+* *The sample never builds an image.* It demonstrates deploying a released artifact, which is what
+  an operator does. `start-sample.sh` preflights the reference and attempts exactly one pull; if
+  that fails it exits non-zero naming both documented routes rather than falling through to
+  `compose up` and surfacing the same failure later as a less legible error.
+* *`deployment/compose-sample/` is self-contained.* Nothing in it reaches into `integration-tests/`
+  or the `api-sheriff` module -- not even for shell helpers, which is why the compose-command
+  resolution is repeated inline in each script rather than sourced from
+  `integration-tests/scripts/lib-docker-compose.sh`. The directory is meant to be copied wholesale.
+* *No comments in `sample-realm.json`.* JSON has no comment syntax, and Keycloak's
+  `RealmRepresentation` rejects unrecognised fields outright -- a `_comment` key fails the import
+  with `Unrecognized field`. Rationale belongs in this document and the operator guide; the only
+  in-file markers are the `CHANGE-ME-BEFORE-PRODUCTION` values themselves, which are loud by
+  construction and trip secret scanners on purpose.
+* *The gateway's `gateway.yaml` stays small.* Everything the integration suite needs and an operator
+  does not -- passthrough SNI, BFF sessions, asset anchors, mTLS -- is *absent* rather than
+  present-and-disabled. A disabled block still has to be read and understood.

--- a/doc/development/diagram-type-deployment.md
+++ b/doc/development/diagram-type-deployment.md
@@ -424,6 +424,14 @@ the `integration-tests` module brings up — and demonstrates:
 Its `<title>` and `<desc>` name it as the integration-test topology explicitly, so no reader mistakes
 the test upstreams or the fault-injection proxy for a recommended production deployment.
 
-**Production and Kubernetes topologies are deliberately not drawn here.** They arrive with PLAN-27,
-which defines them; drawing them before they are defined would document an intention as though it
-were a fact.
+`doc/resources/diagrams/compose-sample-topology.svg` is the second reference implementation. It
+depicts the **compose sample** topology — the three-container stack under
+`deployment/compose-sample` — and is named as such in its `<title>` and `<desc>`, so no reader
+mistakes it for the integration-test stack or for a recommended Kubernetes deployment. It exercises
+a smaller subset of the type deliberately: the containment ladder, one trust boundary whose crossings
+are both marked, protocol-and-port edge labels, mounted material as pills, and a single first-party
+component carrying the `own-bar` accent among external ones. It uses no collapsed group, and the
+skeleton's collapsed-group placeholder is deleted rather than left in place.
+
+**The Kubernetes topology is deliberately not drawn here.** It arrives with PLAN-41, which defines
+it; drawing it before it is defined would document an intention as though it were a fact.

--- a/doc/resources/diagrams/compose-sample-topology.svg
+++ b/doc/resources/diagrams/compose-sample-topology.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Compose sample topology — deployment/compose-sample/docker-compose.yml.
+  theme-handling: A (theme-neutral)
+  see  doc/development/diagram-type-deployment.md
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620"
+     role="img" aria-labelledby="title desc"
+     font-family="ui-sans-serif, -apple-system, system-ui, 'Segoe UI', sans-serif">
+  <title id="title">API Sheriff compose sample topology — the deployment/compose-sample stack, not the integration-test stack and not a Kubernetes recommendation</title>
+  <desc id="desc">The topology of the production-shaped Docker Compose sample under deployment/compose-sample. One Docker host contains one bridge network, compose-sample_api-sheriff, holding exactly three containers. api-sheriff is the first-party gateway, running the published image by tag; it terminates TLS on 8443, serves its management interface on 9000, and mounts its configuration and certificate material read-only. keycloak is the external identity provider that issues the tokens the gateway validates; its admin console is published on host port 1443. demo-api is an external stand-in upstream serving a canned JSON document on 8080 and publishes no host port at all. A trust boundary separates the gateway from the two services reachable only inside the network: the gateway is the only container an operator on the host can reach for traffic. Two edges cross that boundary and carry crossing glyphs — the gateway's JWKS fetch to Keycloak over HTTPS 8443, and the proxied upstream request to demo-api over HTTP 8080.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow-fill"/>
+    </marker>
+    <style>
+      .stroke      { stroke: #6e7681; stroke-width: 1.2; fill: none; }
+      .encl        { font-size: 13px; font-weight: 600; fill: #6e7681; }
+      .encl-sub    { font-size: 11px; fill: #6e7681; font-style: italic; }
+      .item        { font-size: 12px; fill: #6e7681; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .own-bar     { stroke: #6e7681; stroke-width: 3; }
+      .trust       { stroke: #6e7681; stroke-width: 2; stroke-dasharray: 8 4; fill: none; }
+      .trust-lbl   { font-size: 11px; font-weight: 600; fill: #6e7681; }
+      .trust-cross { stroke: #6e7681; stroke-width: 1.2; fill: none; }
+      .arrow       { stroke: #6e7681; stroke-width: 1.5; fill: none; }
+      .arrow-fill  { fill: #6e7681; }
+      .edge-lbl    { font-size: 11px; fill: #6e7681; text-anchor: middle; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .mount-stem  { stroke: #6e7681; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
+      .mount       { font-size: 10px; fill: #6e7681; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+      .caption     { font-size: 12px; fill: #6e7681; text-anchor: middle; font-style: italic; }
+    </style>
+  </defs>
+
+  <!-- ============================================================
+       depth 1 — the Docker host
+       ============================================================ -->
+  <rect class="stroke" x="24" y="64" width="952" height="480" rx="8"/>
+  <text x="36" y="88"  class="encl">docker host</text>
+  <text x="36" y="104" class="encl-sub">published to the host: gateway 8443 and 9000, Keycloak admin 1443 — demo-api publishes nothing</text>
+
+  <!-- ============================================================
+       depth 2 — the one bridge network
+       ============================================================ -->
+  <rect class="stroke" x="40" y="116" width="920" height="412" rx="6"/>
+  <text x="52" y="140" class="encl">compose-sample_api-sheriff (bridge)</text>
+
+  <!-- ============================================================
+       trust boundary
+       ============================================================ -->
+  <line class="trust" x1="470" y1="160" x2="470" y2="500"/>
+  <text x="482" y="152" class="trust-lbl">trust boundary — only the gateway is reachable from the host</text>
+
+  <!-- ============================================================
+       ingress from the host into the gateway
+       ============================================================ -->
+  <line class="arrow" x1="300" y1="116" x2="300" y2="192" marker-end="url(#arrow)"/>
+  <text x="364" y="160" class="edge-lbl">HTTPS :8443</text>
+
+  <!-- ============================================================
+       depth 3 — the first-party gateway, with mounted material
+       ============================================================ -->
+  <rect class="stroke" x="64" y="192" width="280" height="140" rx="4"/>
+  <line class="own-bar" x1="64" y1="200" x2="64" y2="324"/>
+  <text x="76" y="216" class="encl">api-sheriff</text>
+  <text x="76" y="232" class="encl-sub">the gateway — published image, by tag</text>
+  <text x="76" y="260" class="item">listener :8443</text>
+  <text x="76" y="280" class="item">management :9000</text>
+
+  <!-- mounted material — dashed stem, no arrowhead: material, not traffic -->
+  <line class="mount-stem" x1="116" y1="332" x2="116" y2="344"/>
+  <rect class="stroke" x="64" y="344" width="104" height="18" rx="4"/>
+  <text x="72" y="357" class="mount">certificates/</text>
+
+  <line class="mount-stem" x1="242" y1="332" x2="242" y2="344"/>
+  <rect class="stroke" x="184" y="344" width="116" height="18" rx="4"/>
+  <text x="192" y="357" class="mount">sheriff-config/</text>
+
+  <!-- ============================================================
+       depth 3 — external identity provider
+       ============================================================ -->
+  <rect class="stroke" x="496" y="192" width="220" height="124" rx="4"/>
+  <text x="508" y="216" class="encl">keycloak</text>
+  <text x="508" y="232" class="encl-sub">identity provider — token issuer</text>
+  <text x="508" y="260" class="item">https :8443</text>
+  <text x="508" y="280" class="item">published 1443:8443</text>
+
+  <!-- ============================================================
+       depth 3 — external stand-in upstream
+       ============================================================ -->
+  <rect class="stroke" x="744" y="380" width="200" height="104" rx="4"/>
+  <text x="756" y="404" class="encl">demo-api</text>
+  <text x="756" y="420" class="encl-sub">stand-in upstream</text>
+  <text x="756" y="448" class="item">:8080 internal only</text>
+
+  <!-- ============================================================
+       edges — protocol + port labels in monospace, upright
+       ============================================================ -->
+
+  <!-- JWKS fetch: crosses the trust boundary -->
+  <line class="arrow" x1="344" y1="252" x2="496" y2="252" marker-end="url(#arrow)"/>
+  <text x="420" y="244" class="edge-lbl">HTTPS :8443</text>
+  <circle class="trust-cross" cx="470" cy="252" r="3.5"/>
+
+  <!-- proxied upstream request: orthogonal cross-container edge, label on the longest
+       segment, crossing the trust boundary on that segment -->
+  <polyline class="arrow" points="344,300 404,300 404,432 744,432" marker-end="url(#arrow)"/>
+  <text x="574" y="424" class="edge-lbl">HTTP :8080</text>
+  <circle class="trust-cross" cx="470" cy="432" r="3.5"/>
+
+  <!-- ============================================================
+       footer caption
+       ============================================================ -->
+  <text x="500" y="580" class="caption">The compose sample: three containers on one bridge network, reached only through the gateway.</text>
+</svg>

--- a/doc/user/README.adoc
+++ b/doc/user/README.adoc
@@ -77,6 +77,14 @@ layer.
   `QUARKUS_HTTP_SSL_PORT` move under `tls.passthrough_sni`), what the SBOM and the HIGH+CRITICAL
   vulnerability scan do and do not guarantee, and the complete `cosign verify` recipe with both
   mandatory flags. Links to the release process for the artifact policy.
+
+| link:compose-sample.adoc[Compose Sample -- a Production-Shaped Deployment You Can Run]
+| The runnable sample under `deployment/compose-sample`: three containers on one network, brought up
+  with generated sample certificates and gated on a real readiness probe. Covers both routes to the
+  gateway image (the pinned GHCR default and the `API_SHERIFF_IMAGE` local-build override), the
+  request that proves the stack works, and -- explicitly -- every sample-only value that must change
+  before the stack is reachable by anything you care about. Links to the Container Image guide for
+  pulling and verifying, and to Environment-Variable Overrides for the deployment-owned knobs.
 |===
 
 == Scope of This Layer

--- a/doc/user/compose-sample.adoc
+++ b/doc/user/compose-sample.adoc
@@ -48,8 +48,11 @@ docker compose -f integration-tests/docker-compose.yml build api-sheriff
 export API_SHERIFF_IMAGE=api-sheriff:distroless
 ----
 
-Both commands run from the repository root. `API_SHERIFF_IMAGE` is read by the compose file and by
-the bring-up script's image preflight, so exporting it steers both as one.
+Both commands run from the repository root. `API_SHERIFF_IMAGE` is the single knob: the compose file
+references it with no inline fallback, its default lives once in `deployment/compose-sample/.env`
+(which Compose auto-loads), and the bring-up script's image preflight reads the value back out of the
+resolved Compose model instead of restating it. Exporting the variable therefore steers the preflight
+and the stack that actually starts as one -- they cannot disagree.
 
 If neither route has produced the image, the bring-up fails immediately -- naming the reference it
 looked for and both routes -- rather than starting a partial stack.
@@ -180,6 +183,13 @@ For which knobs the deployment owns versus which `gateway.yaml` owns -- the thre
 deployment-bound / build-time classification and the precedence rule -- see
 link:environment-variable-overrides.adoc[Environment-Variable Overrides]. This guide does not
 restate that classification.
+
+One value comes from outside that block: `API_SHERIFF_IMAGE`, which selects the gateway image itself
+rather than configuring the gateway. Its default is written once in `deployment/compose-sample/.env`,
+the file Compose auto-loads from the sample directory. That file is the only place the published
+image reference appears -- `docker-compose.yml` references the variable with no inline fallback, and
+`scripts/start-sample.sh` derives the effective value from the resolved Compose model. An exported
+`API_SHERIFF_IMAGE` wins over the file, which is how Route B above works.
 
 One deliberate absence is worth naming, because it differs from the integration stack:
 `QUARKUS_HTTP_SSL_PORT` is *not* set here. The integration stack moves its terminated listener off

--- a/doc/user/compose-sample.adoc
+++ b/doc/user/compose-sample.adoc
@@ -1,0 +1,205 @@
+= Compose Sample -- a Production-Shaped Deployment You Can Run
+:toc:
+:toclevels: 3
+:sectnums:
+
+A runnable Docker Compose stack that shows how API Sheriff is actually deployed: the published image
+pulled by tag, all configuration supplied through read-only mounts, and every runtime-hardening
+directive a production deployment should set, set explicitly rather than left to a default.
+
+It lives at `deployment/compose-sample/` and is a *sample*, not a test harness. It carries three
+services and nothing else -- the gateway, an identity provider whose realm mints the tokens the
+gateway validates, and a stand-in upstream that the gateway proxies to. The
+link:../development/compose-sample.adoc[contributor guide] explains why it is a separate stack from
+the one `integration-tests` brings up, and draws the topology.
+
+WARNING: Every credential and every piece of key material in this sample is a placeholder. Read
+<<_what_must_change_before_this_is_real>> before this stack is reachable by anything you care about.
+
+== Before you start
+
+You need Docker with Compose v2 (`docker compose version` must succeed), and a gateway image. There
+are two routes to the image; pick one.
+
+=== Route A -- the published image (the default)
+
+The sample defaults to the pinned published image and needs nothing from you but the ability to
+reach `ghcr.io`:
+
+[source,bash]
+----
+docker pull ghcr.io/cuioss/api-sheriff:0.1.0
+----
+
+The bring-up script pulls it for you if it is missing, so this step is optional. For what the
+published image contains, how it is tagged, and how to verify its signature and SBOM, see
+link:container-image.adoc[Container Image -- Pulling, Running and Verifying]; this guide does not
+restate any of it.
+
+=== Route B -- a locally built image
+
+To run the sample against your own build, produce the image and point the sample at it:
+
+[source,bash]
+----
+python3 .plan/execute-script.py plan-marshall:build-maven:maven run \
+  --command-args "clean install -Pnative -pl api-sheriff -am -DskipTests"
+docker compose -f integration-tests/docker-compose.yml build api-sheriff
+export API_SHERIFF_IMAGE=api-sheriff:distroless
+----
+
+Both commands run from the repository root. `API_SHERIFF_IMAGE` is read by the compose file and by
+the bring-up script's image preflight, so exporting it steers both as one.
+
+If neither route has produced the image, the bring-up fails immediately -- naming the reference it
+looked for and both routes -- rather than starting a partial stack.
+
+== Bringing the stack up
+
+=== 1. Generate the sample certificates
+
+The stack serves TLS everywhere, and *no key material is committed*. Generate it once:
+
+[source,bash]
+----
+./deployment/compose-sample/docker/certificates/generate-certificates.sh
+----
+
+This writes a self-signed `localhost.crt` and `localhost.key` next to the script. Both are
+git-ignored. The certificate names `localhost`, `keycloak`, `api-sheriff` and `demo-api` in its SAN
+list, because the gateway reaches the identity provider by its compose service name and a
+certificate without that name would fail hostname verification on the token-key fetch.
+
+=== 2. Start it
+
+[source,bash]
+----
+./deployment/compose-sample/scripts/start-sample.sh
+----
+
+The script preflights the image, brings the three services up, and then blocks on a readiness gate
+until the gateway reports itself ready -- so when it returns, the stack is genuinely usable rather
+than merely started. It exits non-zero if readiness is not reached, printing the container log and
+the full health payload.
+
+Alternatively, run it through the build as an opt-in Maven profile, which brings the stack up, gates
+on readiness, and tears it down again:
+
+[source,bash]
+----
+python3 .plan/execute-script.py plan-marshall:build-maven:maven run \
+  --command-args "verify -Pcompose-sample -pl deployment -am"
+----
+
+Without `-Pcompose-sample` the `deployment` module is a no-op: the default build starts no container
+and costs no measurable time.
+
+=== 3. Drive a request through the gateway
+
+[source,bash]
+----
+curl -k https://localhost:8443/api
+----
+
+[source,json]
+----
+{"service":"demo-api","message":"Reached the upstream through API Sheriff."}
+----
+
+That response came from the `demo-api` container, which publishes no host port at all -- the gateway
+is the only way to reach it. `-k` is required because the certificate is self-signed; that is the
+point of a sample, not a defect.
+
+Two other endpoints are published:
+
+[cols="1,3"]
+|===
+| Address | What it is
+
+| `https://localhost:9000/q/health/ready`
+| The gateway's management interface -- HTTPS, because the sample supplies management certificates.
+  This is what the readiness gate probes.
+
+| `https://localhost:1443`
+| The Keycloak admin console, for inspecting the realm or minting a token by hand.
+|===
+
+=== 4. Stop it
+
+[source,bash]
+----
+./deployment/compose-sample/scripts/stop-sample.sh
+----
+
+This removes the containers, the network and the volumes, so the next bring-up starts from a known
+state and re-imports the realm.
+
+== What must change before this is real
+
+The sample is deliberately loud about being a sample. Every item below is a placeholder that is
+*wrong* for any deployment reachable by something you care about.
+
+[cols="1,2"]
+|===
+| Sample-only value | What a real deployment does instead
+
+| *The generated certificate and key* -- self-signed, with no CA behind it, and written
+  world-readable so the gateway's and Keycloak's differing non-root uids can both read it.
+| Supplies certificate and key from its own PKI, with ownership matched to the runtime uid, mounted
+  at the same two paths. The gateway does not care where they came from.
+
+| *The Keycloak realm client secret* -- `CHANGE-ME-BEFORE-PRODUCTION` in
+  `docker/keycloak/sample-realm.json`.
+| Registers its own confidential client and supplies the secret from the deployment, never from a
+  file in a repository.
+
+| *The Keycloak bootstrap admin credentials* -- `admin` / `admin` in `docker-compose.yml`.
+| Sets real credentials, and does not publish the admin console at all unless it means to.
+
+| *The sample realm user* -- `sample-user` with a placeholder password.
+| Deletes it. It exists only so you can mint a token while trying the stack out.
+
+| *`start-dev`* -- Keycloak runs in development mode.
+| Runs Keycloak in production mode against a real database. The sample's realm lives in a volume and
+  is discarded on teardown.
+|===
+
+The gateway's own configuration under `docker/sheriff-config/` is closer to production-ready: it
+declares the `strict` inbound filter profile explicitly, a TLS floor of 1.2, one public proxy
+namespace, and a token issuer with a host-exact egress allowlist. The one endpoint is
+`auth: require: none`, which is the first thing to change when adapting the sample -- switch it to
+`require: bearer` and the route is gated on a token from the declared issuer.
+
+== Where configuration comes from
+
+The shipped artifact declares nothing about where its configuration or key material lives; the
+deployment supplies both. In this sample that happens entirely through the `environment:` block of
+the `api-sheriff` service, which is the same door the release smoke test drives.
+
+For which knobs the deployment owns versus which `gateway.yaml` owns -- the three-way policy /
+deployment-bound / build-time classification and the precedence rule -- see
+link:environment-variable-overrides.adoc[Environment-Variable Overrides]. This guide does not
+restate that classification.
+
+One deliberate absence is worth naming, because it differs from the integration stack:
+`QUARKUS_HTTP_SSL_PORT` is *not* set here. The integration stack moves its terminated listener off
+8443 because its configuration claims that port for an SNI front listener. This sample declares no
+passthrough SNI, so the gateway terminates directly on 8443 and an override would only mis-address
+it.
+
+== Adapting it
+
+The sample is meant to be copied. The `deployment/compose-sample/` directory is self-contained --
+nothing in it reaches into `integration-tests/` or into the `api-sheriff` module -- so copying the
+directory gives you a working starting point. From there the usual first three changes are:
+
+. Point the `UPSTREAM` alias in `docker/sheriff-config/topology.properties` at your real backend, or
+  override `TOPOLOGY_UPSTREAM` in the environment. It is the one place a backend address is written
+  down.
+. Switch `docker/sheriff-config/endpoints/demo-api.yaml` to `auth: require: bearer`, and add the
+  exact request headers and query parameters your backend needs to its deny-by-default `forward`
+  allowlists.
+. Replace the identity provider with your own, updating the issuer URL, the JWKS URL and the
+  `allowed_egress_hosts` entry in `docker/sheriff-config/gateway.yaml` together -- the issuer value
+  must match the `iss` your tokens actually carry, or every request fails with a 401 that looks like
+  a signature problem and is not.

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   keycloak:
     # NOTE: Dependabot cannot automatically update this image version.
     # Manual updates required. Check: https://quay.io/keycloak/keycloak
-    image: quay.io/keycloak/keycloak:26.5.4@sha256:ae8efb0d218d8921334b03a2dbee7069a0b868240691c50a3ffc9f42fabba8b4
+    image: quay.io/keycloak/keycloak:26.5.7@sha256:45ae20191531eb608ddb0b775d012b40d3e4f942697f3214694887dd7c108d13
     command:
       - start-dev
       - --import-realm

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
              standard reactor build walks through it without downloading Node or starting a container.
              Placed last so the existing module ordering is untouched. -->
         <module>demo-client</module>
+        <!-- Production-shaped docker-compose sample. Carries no Java and contributes nothing to the
+             default lane: every inherited Java plugin is switched off, so this leg builds no artifact. -->
+        <module>deployment</module>
     </modules>
     <scm>
         <url>https://github.com/cuioss/api-sheriff/</url>


### PR DESCRIPTION
## Summary

Adds a new top-level `deployment/` Maven module carrying a **production-shaped docker-compose sample** — the artifact a 0.1.0 adopter copies to run API Sheriff — together with its user/developer documentation layers and an SVG deployment diagram. Also folds in an unrelated but urgent ADR-renumbering fix as the first commit.

## Changes

**ADR renumbering (first commit, cherry-pickable)**

- Renumbered the two duplicate-numbered ADRs to `doc/adr/0032-The_shipped_artifact_declares_nothing_test-shaped_the_deployment_supplies_what_it_names.adoc` and `doc/adr/0033-Absence_in_the_production_type_model_is_a_Nullable_type_not_a_stored_Optional.adoc`, each with its internal `= ADR-00NN:` title line retargeted.
- Retargeted the two inbound by-filename links in `doc/adr/0027-The_token-validation_extensions_unqualified_health_probes_are_excluded_not_accommodated.adoc` so the rename does not ship broken links.

**Module skeleton and reactor registration**

- `deployment/pom.xml` — packaging pom with the Java plugins skipped, mirroring the `integration-tests/` and `demo-client/` shape. Carries the opt-in `compose-sample` profile that runs the sample end to end.
- `pom.xml` — registers `deployment` in the root reactor.

**The compose sample**

- `deployment/compose-sample/docker-compose.yml` — gateway + Keycloak + one realistic upstream (a static `nginx:alpine` demo API), with the runtime hardening reused from the IT stack (`security_opt: [no-new-privileges:true]`, `cap_drop`, `read_only: true`) applied per service. The gateway image is a pinned GHCR tag with a documented local-build override.
- `deployment/compose-sample/docker/sheriff-config/gateway.yaml`, `.../topology.properties`, `.../endpoints/demo-api.yaml` — the gateway configuration the sample runs on.
- `deployment/compose-sample/docker/nginx/demo-api.conf` — the canned upstream response, so the topology reads as "your API goes here".
- `deployment/compose-sample/docker/keycloak/sample-realm.json` — sample realm. Credentials are unmistakably sample-only and documented as must-change-before-production.
- `deployment/compose-sample/docker/certificates/generate-certificates.sh` and `.../certificates/.gitignore` — local TLS material generated, never committed.

**Readiness gate**

- `deployment/compose-sample/scripts/wait-for-ready.sh` — host-side readiness gate following ADR-0031's shape: derives the probe target (published port + scheme) from `compose config --format json`, probes `/q/health/ready`, and fails loudly with a `docker compose logs` hint. The gateway service deliberately carries no `healthcheck:` (the distroless image ships neither a shell nor curl); Keycloak carries a curl-free `/dev/tcp` TCP probe and the gateway is ordered behind it.
- `deployment/compose-sample/scripts/start-sample.sh` and `.../stop-sample.sh` — lifecycle wrappers wired to the `compose-sample` profile, so the sample is *activated* rather than merely committed.

**Documentation and diagram**

- `doc/user/compose-sample.adoc` (operator layer, primary) and `doc/development/compose-sample.adoc`.
- `doc/resources/diagrams/compose-sample-topology.svg` — authored to the shipped deployment-diagram template, render-and-read-back verified in both light and dark backgrounds.
- `doc/README.adoc`, `doc/user/README.adoc`, `doc/development/README.adoc`, `doc/development/diagram-type-deployment.md` — index and template updates.

**Plan artifacts**

- `.plan/project-architecture/_project.json`, `.plan/project-architecture/deployment/enriched.json` — architecture inventory updated for the new module.

## Test Plan

- [x] Quality gate passed (`verify -Ppre-commit`)
- [x] Full verify passed (`verify`)
- [x] Compose model resolves (`docker compose -f deployment/compose-sample/docker-compose.yml config -q`)
- [x] Sample activated end to end (`verify -Pcompose-sample -pl deployment -am`) — the stack comes up and `wait-for-ready.sh` asserts readiness
- [x] Diagram rendered and read back at both light and dark backgrounds
- [x] `manage-adr scan` reports 33 distinct ADR numbers with no duplicates

## Related Issues

None.

---
Generated by plan-finalize skill

## Intent

**Problem.** A 0.1.0 adopter had nothing to copy. The only running compose topology in the tree is `integration-tests/docker-compose.yml`, which is test scaffolding (toxiproxy, go-httpbin, passthrough origins) and misleads anyone who mistakes it for a deployment reference. There was no production-shaped sample, and no operator-facing document describing how to stand the gateway up.

**Approach.** One new `deployment/` module holding exactly one subtree, `compose-sample/`: gateway + Keycloak + a single static nginx upstream that reads as "your API goes here". Hardening (`no-new-privileges`, `cap_drop`, `read_only`) is reused from the IT stack rather than reinvented. Readiness is host-side per ADR-0031 — the gateway's distroless image ships neither a shell nor curl, so a compose `healthcheck:` on it is impossible, not merely awkward; that absence is recorded in-file so a reviewer reads it as deliberate. The readiness script derives its probe target from `compose config --format json` rather than restating host port or scheme, and probes `/q/health/ready`, not liveness. The sample is wired to an opt-in `compose-sample` Maven profile so it is *activated*, not merely committed — a YAML lint would not have caught a stack that does not come up.

TLS is configured through `QUARKUS_HTTP_SSL_CERTIFICATE_FILES` / `QUARKUS_MANAGEMENT_SSL_CERTIFICATE_FILES` and their `_KEY_FILES` peers.

_[Intent truncated — 1396 of 2189 characters shown; full outline in the plan workspace]_


**Non-goals (deliberately out of scope — please do not report these as gaps).**

- **No Helm chart.** No `deployment/helm/`, no `Chart.yaml`, no `values.yaml`, no chart CI job, and no Kubernetes deployment diagram. This was split out by operator decision on 2026-08-02 and moved to the `api-sheriff-next` roadmap (PLAN-41). The alpha ships compose. It was removed deliberately, not overlooked.
- **No `api-sheriff/src/main/java/**` change.** The sample is configuration and documentation only. If the sample could only be made to work by changing gateway code, that is a finding about the config model to report — not something to patch here.
- **No reuse of the integration-test topology.** `integration-tests/docker-compose.yml` is referenced as prior art for runtime hardening and the Keycloak *shape* only. Its backends (toxiproxy, go-httpbin, nginx passthrough, asset origin, gRPC echo) are test scaffolding and are intentionally absent from the sample. This PR does not restructure the IT stack.
- **No `doc/README.adoc` ADR-index backfill.** That table stops at ADR-0019 while the corpus now runs to ADR-0033. Neither renamed ADR appears in it, so the renumbering in this PR breaks no link there. Backfilling the 14 missing rows is separate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production-shaped Docker Compose sample with API gateway, identity provider, and demo API services.
  * Added certificate generation, startup, readiness-check, and shutdown scripts.
  * Added secure defaults, health checks, TLS, authentication, and resource controls.
  * Added optional Maven integration for managing the sample deployment.

* **Documentation**
  * Added operator and contributor guides covering setup, validation, configuration, and adaptation.
  * Added architecture references and corrected ADR numbering references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->