### PR TITLE
docs(deployment): correct the compose sample's ingress claim

### DIFF
--- a/deployment/compose-sample/docker-compose.yml
+++ b/deployment/compose-sample/docker-compose.yml
@@ -147,7 +147,13 @@ services:
     labels:
       de.cuioss.sheriff.management-scheme: "https"
     ports:
-      - "8443:8443"  # Public TLS listener — the only way into the stack
+      # 8443 is the only ingress to the PROXIED SURFACE — no upstream in this file publishes a host
+      # port, so every request that reaches a backend arrives through the gateway's route table.
+      # It is not the only published port in the stack, and the difference matters when reading this
+      # sample as a topology: Keycloak publishes 1443 above so an operator can reach its admin console
+      # and mint a token, and 9000 below is this gateway's own management interface. Both are
+      # deliberate, disclosed exceptions, and neither is routed to by the gateway.
+      - "8443:8443"  # Public TLS listener
       - "9000:9000"  # Management interface (health/metrics), HTTPS
     environment:
       # This block is the DEPLOYMENT DOOR, and it is deliberately the same door the release smoke


### PR DESCRIPTION
## The contradiction

`deployment/compose-sample/docker-compose.yml` annotated the gateway's published port as:

```yaml
- "8443:8443"  # Public TLS listener — the only way into the stack
```

That is false within its own file. About a hundred lines above, the `keycloak` service publishes `1443:8443` so an operator can reach the admin console and mint a token. The gateway's own management interface on `9000` is published directly below the claim, too.

In a deployment *sample* that sentence reads as a security claim about the topology, so the overstatement is worth correcting rather than leaving in place.

## The fix

The intent the comment carried is true and kept: the gateway is the single application ingress — no upstream in the file publishes a host port, so every request that reaches a backend arrives through the gateway's route table. What was false is "only". The published IdP port and the management port are now named as the deliberate, disclosed exceptions they are, with the note that neither is routed to by the gateway.

## Scope

Exactly this one comment in this one file. Comment-only: no YAML keys, no behaviour, no Java. Untouched by design — `integration-tests/docker-compose.yml`, `doc/development/integration-test-topology.adoc`, and the neighbouring comments in this file. The wider IdP-exposure documentation reconciliation is tracked separately (api-sheriff-0-2-0 PLAN-V02-12).

## Why `skip-bot-review`

This is a one-line comment correction with no behaviour change; there is no code surface for CodeRabbit, Sourcery or PR-Agent to review, so the label is set to suppress the three automated passes.

## Verification

No Maven quality gate or full verify was run — nothing compilable changed. The file was confirmed to still parse as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdAZFhFPm56YycmbKzWT8N