### PR TITLE
docs(deployment): state the compose sample's ingress claim precisely

### DIFF
--- a/deployment/compose-sample/docker-compose.yml
+++ b/deployment/compose-sample/docker-compose.yml
@@ -163,7 +163,7 @@ services:
     labels:
       de.cuioss.sheriff.management-scheme: "https"
     ports:
-      - "8443:8443"  # Public TLS listener — the only way into the stack
+      - "8443:8443"  # Public TLS listener — the only port published off-host
       # Management interface (health/metrics), HTTPS — bound to the LOOPBACK interface rather than to
       # every host interface. /q/health and /q/metrics carry no authentication by construction, so
       # publishing them on 0.0.0.0 hands an internal-state view to anything that can reach the host.


### PR DESCRIPTION
One comment in `deployment/compose-sample/docker-compose.yml`. No behaviour change, no keys touched.

## What and why

The gateway port carried:

```
- "8443:8443"  # Public TLS listener — the only way into the stack
```

That claim was **false** when written: the Keycloak admin console was published on `0.0.0.0:1443` and the management interface on `0.0.0.0:9000`.

`a936ca4` (#154) fixed the underlying exposure — both are now bound to `127.0.0.1`, and `demo-api` publishes nothing — which made the sentence *materially* true: `8443` is the only port on a non-loopback interface.

What remains is looseness rather than a defect. Both loopback ports are still reachable **from the host itself**, and one of them is a Keycloak admin console carrying the sample bootstrap credentials. In a deployment sample that distinction is worth stating exactly, so the comment now says what actually holds:

```
- "8443:8443"  # Public TLS listener — the only port published off-host
```

## Notes

- `integration-tests/docker-compose.yml` carries no comparable claim — deliberately untouched.
- The broader IdP-exposure documentation reconciliation is planned separately and is **not** in scope here.
- `skip-bot-review` is set: this is a one-line comment correction with no behaviour change.
- No build run — comment-only, no Java, no YAML keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ccy5JfSnadBAYP8VVcRdtr