### PR TITLE
docs(fapi): record the 0.1.0 FAPI 2.0 position and correct the shipped claim

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -71,6 +71,15 @@ built* and *how the parts fit together*.
   real CVE in a comparable gateway/proxy or OAuth/OIDC stack is mapped to an API Sheriff
   control, a status, and a testable assertion. Doubles as the 1.0 security release gate.
 
+| link:fapi_status.adoc[FAPI 2.0 Conformance Status]
+| Where the BFF stands against the FAPI 2.0 Security Profile (Final), requirement by requirement,
+  with first-party evidence. *0.1.0 is not FAPI 2.0 conformant* -- three mandatory client
+  requirements are unmet. Read this before making any FAPI claim.
+
+| link:fapi_next_steps.adoc[FAPI 2.0 Next Steps]
+| The route from that position to conformance: the mTLS and DPoP routes and why they differ, the
+  seven workstreams, the key-lifecycle constraint, and the decisions owed before work starts.
+
 | TLS Edge (three-layer topic)
 | The accept-time SNI split and mTLS edge, documented across all three layers: the
   link:configuration.adoc#_tls[`tls` configuration reference], the link:user/tls-edge.adoc[operator

--- a/doc/fapi_next_steps.adoc
+++ b/doc/fapi_next_steps.adoc
@@ -1,0 +1,172 @@
+= API Sheriff -- FAPI 2.0 Next Steps
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectnumlevels: 2
+
+The route from the 0.1.0 alpha position recorded in link:fapi_status.adoc[FAPI 2.0 Conformance
+Status] to a genuinely conformant FAPI 2.0 relying party. This document scopes the work and names
+the decisions that must be taken before it starts; it does not schedule it.
+
+[IMPORTANT]
+====
+*The work is wiring, configuration, and key lifecycle -- not architecture.* Every protocol
+capability FAPI 2.0 requires, except one, is already implemented in the `token-sheriff-client`
+engine and merely unused by the gateway. The single exception is the DPoP proof algorithm set, and
+it does not block conformance because the mTLS route is unaffected.
+====
+
+== The Two Routes
+
+FAPI 2.0 §5.3.3.1 requires sender-constrained access tokens via mTLS (RFC 8705) *and/or* DPoP
+(RFC 9449), and permits client authentication by mTLS *or* `private_key_jwt`. That yields two
+coherent routes, which differ sharply in operational cost.
+
+[cols="1,3,3"]
+|===
+| | *mTLS route* | *DPoP route*
+
+| Sender constraint
+| `SenderConstraint.mtls(thumbprint)` -- transport-level, no header, no signing
+| `SenderConstraint.dpop(generator)` -- a signed proof JWT per request
+
+| Client authentication
+| `tls_client_auth` -- the same certificate serves both purposes
+| `private_key_jwt` -- a separate signing key
+
+| Engine support
+| *Complete today*
+| *Blocked* on https://github.com/cuioss/TokenSheriff/issues/618[TokenSheriff#618] (RSA/`RS256`-only)
+
+| Deployment cost
+| A client certificate the IdP trusts; certificate lifecycle and rotation
+| A signing key pair; key lifecycle and rotation
+
+| Operational fit
+| Heavier -- requires mTLS to the IdP, which many deployments do not run
+| Lighter -- ordinary TLS to the IdP, key material held by the gateway
+|===
+
+*Recommendation: build the seam so both are selectable, and implement the mTLS route first.* It is
+unblocked today, it exercises the whole configuration and wiring surface, and it makes the eventual
+DPoP addition a second implementation behind an existing seam rather than a new feature. The engine
+already models exactly this -- `SenderConstraint` is one type with two factory methods.
+
+== Workstreams
+
+=== W1 -- PAR
+
+Route the authorization request through `ParClient.pushAuthorizationRequest` and redirect with the
+returned `request_uri` instead of building a parameterised front-channel URL.
+
+* The gateway currently holds no reference to `ParClient`; add one to the BFF runtime assembly.
+* `LoginFlow.initiate` changes shape: the authorization URL it redirects to carries only
+  `client_id` and `request_uri`.
+* PAR is a *new outbound leg* to the AS. It inherits the existing back-channel egress and scheme
+  validation, but the operational surface (timeouts, failure handling at login initiation) is new.
+* *Consequence worth taking deliberately:* with parameters pushed over the back channel, the
+  front-channel URL no longer carries `state`. This does not by itself retire the
+  `response_mode=query` tradeoff recorded in link:fapi_status.adoc[the status document] -- the
+  *response* still returns `code`/`state`/`iss` on a URL -- so the binding-cookie design is
+  unchanged. Re-evaluate `form_post` only as a separate decision, on its own merits.
+
+=== W2 -- Client authentication
+
+Replace `client_secret_basic` with `tls_client_auth` (mTLS route) or `private_key_jwt` (DPoP route).
+Both are implemented in the engine as `MtlsClientAuth` and `PrivateKeyJwtAuth`, and both are
+selectable through `ClientAuthMethod`.
+
+This is a *breaking configuration change*: `oidc.client_secret` gives way to a key or certificate
+reference. `ConfigLoader` lists `/oidc/client_secret` among its secrets-rule pointers, and that list
+changes with it.
+
+=== W3 -- Sender constraint and key lifecycle
+
+Wire a `SenderConstraint` into both `AuthorizationCodeFlow` (the code-exchange constructor takes it)
+and `RefreshFlow` (its four-argument constructor takes it). *It must be the same instance* -- a
+refresh presented against a token bound to a different key fails.
+
+Key lifecycle is the substantive work, and the constraint it imposes is the one to design for
+first:
+
+* The proof key or client certificate must *outlive the tokens bound to it*. A key generated at boot
+  silently kills refresh for every live session on restart, because the AS bound those tokens to a
+  key that no longer exists.
+* A per-node key breaks refresh across nodes: a session bound on one node cannot refresh on another.
+  This is the *same* single-node constraint the in-memory `PendingAuthorizationStore` already
+  imposes, arriving by a different route -- and it applies to the sealed-cookie mode too, which is
+  otherwise the horizontally scalable one.
+* *Therefore the key is provisioned deployment material, alongside the TLS profiles -- never a
+  per-process artifact.*
+
+=== W4 -- Trust and key material plumbing
+
+`ClientConfiguration` is currently built with no SSL context, so the BFF's back-channel legs use the
+JVM default trust store while the JWKS leg is trust-profile-configurable. The mTLS route requires
+the gateway to *present* a certificate on those legs, so this asymmetry has to close.
+
+`JwksTrustProfileResolver` maps a logical profile name to an `SSLContext` and deliberately refuses a
+profile carrying no trust anchors. Client *key* material is a different shape, so this needs either
+a widened contract on that resolver or a second seam beside it. Whichever is chosen, preserve the
+property that makes the existing one sound: *a named profile means these anchors, and never "no
+verification at all"* -- the resolver refuses `trust-all` for exactly that reason.
+
+=== W5 -- Configuration surface
+
+New `oidc` sub-blocks for client authentication and the sender constraint, with the secrets rule
+applied to any new secret-bearing pointer.
+
+[WARNING]
+====
+Every new nested configuration record *must* be registered in `ConfigModelReflection`. It registers
+the config model explicitly, including `OidcConfig` and each of its nested records. A record omitted
+there boot-fails *only in the native image*, while every JVM-level gate stays green.
+====
+
+=== W6 -- The `cnf` forwarding decision
+
+A `require: session` route injects the mediated token upstream as `Authorization: Bearer`
+(`SessionAuthenticationStage`). Once that token is sender-constrained it carries a `cnf` claim. A
+`cnf`-blind upstream accepts it unchanged, which is the status quo; a DPoP-aware upstream *must
+reject* it for want of a proof. This is latent breakage, not a current fault -- it surfaces the day
+any backend gets stricter.
+
+Two clean resolutions, both cheap now and expensive to retrofit:
+
+. *Document the contract* -- the gateway forwards a bound token as bearer, and upstreams must not
+  validate `cnf`. Zero code, but it writes an assumption into every backend.
+. *Stop forwarding the bound token* -- exchange it at the gateway (RFC 8693 token exchange) for an
+  upstream-scoped token, so the binding never leaves the gateway. The upstream contract then stays
+  literally unchanged.
+
+*This decision is a prerequisite, not a follow-up.* It determines whether conformance is a
+gateway-local property or a contract change reaching every backend.
+
+=== W7 -- Documentation
+
+Update link:fapi_status.adoc[the status document] as requirements move from UNMET to MET, and revise
+link:features-analysis.adoc[the feature analysis] -- whose FAPI/PAR differentiator claim is written
+against this target state rather than the shipped one.
+
+== Decisions Required Before Work Starts
+
+. *Which route* -- mTLS, DPoP, or a seam supporting both. Determines W2, W3, and W4.
+. *The `cnf` forwarding contract* (W6) -- document the assumption, or introduce token exchange.
+. *Key and certificate provisioning* -- how deployment supplies the material, and how rotation works
+  without invalidating live sessions.
+. *Whether conformance is a stated product goal* -- it implies ongoing tracking of the profile, and
+  a conformance suite run is the only credible evidence for the claim. Until such a run exists, the
+  honest posture is "implements the FAPI 2.0 controls", never "FAPI 2.0 certified".
+
+== Out of Scope
+
+* Authorization-server-side requirements -- the IdP's concern.
+* FAPI 2.0 Message Signing (a separate profile from the Security Profile assessed here).
+* Retiring the `response_mode=query` tradeoff, which is an independent decision on its own merits
+  (see W1).
+
+== Related
+
+* link:fapi_status.adoc[FAPI 2.0 Conformance Status] -- the current position and its evidence
+* https://github.com/cuioss/TokenSheriff/issues/618[TokenSheriff#618] -- the DPoP algorithm gap
+* link:security-threat-model.adoc[Threat Model]

--- a/doc/fapi_status.adoc
+++ b/doc/fapi_status.adoc
@@ -1,0 +1,176 @@
+= API Sheriff -- FAPI 2.0 Conformance Status (0.1.0 Alpha)
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectnumlevels: 2
+
+This document states, requirement by requirement, where API Sheriff's BFF stands against the
+*FAPI 2.0 Security Profile (Final)* as of the 0.1.0 alpha release. It exists because the profile is
+frequently claimed loosely, and because an earlier revision of
+link:features-analysis.adoc[the feature analysis] claimed capabilities the shipped code does not
+have (corrected in the same change that added this document).
+
+[IMPORTANT]
+====
+*Verdict: API Sheriff 0.1.0 is NOT FAPI 2.0 conformant.* Three of the profile's mandatory client
+requirements are unmet. What ships is a hardened OIDC confidential-client BFF -- a sound
+implementation of the RFC 9700 baseline -- not a FAPI 2.0 relying party. No FAPI conformance should
+be claimed, implied, or marketed for this release.
+
+The gap is *wiring and key management*, not architecture. See
+link:fapi_next_steps.adoc[FAPI 2.0 -- Next Steps] for the route to closing it.
+====
+
+== Scope
+
+FAPI 2.0 places requirements on both the authorization server and the client. API Sheriff's BFF is
+a *client* (relying party), so only the client-side requirements are assessed here. Requirements on
+the authorization server are the IdP's concern (Keycloak, in the reference topology) and are out of
+scope for this document.
+
+Everything below was verified first-party against the shipped source of API Sheriff and of the
+`token-sheriff-client` engine it consumes. Where a capability exists in the engine but is not wired
+by the gateway, that distinction is stated explicitly -- *a capability present in a dependency is
+not a capability of the product.*
+
+== Requirement Matrix
+
+[cols="3,1,4"]
+|===
+| FAPI 2.0 requirement | Status | Evidence
+
+| Sender-constrained access tokens -- mTLS (RFC 8705) and/or DPoP (RFC 9449) (§5.3.3.1)
+| *UNMET*
+| `BffRuntimeProducer` constructs `AuthorizationCodeFlow` with a `null` `senderConstraint`, and
+  `RefreshFlow` via its three-argument constructor. Tokens are plain bearer tokens carrying no
+  `cnf` claim.
+
+| Pushed Authorization Requests (RFC 9126) (§5.3.3.2)
+| *UNMET*
+| The authorization URL is built front-channel by
+  `QueryResponseModeAuthorizationRequestBuilder` through `AuthorizationCodeFlow.authorize`. The
+  engine ships a complete `ParClient`, but the gateway holds no reference to it -- the only mention
+  of `ParResponse` in this repository is a GraalVM reflection registration in
+  `TokenClientDslJsonReflection`, which registers the type for serialization and never calls it.
+
+| Client authentication -- mTLS or `private_key_jwt` (§5.3.3.1)
+| *UNMET*
+| `ClientAuthMethod.CLIENT_SECRET_BASIC` with `ClientSecretBasicAuth`. `client_secret_basic` is not
+  among the profile's permitted methods.
+
+| PKCE with `S256` (§5.3.3.2)
+| *MET*
+| The engine's `AuthorizationRequestBuilder` always emits `code_challenge` /
+  `code_challenge_method=S256`, and *fails closed* -- it throws and refuses to start the flow when
+  the provider does not advertise `S256`, so no `plain` or non-PKCE downgrade is reachable.
+
+| `iss` authorization-response parameter (RFC 9207) (§5.3.3.2)
+| *MET*
+| `IssValidator`, applied in `AuthorizationCodeFlow.exchange` after the state check and before the
+  code is redeemed. When the provider advertises
+  `authorization_response_iss_parameter_supported`, an *absent* `iss` is itself rejected, closing
+  the omit-`iss` bypass.
+
+| Signing algorithms restricted to `PS256`, `ES256`, or `EdDSA` (Ed25519) (§5.4.1)
+| *N/A today, blocking later*
+| No client-side signing is performed today, because neither `private_key_jwt` nor DPoP is in use.
+  It becomes binding the moment either is wired -- see <<_the_dpop_algorithm_constraint>>.
+|===
+
+Any one of the three *UNMET* rows is disqualifying on its own.
+
+== What Is Actually In Place
+
+The absence of FAPI conformance should not be read as a weak flow. The shipped BFF implements the
+RFC 9700 baseline carefully, and several controls exceed it:
+
+* *PKCE `S256`, fail-closed.* A provider that does not advertise `S256` causes the flow to be
+  refused rather than downgraded.
+* *RFC 9207 mix-up defence*, including rejection of an omitted `iss` where the provider advertises
+  support.
+* *Browser binding.* A short-lived `__Host-`-prefixed binding cookie ties an in-flight login to the
+  browser that started it. A callback is honoured only when *both* the binding cookie resolves the
+  pending record *and* the returned `state` matches it (constant-time). A callback replayed in a
+  different browser is rejected `403` even with a valid `state`.
+* *Single-use pending records.* Single-use is a store invariant, not a caller contract --
+  `PendingAuthorizationStore.consume` removes the record as it returns it, so a replay resolves
+  empty even inside the record's five-minute TTL. That TTL is fixed rather than operator-tunable,
+  because unauthenticated browsers create these records.
+* *Parameter-injection defence.* The callback rejects a duplicated `code` or `state` before
+  anything else (the Keycloak CVE-2026-9689 class).
+* *SSRF-guarded back channel.* Discovery-advertised endpoints are run through an egress/scheme
+  validator before every back-channel call, so a hostile discovery document cannot redirect the
+  token request at an internal address.
+
+== The Accepted `response_mode` Tradeoff
+
+This is not a FAPI requirement, but it is the design decision most often mistaken for one, so it is
+recorded here.
+
+The engine's default `AuthorizationRequestBuilder` requests `response_mode=form_post` deliberately,
+so that `code`, `state`, and `iss` are delivered in a POST body rather than on a URL, where they
+would reach browser history, proxy/CDN and server access logs, and the `Referer` header.
+
+*API Sheriff overrides this* with `QueryResponseModeAuthorizationRequestBuilder`. The reason is the
+binding cookie: it is `SameSite=Lax`, and a Lax cookie is sent on a top-level GET navigation but
+*not* on the cross-site POST that a `form_post` callback performs. With `form_post` the binding
+cookie is dropped and every real-browser login dead-ends on the "no binding cookie" rejection.
+
+The exposure is accepted by operator decision and *bounded, not removed*:
+
+* PKCE means a leaked code is not redeemable without the gateway-held verifier;
+* the code is single-use and short-lived at the token endpoint;
+* the binding-cookie plus `state` double-check rejects a code replayed from another browser even
+  while it is still live.
+
+`SameSite=None` was considered and rejected -- it would require permitting the cross-site sends the
+binding cookie exists to prevent. `SameSite=Strict` is not an option at all: the callback is a
+cross-site top-level navigation, on which a Strict cookie is never sent. The full statement lives on
+`QueryResponseModeAuthorizationRequestBuilder`.
+
+[NOTE]
+====
+The binding cookie carries no CSRF weight, and should not be read as if it did. A Lax cookie *is*
+sent on an attacker-initiated cross-site top-level GET. What defends against login CSRF and code
+injection is the `state` comparison against the record the cookie resolved to; the cookie defends a
+different attack -- replay of a captured callback in another browser. The two controls are
+orthogonal (see link:security-threat-model.adoc[the threat model], BFF-02).
+====
+
+[#_the_dpop_algorithm_constraint]
+== The DPoP Algorithm Constraint
+
+Sender-constraining has two permitted routes, and they are *not* equally available:
+
+* *mTLS is available today.* `SenderConstraint.mtls(certificateThumbprint)` records a
+  transport-level binding -- the certificate is presented by the HTTP handler's SSL context, no
+  header is added and no signing algorithm is involved. Nothing in the engine blocks this route.
+* *DPoP is blocked upstream.* `DpopProofGenerator` accepts RSA key pairs only and signs with
+  `RS256` / `RS384` / `RS512`; every other algorithm throws. Its embedded header `jwk` and its `jkt`
+  thumbprint are both computed RSA-only. FAPI 2.0 §5.4.1 does not permit `RS256`, so a proof this
+  generator emits is non-conformant by construction. Tracked upstream as
+  https://github.com/cuioss/TokenSheriff/issues/618[TokenSheriff#618].
+
+Because the profile accepts "one or both of" mTLS and DPoP, *the upstream issue does not block
+conformance* -- it blocks one of the two routes to it.
+
+== Consequence for Deployments
+
+Sender-constraining is realised *at the resource server*: the `cnf` claim only does work when
+something validating the token checks it. Terminating the constraint at the gateway -- the intended
+boundary -- protects the token at rest in the gateway's session store and binds the refresh token,
+and buys the upstreams behind the gateway nothing, because they continue to receive a plain bearer
+token exactly as today.
+
+That is a legitimate architecture, and it is the one planned. It carries one forward-looking
+consequence recorded in link:fapi_next_steps.adoc[Next Steps]: a `require: session` route forwards
+the mediated token upstream as `Authorization: Bearer`, and once that token is sender-constrained it
+carries `cnf`. A `cnf`-blind upstream accepts it unchanged; a DPoP-aware upstream *must reject* it
+for want of a proof.
+
+== Related
+
+* link:fapi_next_steps.adoc[FAPI 2.0 -- Next Steps] -- the route to conformance
+* link:security-threat-model.adoc[Threat Model] -- BFF-02 and the callback controls
+* link:variants/02-bff-session.adoc[Variant 2 -- Server-Side Session BFF]
+* link:variants/03-bff-cookie.adoc[Variant 3 -- Sealed-Cookie BFF]

--- a/doc/features-analysis.adoc
+++ b/doc/features-analysis.adoc
@@ -200,21 +200,34 @@ architecture makes it uniquely able to close all three.
   `realip` / Kong issues cited in ADR-0003's references) and "Forwarded header sabotage".
   See link:adr/0003-forwarded-headers.adoc[ADR-0003].
 
-| *PAR-driven, FAPI-2.0-aligned confidential-client flow*
-| A *major* differentiator. API Sheriff drives the authorization-code flow through *Pushed
-  Authorization Requests* (PAR, RFC 9126) -- pushing the authorization parameters over the back
-  channel and redirecting with the returned `request_uri`, so parameters are never exposed or
-  tamperable in the browser -- as part of a FAPI-2.0-aligned confidential-client posture (PKCE
-  `S256`, exact `redirect_uri`, `iss` mix-up defence, sender-constrained tokens). This is
-  delivered by the `token-sheriff-client` engine (`CLIENT-10` PAR, `CLIENT-11`
-  sender-constraint; the authoritative surface is `TokenSheriff/doc/client`), which API Sheriff
-  consumes. *Competitor reality (verified):* three of the six evaluated gateways
+| *PAR-driven, FAPI-2.0-aligned confidential-client flow* -- *TARGET, NOT SHIPPED IN 0.1.0*
+| A *major* differentiator -- and, as of the 0.1.0 alpha, an *unrealised* one. The intended posture
+  drives the authorization-code flow through *Pushed Authorization Requests* (PAR, RFC 9126) --
+  pushing the authorization parameters over the back channel and redirecting with the returned
+  `request_uri`, so parameters are never exposed or tamperable in the browser -- as part of a
+  FAPI-2.0-aligned confidential-client posture (PKCE `S256`, exact `redirect_uri`, `iss` mix-up
+  defence, sender-constrained tokens).
++
+[IMPORTANT]
+====
+*0.1.0 ships none of the PAR or sender-constrained-token half of this claim.* PKCE `S256` and the
+`iss` mix-up defence are delivered; PAR, sender-constrained tokens, and a FAPI-permitted client
+authentication method are not. The capabilities exist in the `token-sheriff-client` engine
+(`CLIENT-10` PAR, `CLIENT-11` sender-constraint) but are *not wired* by the gateway -- a capability
+present in a dependency is not a capability of the product. See
+link:fapi_status.adoc[FAPI 2.0 Conformance Status] for the requirement-by-requirement position and
+link:fapi_next_steps.adoc[FAPI 2.0 Next Steps] for the route to closing it. *No FAPI conformance may
+be claimed for this release.*
+====
++
+*Competitor reality (verified):* three of the six evaluated gateways
   (KrakenD, Tyk, Gravitee-APIM) are not OIDC relying parties in the data plane at all -- they
   only *validate* pre-issued JWTs. The two that genuinely act as an RP in OSS (APISIX's
   `openid-connect`, community Traefik plugins) run a plain PKCE code flow and expose *no* PAR and
   claim *no* FAPI 2.0. The only product shipping PAR inside its RP is *Kong, Enterprise-only*,
   and it markets generic "FAPI" (1.0-era), not FAPI 2.0. A first-class, *OSS*, PAR-initiating,
-  FAPI-2.0-aligned RP/BFF is therefore genuinely uncovered. (Do not conflate sides: many IdPs
+  FAPI-2.0-aligned RP/BFF is therefore genuinely uncovered -- *the opportunity is real and still
+  open; API Sheriff has not yet taken it.* (Do not conflate sides: many IdPs
   and Gravitee's separate *Access Management* product support PAR/FAPI as the *authorization
   server* -- the opposite side of the wire; the differentiator claimed here is the *client/RP*
   side, pushing to the `pushed_authorization_request_endpoint` and driving the redirect.) See
@@ -254,7 +267,7 @@ Secondary differentiators worth claiming:
 | Immutable static config | Yes | Standalone mode | file provider | Yes (native)
 | OIDC RP + cookie mediation | Yes | Yes | EE only | No
 | Transparent token refresh | Yes | Yes | EE only | M2M only
-| PAR-initiating FAPI 2.0 RP | *Yes* | No | No | No
+| PAR-initiating FAPI 2.0 RP | Planned (not in 0.1.0) | No | No | No
 | Offline JWT validation | Yes | Yes | Partial | Yes
 | Zero-trust forwarding | Yes | No | No | Yes
 | Path allowlist + param limits | Yes | Partial | No | Partial


### PR DESCRIPTION
## What

Two new documents recording where the BFF stands against the **FAPI 2.0 Security Profile (Final)**, plus a correction to a differentiator claim that asserted capabilities the shipped code does not have.

- `doc/fapi_status.adoc` — requirement-by-requirement assessment for the 0.1.0 alpha, with first-party evidence
- `doc/fapi_next_steps.adoc` — the route to conformance: the two routes, seven workstreams, and the decisions owed before work starts
- `doc/features-analysis.adoc` — the claim correction
- `doc/README.adoc` — both documents indexed

Documentation only. No production or test code is touched.

## The verdict

**0.1.0 is not FAPI 2.0 conformant.** Three mandatory client requirements are unmet:

| Requirement | Status | Why |
|---|---|---|
| Sender-constrained tokens (§5.3.3.1) | UNMET | `null` `senderConstraint` passed to `AuthorizationCodeFlow` and `RefreshFlow` |
| PAR (§5.3.3.2) | UNMET | The engine ships a complete `ParClient`; the gateway holds no reference to it |
| Client auth: mTLS or `private_key_jwt` (§5.3.3.1) | UNMET | `client_secret_basic`, which the profile does not permit |
| PKCE `S256` (§5.3.3.2) | MET | Fails closed — refuses the flow when `S256` is not advertised |
| `iss` / RFC 9207 (§5.3.3.2) | MET | Rejects an *absent* `iss` where the provider advertises support |

What ships is a hardened OIDC confidential-client BFF implementing the RFC 9700 baseline carefully — it is simply not a FAPI 2.0 relying party, and nothing should claim it is.

## Why the claim correction

`features-analysis.adoc` stated, in the present tense and as a "major differentiator", that API Sheriff "drives the authorization-code flow through Pushed Authorization Requests" as part of a posture including "sender-constrained tokens", and the summary matrix asserted `PAR-initiating FAPI 2.0 RP | Yes` against four named competitors.

Neither the PAR nor the sender-constraint half is true of the shipped code. The capabilities do exist in `token-sheriff-client` — but **a capability present in a dependency is not a capability of the product**. The only reference to `ParResponse` in this repository is a GraalVM reflection registration, which registers the type for serialization and never calls it. That is precisely the shape that let the claim survive: grepping for the class name finds apparent evidence of a feature that is never invoked.

The claim is restated as a target, the matrix row now reads `Planned (not in 0.1.0)`, and both point at the new status document. The competitive *opportunity* the section describes is untouched — it is real and still open.

## Upstream

The one engine-side gap is DPoP proof signing: `DpopProofGenerator` accepts RSA keys only and signs `RS256`/`RS384`/`RS512`, while the profile permits `PS256`, `ES256`, or `EdDSA`. Filed as cuioss/TokenSheriff#618.

It does **not** block conformance. The profile accepts *"one or both of"* mTLS and DPoP, and `SenderConstraint.mtls(...)` records a transport-level binding involving no header and no signing algorithm — so the mTLS route is unaffected and available today.

## Verification

Every claim was checked first-party against the shipped source of both repositories, and the six spec requirements against the published profile text. Documents cite classes and methods rather than line numbers, which decay.

The quality gate (`verify -Ppre-commit`) passes. The full `verify` was skipped by maintainer decision — this change contains no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ccy5JfSnadBAYP8VVcRdtr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAPI 2.0 conformance status documentation for the 0.1.0 alpha release.
  * Documented planned steps toward full FAPI 2.0 conformance, including mTLS and DPoP options.
  * Clarified that PAR and sender-constrained tokens are planned but not included in version 0.1.0.
  * Updated feature analysis and comparison materials to reflect the current implementation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->