### PR TITLE
fix(bff): declare max_cookie_size in schema, sweep expired sessions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,23 +144,17 @@ the client unchanged. There is no response-header allowlist, and no configuratio
 them. Terminate such fingerprinting at the upstream, or in front of the gateway, if it matters to
 you.
 
-Cookie-mode BFF cannot be configured as documented::
-`oidc.session.max_cookie_size` is implemented in the model, enforced by the configuration
-validator and documented as a supported key, but it is *absent from the bundled
-`schema/gateway.schema.json`*, which rejects unknown keys. A `gateway.yaml` declaring it therefore
-fails schema validation before binding. Until the schema is corrected, use *server* session mode
-(Variant 2) rather than cookie mode (Variant 3).
-
 The server-mode session store is single-node and in-memory::
 `InMemorySessionStore` is the only implementation of the `SessionStore` seam, and `session.store`
 accepts exactly one value, `memory`. There is no distributed or persistent option. A server-mode
 BFF deployment is therefore single-node or sticky-session, and every session is lost on restart.
-Capacity is also not reclaimed on its own: an expired session is removed only when its own id is
-next looked up, and no periodic sweep is scheduled, so a session abandoned without a logout holds
-its `oidc.session.max_sessions` slot until the process restarts. Size `max_sessions` against
-total logins per process lifetime rather than against peak concurrency -- once the ceiling is
-reached, new logins are refused fail-closed.
-Cookie mode is the stateless alternative by design -- subject to the schema limitation above.
+Capacity is reclaimed at the ceiling rather than continuously: an expired session is removed when
+its own id is next looked up, and otherwise keeps its slot until a new login finds the store at
+its `oidc.session.max_sessions` bound, which sweeps the expired entries and admits the login if
+that freed a slot. No scheduler, timer thread or periodic sweep is involved. Size `max_sessions`
+against expected peak concurrency -- the ceiling refuses new logins fail-closed only when that
+many sessions are genuinely still live.
+Cookie mode is the stateless alternative by design.
 
 The cookie-mode BFF has had no systematic threat-model pass::
 The threat model covers the cookie-mode surface through individual catalogue entries (the AES-GCM

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
@@ -32,13 +32,19 @@ import java.util.Set;
  * Sessions are keyed by their opaque id in a primary map. Two secondary indexes — by IdP
  * {@code sid} and by {@code sub} — give O(1) back-channel logout destruction without scanning
  * the primary map. Every removal path (direct destroy, back-channel destroy, lazy TTL eviction,
- * periodic sweep) keeps the indexes consistent through a single {@link #removeInternal} seam.
+ * at-capacity sweep) keeps the indexes consistent through a single {@link #removeInternal} seam.
  * <p>
- * The absolute TTL is enforced two ways with <strong>no per-session timer threads</strong>:
- * lazily on {@link #resolve} (an expired session is evicted as it is looked up) and by an
- * operator/scheduler-driven {@link #sweepExpired}. A documented {@code maxSessions} bound caps
- * the live-session count (a capacity ceiling for the operator's memory math); creating a session
- * beyond the bound is refused fail-closed. Every operation is guarded by the instance monitor.
+ * The absolute TTL is enforced two ways, with <strong>no per-session timer threads, no scheduler,
+ * and no periodic task</strong>: lazily on {@link #resolve} (an expired session is evicted as it is
+ * looked up) and opportunistically by {@link #sweepExpired}, whose one automatic trigger is
+ * {@link #create} finding the store at its {@code maxSessions} bound.
+ * <p>
+ * That trigger is what makes the bound a ceiling on <em>live</em> sessions rather than on
+ * accumulated ones. An expired session that nothing has resolved since it lapsed still occupies its
+ * slot, so without a reclaiming trigger a store could sit permanently full of dead sessions and
+ * refuse every login. Creation therefore sweeps once at the bound and re-tests it; only a store
+ * still full of live sessions afterwards is refused, fail-closed. Every operation is guarded by the
+ * instance monitor.
  *
  * @author API Sheriff Team
  * @since 1.0
@@ -64,10 +70,19 @@ public final class InMemorySessionStore implements SessionStore {
     }
 
     @Override
-    public synchronized void create(SessionRecord session) {
+    public synchronized void create(SessionRecord session, Instant now) {
         Objects.requireNonNull(session, "session");
-        if (byId.size() >= maxSessions) {
-            throw new IllegalStateException("session store is at its max-session bound of " + maxSessions);
+        Objects.requireNonNull(now, "now");
+        // An upsert replaces a record already counted against the bound, so it consumes no new
+        // capacity and must not be refused at the ceiling — that is the path a rotated session takes.
+        if (!byId.containsKey(session.sessionId()) && byId.size() >= maxSessions) {
+            // Sweep once, then re-test: expired sessions still hold their slots until something
+            // reclaims them, and reaching the bound is the trigger. A store still at the bound after
+            // the sweep is genuinely full of live sessions, and refusing it is the fail-closed guard.
+            sweepExpired(now);
+            if (byId.size() >= maxSessions) {
+                throw new IllegalStateException("session store is at its max-session bound of " + maxSessions);
+            }
         }
         byId.put(session.sessionId(), session);
         index(bySub, session.sub(), session.sessionId());

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
@@ -32,7 +32,8 @@ import java.util.Set;
  * Sessions are keyed by their opaque id in a primary map. Two secondary indexes — by IdP
  * {@code sid} and by {@code sub} — give O(1) back-channel logout destruction without scanning
  * the primary map. Every removal path (direct destroy, back-channel destroy, lazy TTL eviction,
- * at-capacity sweep) keeps the indexes consistent through a single {@link #removeInternal} seam.
+ * at-capacity sweep, and the eviction of the record an upsert replaces) keeps the indexes consistent
+ * through a single {@link #removeInternal} seam.
  * <p>
  * The absolute TTL is enforced two ways, with <strong>no per-session timer threads, no scheduler,
  * and no periodic task</strong>: lazily on {@link #resolve} (an expired session is evicted as it is
@@ -86,18 +87,13 @@ public final class InMemorySessionStore implements SessionStore {
                 throw new IllegalStateException("session store is at its max-session bound of " + maxSessions);
             }
         }
-        SessionRecord previous = byId.put(session.sessionId(), session);
-        if (previous != null) {
-            // An upsert may carry a different sub or sid than the record it replaces. The previous
-            // record's own index memberships must go, or the stale key keeps resolving to this id:
-            // a later destroyBySub/destroyBySid on it would destroy the replacement and report a
-            // phantom deletion, since removeInternal only deindexes under the NEW sub/sid.
-            deindex(bySub, previous.sub(), session.sessionId());
-            String previousSid = previous.sid();
-            if (previousSid != null) {
-                deindex(bySid, previousSid, session.sessionId());
-            }
-        }
+        // An upsert may carry a different sub or sid than the record it replaces, and a deindex is
+        // only ever keyed by the record's OWN sub/sid — so the previous record leaves through the
+        // same removeInternal seam every other removal path uses. Left indexed, its stale sub/sid
+        // would keep resolving to this id, and a later destroyBySub/destroyBySid on that stale key
+        // would destroy the replacement and report a phantom deletion.
+        removeInternal(session.sessionId());
+        byId.put(session.sessionId(), session);
         index(bySub, session.sub(), session.sessionId());
         String sid = session.sid();
         if (sid != null) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
@@ -36,15 +36,17 @@ import java.util.Set;
  * <p>
  * The absolute TTL is enforced two ways, with <strong>no per-session timer threads, no scheduler,
  * and no periodic task</strong>: lazily on {@link #resolve} (an expired session is evicted as it is
- * looked up) and opportunistically by {@link #sweepExpired}, whose one automatic trigger is
- * {@link #create} finding the store at its {@code maxSessions} bound.
+ * looked up) and opportunistically by {@link #sweepExpired}, whose one automatic trigger is a
+ * <em>capacity-consuming</em> {@link #create} — one introducing a session id the store does not yet
+ * hold — finding the store at its {@code maxSessions} bound. An upsert of an already-stored id
+ * replaces a record already counted against the bound, so it consumes no capacity and never sweeps.
  * <p>
  * That trigger is what makes the bound a ceiling on <em>live</em> sessions rather than on
  * accumulated ones. An expired session that nothing has resolved since it lapsed still occupies its
  * slot, so without a reclaiming trigger a store could sit permanently full of dead sessions and
- * refuse every login. Creation therefore sweeps once at the bound and re-tests it; only a store
- * still full of live sessions afterwards is refused, fail-closed. Every operation is guarded by the
- * instance monitor.
+ * refuse every login. A capacity-consuming creation therefore sweeps once at the bound and re-tests
+ * it; only a store still full of live sessions afterwards is refused, fail-closed. Every operation
+ * is guarded by the instance monitor.
  *
  * @author API Sheriff Team
  * @since 1.0
@@ -84,7 +86,18 @@ public final class InMemorySessionStore implements SessionStore {
                 throw new IllegalStateException("session store is at its max-session bound of " + maxSessions);
             }
         }
-        byId.put(session.sessionId(), session);
+        SessionRecord previous = byId.put(session.sessionId(), session);
+        if (previous != null) {
+            // An upsert may carry a different sub or sid than the record it replaces. The previous
+            // record's own index memberships must go, or the stale key keeps resolving to this id:
+            // a later destroyBySub/destroyBySid on it would destroy the replacement and report a
+            // phantom deletion, since removeInternal only deindexes under the NEW sub/sid.
+            deindex(bySub, previous.sub(), session.sessionId());
+            String previousSid = previous.sid();
+            if (previousSid != null) {
+                deindex(bySid, previousSid, session.sessionId());
+            }
+        }
         index(bySub, session.sub(), session.sessionId());
         String sid = session.sid();
         if (sid != null) {

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBinding.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBinding.java
@@ -61,7 +61,7 @@ public final class ServerSessionBinding implements SessionBinding {
     public BoundSession bind(SessionRecord session, Instant now) {
         Objects.requireNonNull(session, "session");
         Objects.requireNonNull(now, "now");
-        sessionStore.create(session);
+        sessionStore.create(session, now);
         return new BoundSession(session, List.of(sessionCookieCodec.toSetCookieHeader(session.sessionId())));
     }
 
@@ -78,9 +78,10 @@ public final class ServerSessionBinding implements SessionBinding {
         Objects.requireNonNull(now, "now");
         // create() upserts by session id (SessionStore contract; InMemorySessionStore is a keyed map
         // put), so no pre-destroy is needed. Destroying first would open a window where a concurrent
-        // resolve() misses the rotating session. The opaque handle is unchanged, so the browser needs
-        // no new Set-Cookie.
-        sessionStore.create(rotated);
+        // resolve() misses the rotating session. An upsert consumes no new capacity, so this call is
+        // admitted even at the max-session bound. The opaque handle is unchanged, so the browser
+        // needs no new Set-Cookie.
+        sessionStore.create(rotated, now);
         return new BoundSession(rotated, List.of());
     }
 

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionStore.java
@@ -42,11 +42,20 @@ public interface SessionStore {
     /**
      * Stores a session, upserting by its opaque id — re-creating an existing id replaces the record
      * in place, which is how a rotated session is persisted without a destroy-then-create window.
+     * An upsert consumes no new capacity, so it is admitted even at the bound.
+     * <p>
+     * {@code now} is the reference instant capacity is reclaimed against. When a <em>new</em> id
+     * arrives while the store sits at its max-session bound, the implementation sweeps the sessions
+     * expired at {@code now} and admits the session if that freed a slot. A store genuinely full of
+     * <em>live</em> sessions still refuses fail-closed — the bound caps concurrent live sessions,
+     * never accumulated dead ones.
      *
      * @param session the session to store
-     * @throws IllegalStateException when the store is at its max-session capacity bound
+     * @param now     the reference instant expired capacity is reclaimed against
+     * @throws IllegalStateException when the store is at its max-session capacity bound and no
+     *                               expired session could be reclaimed to admit this one
      */
-    void create(SessionRecord session);
+    void create(SessionRecord session, Instant now);
 
     /**
      * Resolves a live session by its opaque id, enforcing the absolute TTL lazily: an expired
@@ -84,8 +93,13 @@ public interface SessionStore {
     int destroyBySub(String sub);
 
     /**
-     * Removes every session expired at {@code now}. Invoked by a periodic sweep so eviction does
-     * not rely on access alone — there are no per-session timer threads.
+     * Removes every session expired at {@code now}.
+     * <p>
+     * No scheduler, timer thread, or periodic task drives this. Its one automatic trigger is
+     * {@link #create(SessionRecord, Instant)} reaching the max-session bound, which is what lets an
+     * expired session release the slot it still occupies. Expiry itself never depends on the sweep:
+     * {@link #resolve} evicts an expired session as it is looked up, so an expired session is
+     * unresolvable whether or not it has been swept.
      *
      * @param now the reference instant
      * @return the number of sessions swept

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
@@ -33,7 +33,9 @@
  *       {@link de.cuioss.sheriff.gateway.bff.session.SessionStore} (implemented only by
  *       {@link de.cuioss.sheriff.gateway.bff.session.InMemorySessionStore} — keyed by opaque id,
  *       with secondary indexes by {@code sid}/{@code sub} for O(1) back-channel destruction, an
- *       absolute TTL enforced lazily plus by a periodic sweep, and a documented max-session bound)
+ *       absolute TTL enforced lazily on resolve plus an opportunistic sweep triggered when a
+ *       create arrives at the max-session bound — no scheduler and no timer threads — and a
+ *       documented max-session bound capping live sessions)
  *       and {@link de.cuioss.sheriff.gateway.bff.session.SessionCookieCodec}, which sets and reads
  *       the hardened {@code __Host-} session cookie carrying only the opaque id. In this mode the
  *       token material never leaves the server.</li>

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
@@ -34,10 +34,9 @@
  *       {@link de.cuioss.sheriff.gateway.bff.session.InMemorySessionStore} — keyed by opaque id,
  *       with secondary indexes by {@code sid}/{@code sub} for O(1) back-channel destruction, an
  *       absolute TTL enforced lazily on resolve plus an opportunistic sweep triggered when a
- *       capacity-consuming create — one introducing a session id the store does not yet hold —
- *       arrives at the max-session bound, an upsert of an already-stored id never sweeping since it
- *       consumes no capacity — no scheduler and no timer threads — and a
- *       documented max-session bound capping live sessions)
+ *       capacity-consuming create — one introducing a session id the store does not yet hold, never
+ *       an upsert of an already-stored one — arrives at the max-session bound — no scheduler and no
+ *       timer threads — and a documented max-session bound capping live sessions)
  *       and {@link de.cuioss.sheriff.gateway.bff.session.SessionCookieCodec}, which sets and reads
  *       the hardened {@code __Host-} session cookie carrying only the opaque id. In this mode the
  *       token material never leaves the server.</li>

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
@@ -34,7 +34,9 @@
  *       {@link de.cuioss.sheriff.gateway.bff.session.InMemorySessionStore} — keyed by opaque id,
  *       with secondary indexes by {@code sid}/{@code sub} for O(1) back-channel destruction, an
  *       absolute TTL enforced lazily on resolve plus an opportunistic sweep triggered when a
- *       create arrives at the max-session bound — no scheduler and no timer threads — and a
+ *       capacity-consuming create — one introducing a session id the store does not yet hold —
+ *       arrives at the max-session bound, an upsert of an already-stored id never sweeping since it
+ *       consumes no capacity — no scheduler and no timer threads — and a
  *       documented max-session bound capping live sessions)
  *       and {@link de.cuioss.sheriff.gateway.bff.session.SessionCookieCodec}, which sets and reads
  *       the hardened {@code __Host-} session cookie carrying only the opaque id. In this mode the

--- a/api-sheriff/src/main/resources/schema/gateway.schema.json
+++ b/api-sheriff/src/main/resources/schema/gateway.schema.json
@@ -318,6 +318,10 @@
             "max_sessions": {
               "type": "integer",
               "description": "Server-mode upper bound on concurrently stored sessions — a DoS guard on the in-memory store. Creating a session beyond the bound is refused fail-closed."
+            },
+            "max_cookie_size": {
+              "type": "integer",
+              "description": "Cookie-mode sealed cookie-value size budget in bytes; valid range 40..8192, defaulting to 4096 when omitted. This is the ONE declared number driving both ends of the round trip — the seal-time budget and the gateway's pre-route Cookie header-value cap — so the two can never contradict each other. The bounds are stated here in prose only: the configuration validator is the sole enforcing authority and names the offending value at boot, which is why no minimum, maximum or default keyword is declared."
             }
           }
         },

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
@@ -181,7 +181,7 @@ class AuthenticationStageTest {
                 .idToken("id-token")
                 .sub("subject")
                 .expiresAt(NOW.plusSeconds(3600))
-                .build());
+                .build(), NOW);
         SessionCookieCodec codec = new SessionCookieCodec(SessionCookieCodec.DEFAULT_COOKIE_NAME, Duration.ofHours(1));
         return new SessionAuthenticationStage(new ServerSessionBinding(store, codec),
                 (session, cookieHeader, now) -> Optional.of(new SessionBinding.BoundSession(session, List.of())),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinatorTest.java
@@ -130,7 +130,7 @@ class TokenRefreshCoordinatorTest {
         void shouldReturnCurrentWhenNotNearExpiry() {
             AtomicInteger calls = new AtomicInteger();
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             TokenRefreshCoordinator coordinator = coordinator(NOT_NEAR, rt -> {
                 calls.incrementAndGet();
                 return rotation();
@@ -148,7 +148,7 @@ class TokenRefreshCoordinatorTest {
         void shouldReturnCurrentWhenNoRefreshToken() {
             AtomicInteger calls = new AtomicInteger();
             SessionRecord live = session(null);
-            store.create(live);
+            store.create(live, NOW);
             TokenRefreshCoordinator coordinator = coordinator(NEAR, rt -> {
                 calls.incrementAndGet();
                 return rotation();
@@ -169,7 +169,7 @@ class TokenRefreshCoordinatorTest {
         @DisplayName("Should refresh through the engine and persist the rotated token material")
         void shouldRefreshAndPersist() {
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             TokenRefreshCoordinator coordinator = coordinator(NEAR, rt -> rotation());
 
             RefreshOutcome outcome = coordinator.refresh(live, COOKIE_HEADER, NOW);
@@ -186,7 +186,7 @@ class TokenRefreshCoordinatorTest {
         @DisplayName("Should pass the session's current refresh token to the engine")
         void shouldPresentCurrentRefreshToken() {
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             AtomicInteger calls = new AtomicInteger();
             TokenRefreshCoordinator coordinator = coordinator(NEAR, presented -> {
                 calls.incrementAndGet();
@@ -210,7 +210,7 @@ class TokenRefreshCoordinatorTest {
         @DisplayName("Should destroy the session and fail when the engine refresh is rejected")
         void shouldFailAndDestroyOnEngineRejection() {
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             TokenRefreshCoordinator coordinator = coordinator(NEAR, rt -> {
                 throw new ClientProtocolException("token endpoint rejected the refresh grant");
             });
@@ -227,7 +227,7 @@ class TokenRefreshCoordinatorTest {
         @DisplayName("Should destroy the session when the engine reports refresh-token reuse (family revoked)")
         void shouldFailOnReuseDetection() {
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             TokenRefreshCoordinator coordinator = coordinator(NEAR, rt -> {
                 throw new ClientProtocolException("refresh token family is revoked");
             });
@@ -259,7 +259,7 @@ class TokenRefreshCoordinatorTest {
         @DisplayName("Should coalesce concurrent refreshes on one session into a single engine call")
         void shouldCoalesceConcurrentRefreshes() throws Exception {
             SessionRecord live = session(CURRENT_REFRESH);
-            store.create(live);
+            store.create(live, NOW);
             CountDownLatch entered = new CountDownLatch(1);
             CountDownLatch proceed = new CountDownLatch(1);
             AtomicInteger calls = new AtomicInteger();

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpointTest.java
@@ -107,7 +107,7 @@ class LoginInitiationEndpointTest {
                 .acr(null)
                 .authTime(null)
                 .build();
-        sessionStore.create(session);
+        sessionStore.create(session, T0);
         return sessionCodec.toSetCookieHeader(SESSION_ID).split(";", 2)[0];
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpointTest.java
@@ -74,7 +74,7 @@ class LogoutEndpointTest {
                 .sub("user-sub-1")
                 .expiresAt(NOW.plus(Duration.ofHours(8)))
                 .build();
-        store.create(session);
+        store.create(session, NOW);
         cookieHeader = SessionCookieCodec.DEFAULT_COOKIE_NAME + "=" + sessionId;
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpointTest.java
@@ -88,7 +88,7 @@ class UserInfoEndpointTest {
                 .acr(ACR)
                 .authTime(AUTH_TIME)
                 .build();
-        sessionStore.create(session);
+        sessionStore.create(session, T0);
         cookieHeader = sessionCodec.toSetCookieHeader(SESSION_ID).split(";", 2)[0];
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStageTest.java
@@ -385,7 +385,7 @@ class SessionAuthenticationStageTest {
 
     private static SessionBinding bindingWith(SessionRecord session) {
         InMemorySessionStore store = new InMemorySessionStore(16);
-        store.create(session);
+        store.create(session, NOW);
         return new ServerSessionBinding(store, CODEC);
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
@@ -170,6 +170,35 @@ class InMemorySessionStoreTest {
             assertEquals(0, store.destroyBySid("A"), "the secondary index was cleaned after the destroy");
             assertEquals(0, store.destroyBySid("never-seen"));
         }
+
+        @Test
+        @DisplayName("Should drop the previous subject's index entry when an upsert changes sub")
+        void shouldRepairSubIndexOnUpsert() {
+            InMemorySessionStore store = new InMemorySessionStore(16);
+            store.create(session("s1", "old-sub", null, FUTURE), T0);
+
+            store.create(session("s1", "new-sub", null, FUTURE), T0);
+
+            assertEquals(0, store.destroyBySub("old-sub"),
+                    "the replaced record's subject must not keep resolving to the session id — otherwise a"
+                            + " back-channel logout for the old subject destroys the replacement");
+            assertTrue(store.resolve("s1", T0).isPresent(), "the replacement survived the stale-subject destroy");
+            assertEquals(1, store.destroyBySub("new-sub"), "the replacement is reachable under its own subject");
+        }
+
+        @Test
+        @DisplayName("Should drop the previous sid's index entry when an upsert changes sid")
+        void shouldRepairSidIndexOnUpsert() {
+            InMemorySessionStore store = new InMemorySessionStore(16);
+            store.create(session("s1", "sub1", "old-sid", FUTURE), T0);
+
+            store.create(session("s1", "sub1", "new-sid", FUTURE), T0);
+
+            assertEquals(0, store.destroyBySid("old-sid"),
+                    "an IdP that rotates sid on refresh must not leave the old sid destroying the new session");
+            assertTrue(store.resolve("s1", T0).isPresent(), "the replacement survived the stale-sid destroy");
+            assertEquals(1, store.destroyBySid("new-sid"), "the replacement is reachable under its own sid");
+        }
     }
 
     @Nested
@@ -213,7 +242,8 @@ class InMemorySessionStoreTest {
             store.create(session("s2", "sub2", null, FUTURE), T0);
 
             SessionRecord overflow = session("s3", "sub3", null, FUTURE);
-            assertThrows(IllegalStateException.class, () -> store.create(overflow, T0.plusSeconds(10)),
+            Instant afterExpiry = T0.plusSeconds(10);
+            assertThrows(IllegalStateException.class, () -> store.create(overflow, afterExpiry),
                     "the at-capacity sweep reclaims nothing while every session is live, so the DoS"
                             + " guard must still refuse — reclamation may not become a way around the bound");
             assertEquals(2, store.size(), "the refused create left the store untouched");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.sheriff.gateway.bff.session;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -33,6 +34,11 @@ import org.junit.jupiter.api.Test;
  * Tests for the D3 server-side session store: {@link SessionRecord} (credential redaction, TTL,
  * normalization) and {@link InMemorySessionStore} (create/resolve/destroy, lazy + swept TTL
  * eviction, O(1) back-channel destruction by {@code sid}/{@code sub}, and the max-session bound).
+ * <p>
+ * The {@code Capacity} cases cover the bound from both sides: a create that reaches the bound
+ * reclaims the slots of sessions expired at its reference instant, while a bound genuinely full of
+ * live sessions still refuses fail-closed. Both directions are asserted, because reclamation that
+ * quietly stopped refusing would turn the DoS guard off rather than make it accurate.
  */
 class InMemorySessionStoreTest {
 
@@ -61,7 +67,7 @@ class InMemorySessionStoreTest {
         @DisplayName("Should resolve a created session and drop it after destroy-by-id")
         void shouldCreateResolveDestroy() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("s1", "sub1", "sid1", FUTURE));
+            store.create(session("s1", "sub1", "sid1", FUTURE), T0);
 
             assertTrue(store.resolve("s1", T0).isPresent());
             store.destroyById("s1");
@@ -92,7 +98,7 @@ class InMemorySessionStoreTest {
         @DisplayName("Should evict an expired session lazily on resolve")
         void shouldEvictExpiredLazily() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("s1", "sub1", null, T0.plusSeconds(10)));
+            store.create(session("s1", "sub1", null, T0.plusSeconds(10)), T0);
 
             assertTrue(store.resolve("s1", T0.plusSeconds(11)).isEmpty(), "an expired session is refused");
             assertEquals(0, store.size(), "the expired session was evicted lazily on resolve");
@@ -103,7 +109,7 @@ class InMemorySessionStoreTest {
         void shouldTreatBoundaryAsExpired() {
             InMemorySessionStore store = new InMemorySessionStore(16);
             Instant expiry = T0.plusSeconds(10);
-            store.create(session("s1", "sub1", null, expiry));
+            store.create(session("s1", "sub1", null, expiry), T0);
 
             assertTrue(store.resolve("s1", expiry).isEmpty(), "expiry is inclusive of the boundary");
         }
@@ -112,9 +118,9 @@ class InMemorySessionStoreTest {
         @DisplayName("Should sweep every expired session and leave live ones untouched")
         void shouldSweepExpired() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("dead1", "sub1", null, T0.plusSeconds(5)));
-            store.create(session("dead2", "sub2", null, T0.plusSeconds(5)));
-            store.create(session("live", "sub3", null, FUTURE));
+            store.create(session("dead1", "sub1", null, T0.plusSeconds(5)), T0);
+            store.create(session("dead2", "sub2", null, T0.plusSeconds(5)), T0);
+            store.create(session("live", "sub3", null, FUTURE), T0);
 
             int swept = store.sweepExpired(T0.plusSeconds(10));
 
@@ -132,9 +138,9 @@ class InMemorySessionStoreTest {
         @DisplayName("Should destroy every session carrying the given sid")
         void shouldDestroyBySid() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("s1", "sub1", "A", FUTURE));
-            store.create(session("s2", "sub2", "A", FUTURE));
-            store.create(session("s3", "sub3", "B", FUTURE));
+            store.create(session("s1", "sub1", "A", FUTURE), T0);
+            store.create(session("s2", "sub2", "A", FUTURE), T0);
+            store.create(session("s3", "sub3", "B", FUTURE), T0);
 
             assertEquals(2, store.destroyBySid("A"));
             assertTrue(store.resolve("s1", T0).isEmpty());
@@ -146,9 +152,9 @@ class InMemorySessionStoreTest {
         @DisplayName("Should destroy every session for the given subject")
         void shouldDestroyBySub() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("s1", "user-x", null, FUTURE));
-            store.create(session("s2", "user-x", null, FUTURE));
-            store.create(session("s3", "user-y", null, FUTURE));
+            store.create(session("s1", "user-x", null, FUTURE), T0);
+            store.create(session("s2", "user-x", null, FUTURE), T0);
+            store.create(session("s3", "user-y", null, FUTURE), T0);
 
             assertEquals(2, store.destroyBySub("user-x"));
             assertTrue(store.resolve("s3", T0).isPresent(), "an unrelated subject is untouched");
@@ -158,7 +164,7 @@ class InMemorySessionStoreTest {
         @DisplayName("Should report zero and clean the index when the sid is already gone")
         void shouldReturnZeroForUnknownSidAndCleanIndex() {
             InMemorySessionStore store = new InMemorySessionStore(16);
-            store.create(session("s1", "sub1", "A", FUTURE));
+            store.create(session("s1", "sub1", "A", FUTURE), T0);
 
             assertEquals(1, store.destroyBySid("A"));
             assertEquals(0, store.destroyBySid("A"), "the secondary index was cleaned after the destroy");
@@ -174,24 +180,67 @@ class InMemorySessionStoreTest {
         @DisplayName("Should refuse a session created beyond the max-session bound")
         void shouldEnforceMaxBound() {
             InMemorySessionStore store = new InMemorySessionStore(2);
-            store.create(session("s1", "sub1", null, FUTURE));
-            store.create(session("s2", "sub2", null, FUTURE));
+            store.create(session("s1", "sub1", null, FUTURE), T0);
+            store.create(session("s2", "sub2", null, FUTURE), T0);
 
             SessionRecord overflow = session("s3", "sub3", null, FUTURE);
-            assertThrows(IllegalStateException.class, () -> store.create(overflow));
+            assertThrows(IllegalStateException.class, () -> store.create(overflow, T0));
         }
 
         @Test
         @DisplayName("Should free capacity once expired sessions are swept")
         void shouldFreeCapacityAfterSweep() {
             InMemorySessionStore store = new InMemorySessionStore(2);
-            store.create(session("s1", "sub1", null, T0.plusSeconds(5)));
-            store.create(session("s2", "sub2", null, FUTURE));
+            store.create(session("s1", "sub1", null, T0.plusSeconds(5)), T0);
+            store.create(session("s2", "sub2", null, FUTURE), T0);
 
             store.sweepExpired(T0.plusSeconds(10));
-            store.create(session("s3", "sub3", null, FUTURE));
+            store.create(session("s3", "sub3", null, FUTURE), T0);
 
             assertEquals(2, store.size());
+        }
+
+        @Test
+        @DisplayName("Should reclaim an expired session's slot when a create reaches the bound")
+        void shouldReclaimExpiredCapacityOnCreate() {
+            InMemorySessionStore store = new InMemorySessionStore(2);
+            store.create(session("s1", "sub1", null, T0.plusSeconds(5)), T0);
+            store.create(session("s2", "sub2", null, T0.plusSeconds(5)), T0);
+
+            // Driven through create() alone — sweepExpired is deliberately never called by hand here.
+            // Calling it would merely re-test "Should free capacity once expired sessions are swept"
+            // above; what this case exists to prove is that reaching the bound is itself the trigger.
+            store.create(session("s3", "sub3", null, FUTURE), T0.plusSeconds(10));
+
+            assertEquals(1, store.size(), "both expired sessions released their slots, leaving only the new one");
+            assertTrue(store.resolve("s3", T0.plusSeconds(10)).isPresent(), "the reclaiming create was admitted");
+        }
+
+        @Test
+        @DisplayName("Should still refuse a create at the bound when every stored session is live")
+        void shouldRefuseWhenBoundIsFullOfLiveSessions() {
+            InMemorySessionStore store = new InMemorySessionStore(2);
+            store.create(session("s1", "sub1", null, FUTURE), T0);
+            store.create(session("s2", "sub2", null, FUTURE), T0);
+
+            SessionRecord overflow = session("s3", "sub3", null, FUTURE);
+            assertThrows(IllegalStateException.class, () -> store.create(overflow, T0.plusSeconds(10)),
+                    "the at-capacity sweep reclaims nothing while every session is live, so the DoS"
+                            + " guard must still refuse — reclamation may not become a way around the bound");
+            assertEquals(2, store.size(), "the refused create left the store untouched");
+        }
+
+        @Test
+        @DisplayName("Should admit an upsert of an already-stored session id at the bound")
+        void shouldAdmitUpsertAtCapacity() {
+            InMemorySessionStore store = new InMemorySessionStore(2);
+            store.create(session("s1", "sub1", null, FUTURE), T0);
+            store.create(session("s2", "sub2", null, FUTURE), T0);
+
+            assertDoesNotThrow(() -> store.create(session("s1", "sub1", null, FUTURE), T0),
+                    "an upsert replaces a record already counted against the bound, so it consumes no"
+                            + " new capacity — this is the path a rotated session takes at a full store");
+            assertEquals(2, store.size(), "the upsert replaced in place rather than adding an entry");
         }
 
         @Test

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
@@ -177,17 +177,6 @@ class InMemorySessionStoreTest {
     class Capacity {
 
         @Test
-        @DisplayName("Should refuse a session created beyond the max-session bound")
-        void shouldEnforceMaxBound() {
-            InMemorySessionStore store = new InMemorySessionStore(2);
-            store.create(session("s1", "sub1", null, FUTURE), T0);
-            store.create(session("s2", "sub2", null, FUTURE), T0);
-
-            SessionRecord overflow = session("s3", "sub3", null, FUTURE);
-            assertThrows(IllegalStateException.class, () -> store.create(overflow, T0));
-        }
-
-        @Test
         @DisplayName("Should free capacity once expired sessions are swept")
         void shouldFreeCapacityAfterSweep() {
             InMemorySessionStore store = new InMemorySessionStore(2);

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
@@ -25,7 +25,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
@@ -36,6 +38,14 @@ import java.util.regex.Pattern;
 import de.cuioss.sheriff.gateway.asset.AssetResponseEnvelope;
 import de.cuioss.sheriff.gateway.config.model.SecurityProfile;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.SpecificationVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -67,10 +77,24 @@ import org.junit.jupiter.api.Test;
  * adjectives, so a sentence like "with minimal overhead" satisfies one while the mode it names has
  * no entry at all.
  * <p>
+ * <strong>Shipped exhibits round-trip through the bundled schema.</strong> The same drift problem has
+ * a second shape: a document may restate not a <em>set</em> but a whole <em>configuration example</em>
+ * an operator is invited to copy. Such an exhibit has no mechanical tie to the schema that governs
+ * the file it exemplifies, so a key the schema never declares reads as supported while the gateway
+ * refuses it at boot — the failure mode this guard was written for, where the shipped cookie-mode
+ * exhibits declared {@code oidc.session.max_cookie_size} against a schema whose
+ * {@code additionalProperties: false} rejected it. The two shipped exhibits are therefore validated
+ * against the bundled schema through the same {@code com.networknt} code path {@code ConfigLoader}
+ * boots with, and must produce zero errors.
+ * <p>
  * <strong>No vacuous pass.</strong> Every extraction is anchored on a literal sentence fragment held
  * in a named constant. When an anchor cannot be located, or locates an empty set, the test fails
  * naming both the document and the anchor rather than asserting over nothing. A guard that stops
  * matching after a rewrite must break loudly; one that quietly matches nothing is worse than absent.
+ * The exhibit guards carry the same discipline in two parts: each extracted exhibit must be non-empty
+ * and must still carry the budget key whose absence from the schema motivated the guard, and a
+ * negative control drives an undeclared {@code oidc.session} key through the identical code path to
+ * prove that path can still reject.
  *
  * @author API Sheriff Team
  * @since 1.0
@@ -83,6 +107,7 @@ class DocumentedSetsContractTest {
 
     private static final Path CONFIGURATION_ADOC = repoRoot().resolve("doc/configuration.adoc");
     private static final Path USER_README_ADOC = repoRoot().resolve("doc/user/README.adoc");
+    private static final Path BFF_COOKIE_ADOC = repoRoot().resolve("doc/user/bff-cookie.adoc");
 
     /** The bundled schema, read off the classpath so the assertion sees the shipped copy. */
     private static final String SCHEMA_RESOURCE = "/schema/gateway.schema.json";
@@ -110,6 +135,45 @@ class DocumentedSetsContractTest {
      * whose own line also carries a {@code #} comment containing the {@code |}-separated mode list.
      */
     private static final String CONFIG_PROFILE_ANCHOR = "profile: strict";
+
+    /**
+     * Anchor for the cookie-mode exhibit in {@code doc/user/bff-cookie.adoc} — the sentence that
+     * introduces it. The {@code [source,yaml]} block that follows is the fragment operators copy.
+     */
+    private static final String COOKIE_EXHIBIT_ANCHOR = "A minimal cookie-based configuration:";
+
+    /**
+     * Anchor for the annotated {@code gateway.yaml} skeleton in {@code doc/configuration.adoc} — the
+     * section heading it opens. Unlike the cookie exhibit this block is already a whole document.
+     */
+    private static final String SKELETON_ANCHOR = "== Gateway Configuration";
+
+    /** Opens an AsciiDoc YAML listing; the delimited block itself follows on the next line. */
+    private static final String YAML_BLOCK_OPEN = "[source,yaml]";
+
+    /** The AsciiDoc listing-block delimiter enclosing an exhibit's body. */
+    private static final String YAML_FENCE = "----";
+
+    /**
+     * The key whose absence from the bundled schema motivated these exhibit guards. Only the key is
+     * asserted, never its value: the numeric bounds are owned by {@code SealedSessionCookieCodec} and
+     * enforced by {@code ConfigValidator}, so restating a numeral here would create the third copy
+     * this plan exists to avoid.
+     */
+    private static final String COOKIE_BUDGET_KEY = "max_cookie_size:";
+
+    /**
+     * The single root key the bundled schema requires. The cookie exhibit is a fragment rooted at
+     * {@code oidc}, so it is wrapped with this line to become a document the schema can judge.
+     */
+    private static final String MINIMAL_DOCUMENT_ROOT = "version: 1\n";
+
+    /**
+     * Enables the validator's {@code errorMessage} extension, mirroring {@code ConfigLoader}'s
+     * registry configuration so these guards judge the exhibits through the boot code path rather
+     * than through a differently-configured validator of their own.
+     */
+    private static final String ERROR_MESSAGE_KEYWORD = "errorMessage";
 
     private static final Pattern BACKTICKED = Pattern.compile("`([^`]+)`");
 
@@ -214,6 +278,67 @@ class DocumentedSetsContractTest {
         }
     }
 
+    @Test
+    @DisplayName("doc/user/bff-cookie.adoc's cookie-mode exhibit validates against the bundled schema")
+    void cookieExhibitValidatesAgainstTheBundledSchema() throws Exception {
+        // Arrange — the exhibit is a fragment rooted at 'oidc', so it is wrapped into the minimal
+        // document the schema accepts; 'version' is the only key it requires at the root
+        String exhibit = yamlBlockAfter(read(BFF_COOKIE_ADOC), COOKIE_EXHIBIT_ANCHOR,
+                BFF_COOKIE_ADOC.toString());
+        assertCarriesBudgetKey(exhibit, BFF_COOKIE_ADOC.toString());
+
+        // Act
+        List<String> errors = validationErrors(MINIMAL_DOCUMENT_ROOT + exhibit, BFF_COOKIE_ADOC.toString());
+
+        // Assert
+        assertEquals(List.of(), errors, BFF_COOKIE_ADOC + " ships a cookie-mode configuration exhibit"
+                + " that the bundled gateway schema rejects. An operator copying it would have the"
+                + " boot refused, so either the exhibit or the schema is wrong — they are not allowed"
+                + " to disagree");
+    }
+
+    @Test
+    @DisplayName("doc/configuration.adoc's annotated gateway.yaml skeleton validates against the bundled schema")
+    void configurationSkeletonValidatesAgainstTheBundledSchema() throws Exception {
+        // Arrange — this exhibit already begins at 'version: 1', so it needs no wrapping
+        String skeleton = yamlBlockAfter(read(CONFIGURATION_ADOC), SKELETON_ANCHOR,
+                CONFIGURATION_ADOC.toString());
+        assertCarriesBudgetKey(skeleton, CONFIGURATION_ADOC.toString());
+
+        // Act
+        List<String> errors = validationErrors(skeleton, CONFIGURATION_ADOC.toString());
+
+        // Assert
+        assertEquals(List.of(), errors, CONFIGURATION_ADOC + " ships an annotated gateway.yaml skeleton"
+                + " that the bundled gateway schema rejects. The skeleton is the reference document"
+                + " every other example is derived from, so a key it declares must be a key the schema"
+                + " declares");
+    }
+
+    @Test
+    @DisplayName("the exhibit code path still rejects an undeclared key under oidc.session")
+    void undeclaredSessionKeyIsRejectedByTheSameCodePath() {
+        // Arrange — the negative control: the same shape as the exhibits above, with one key
+        // deliberately misspelled into a key the schema does not declare
+        String document = """
+                version: 1
+                oidc:
+                  session:
+                    mode: cookie
+                    max_cookie_sizes: 4096
+                """;
+
+        // Act
+        List<String> errors = validationErrors(document, "the oidc.session negative control");
+
+        // Assert
+        assertFalse(errors.isEmpty(), "the bundled gateway schema accepted 'max_cookie_sizes' under"
+                + " oidc.session, which it does not declare. The two exhibit guards above assert zero"
+                + " errors through this same code path, so without a demonstrated rejection they would"
+                + " pass just as happily against a schema that validates nothing at all. The"
+                + " oidc.session node sets additionalProperties: false and must refuse an undeclared key");
+    }
+
     // --- helpers ---------------------------------------------------------------------------------
 
     /**
@@ -256,6 +381,102 @@ class DocumentedSetsContractTest {
                 document + " states a count that no longer matches"
                         + " AssetResponseEnvelope.CONTENT_TYPES; the list and the stated count must move"
                         + " together");
+    }
+
+    /**
+     * The body of the first AsciiDoc {@code [source,yaml]} listing block following an anchor.
+     *
+     * @param document the document text
+     * @param anchor   the literal anchor fragment preceding the block
+     * @param label    the document label used in every failure message
+     * @return the block's body, without the enclosing delimiters
+     */
+    private static String yamlBlockAfter(String document, String anchor, String label) {
+        int from = anchorIndex(document, anchor, label);
+        int open = document.indexOf(YAML_BLOCK_OPEN, from);
+        if (open < 0) {
+            return fail(label + ": no " + YAML_BLOCK_OPEN + " listing follows the anchor \"" + anchor
+                    + "\"; the anchor no longer reaches the exhibit this guard protects");
+        }
+        int fence = document.indexOf(YAML_FENCE, open + YAML_BLOCK_OPEN.length());
+        if (fence < 0) {
+            return fail(label + ": the " + YAML_BLOCK_OPEN + " listing after the anchor \"" + anchor
+                    + "\" opens no '" + YAML_FENCE + "' delimited block");
+        }
+        int bodyStart = fence + YAML_FENCE.length();
+        int close = document.indexOf("\n" + YAML_FENCE, bodyStart);
+        if (close < 0) {
+            return fail(label + ": the exhibit opened after the anchor \"" + anchor + "\" is never"
+                    + " closed by '" + YAML_FENCE + "'; this guard would otherwise assert over the rest"
+                    + " of the file");
+        }
+        return document.substring(bodyStart, close);
+    }
+
+    /**
+     * Guards an extracted exhibit against passing vacuously: it must be non-empty, and it must still
+     * carry {@link #COOKIE_BUDGET_KEY} — the key whose omission from the bundled schema is precisely
+     * what these guards exist to catch. An exhibit that no longer declares it would validate cleanly
+     * against a schema that never declared it either, which is the silent pass this check refuses.
+     *
+     * @param exhibit  the extracted exhibit body
+     * @param document the document label used in every failure message
+     */
+    private static void assertCarriesBudgetKey(String exhibit, String document) {
+        assertFalse(exhibit.isBlank(), document + ": the extracted exhibit is empty, so validating it"
+                + " would assert nothing");
+        assertTrue(exhibit.contains(COOKIE_BUDGET_KEY), document + ": the extracted exhibit no longer"
+                + " declares '" + COOKIE_BUDGET_KEY + "'. That key is the one this guard was written"
+                + " for — without it the exhibit would validate against a schema that omits it too,"
+                + " and the drift this test protects against would go unnoticed");
+    }
+
+    /**
+     * Validates a YAML document against the bundled gateway schema through the same
+     * {@code com.networknt} path {@code ConfigLoader} uses at boot, including its
+     * {@code errorMessage} registry configuration.
+     * <p>
+     * The parsed tree is bridged to the validator through its own JSON rendering exactly as the
+     * loader does it, so these guards exercise the shipped behaviour rather than an approximation of
+     * it.
+     *
+     * @param yaml     the document to validate
+     * @param label    the document label used in every failure message
+     * @return the validation messages, empty when the document satisfies the schema
+     */
+    private static List<String> validationErrors(String yaml, String label) {
+        JsonNode tree;
+        try {
+            tree = new YAMLMapper().readTree(yaml);
+        } catch (IOException e) {
+            return fail(label + ": the exhibit is not parseable YAML, so the gateway could never load"
+                    + " it as written: " + e.getMessage());
+        }
+        List<String> messages = new ArrayList<>();
+        for (Error error : gatewaySchema().validate(tree.toString(), InputFormat.JSON)) {
+            messages.add(error.getInstanceLocation() + ": " + error.getMessage());
+        }
+        return messages;
+    }
+
+    /**
+     * The bundled gateway schema, compiled off the classpath so the assertion sees the shipped copy.
+     *
+     * @return the compiled schema
+     */
+    private static Schema gatewaySchema() {
+        SchemaRegistry registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.schemaRegistryConfig(SchemaRegistryConfig.builder()
+                        .errorMessageKeyword(ERROR_MESSAGE_KEYWORD)
+                        .build()));
+        try (InputStream in = DocumentedSetsContractTest.class.getResourceAsStream(SCHEMA_RESOURCE)) {
+            if (in == null) {
+                return fail("the bundled schema " + SCHEMA_RESOURCE + " is not on the test classpath");
+            }
+            return registry.getSchema(in);
+        } catch (IOException e) {
+            return fail("cannot read the bundled schema " + SCHEMA_RESOURCE + ": " + e.getMessage());
+        }
     }
 
     /**

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
@@ -163,6 +163,25 @@ class DocumentedSetsContractTest {
     private static final String COOKIE_BUDGET_KEY = "max_cookie_size:";
 
     /**
+     * The undeclared key the {@code oidc.session} negative control injects, and the JSON pointer the
+     * validator reports it against. Both must stay in step with the control's own document literal.
+     * <p>
+     * A rendered error is {@code "<instanceLocation>: <message>"}, and only these two parts are
+     * locale-stable: the message wording is emitted in the JVM's default locale (it reads
+     * {@code "Eigenschaft 'max_cookie_sizes' ist im Schema nicht definiert…"} on a German JVM), while
+     * the pointer and the key name interpolated into it are not translated. The control's predicate
+     * is therefore built from these alone — asserting any translated wording would make the guard
+     * fail on a machine whose locale merely differs.
+     * <p>
+     * The pointer names the {@code oidc.session} node rather than the key itself because that is
+     * where {@code additionalProperties: false} reports the violation.
+     */
+    private static final String INJECTED_SESSION_KEY = "max_cookie_sizes";
+
+    /** The JSON pointer the injected key's rejection is reported against; see {@link #INJECTED_SESSION_KEY}. */
+    private static final String INJECTED_SESSION_KEY_LOCATION = "/oidc/session";
+
+    /**
      * The single root key the bundled schema requires. The cookie exhibit is a fragment rooted at
      * {@code oidc}, so it is wrapped with this line to become a document the schema can judge.
      */
@@ -332,11 +351,18 @@ class DocumentedSetsContractTest {
         List<String> errors = validationErrors(document, "the oidc.session negative control");
 
         // Assert
-        assertFalse(errors.isEmpty(), "the bundled gateway schema accepted 'max_cookie_sizes' under"
-                + " oidc.session, which it does not declare. The two exhibit guards above assert zero"
-                + " errors through this same code path, so without a demonstrated rejection they would"
-                + " pass just as happily against a schema that validates nothing at all. The"
-                + " oidc.session node sets additionalProperties: false and must refuse an undeclared key");
+        assertTrue(errors.stream().anyMatch(error -> error.contains(INJECTED_SESSION_KEY_LOCATION)
+                        && error.contains(INJECTED_SESSION_KEY)),
+                "no reported error points at '" + INJECTED_SESSION_KEY + "' under "
+                        + INJECTED_SESSION_KEY_LOCATION + ", so the bundled gateway schema did not reject"
+                        + " the key it does not declare. The two exhibit guards above assert zero"
+                        + " errors through this same code path, so without a demonstrated rejection they would"
+                        + " pass just as happily against a schema that validates nothing at all. The"
+                        + " oidc.session node sets additionalProperties: false and must refuse an undeclared key."
+                        + " Asserting on the injected key rather than merely on a non-empty list is what keeps"
+                        + " this control honest: any unrelated schema error — a new required key at the root or"
+                        + " under oidc — would otherwise keep it green after it had stopped proving anything."
+                        + " Observed errors: " + errors);
     }
 
     // --- helpers ---------------------------------------------------------------------------------

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
@@ -330,7 +330,7 @@ class GatewayEdgeRouteBffWiringTest {
             SessionStore store = new InMemorySessionStore(16);
             String sessionId = SessionRecord.newSessionId();
             store.create(SessionRecord.builder().sessionId(sessionId).accessToken("a").idToken("i").sub("sub")
-                    .expiresAt(Instant.now().plus(Duration.ofHours(1))).build());
+                    .expiresAt(Instant.now().plus(Duration.ofHours(1))).build(), Instant.now());
             sessionCookie = SessionCookieCodec.DEFAULT_COOKIE_NAME + "=" + sessionId;
 
             GatewayConfig gatewayConfig = GatewayConfig.builder().version(1).oidc(fullOidc()).build();
@@ -449,7 +449,7 @@ class GatewayEdgeRouteBffWiringTest {
         void shouldDispatchLogin() {
             String sessionId = SessionRecord.newSessionId();
             store.create(SessionRecord.builder().sessionId(sessionId).accessToken("a").idToken("i").sub("sub")
-                    .expiresAt(now.plus(Duration.ofHours(1))).build());
+                    .expiresAt(now.plus(Duration.ofHours(1))).build(), now);
             String cookie = SessionCookieCodec.DEFAULT_COOKIE_NAME + "=" + sessionId;
             BffRuntime.ReservedHttpResponse response = runtime.dispatch(ReservedEndpoint.LOGIN,
                     new BffRuntime.ReservedHttpRequest("", cookie, null, "/home", null, null, "GET"), now);

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -311,7 +311,9 @@ oidc:                              # only used by the BFF variants (2 and 3)
     mode: cookie                   # cookie (Variant 3) | server (Variant 2)
     store: memory                  # REQUIRED for server mode; memory is the only initial option
     max_sessions: 10000            # server mode only: upper bound on concurrently stored
-                                   #   sessions -- a DoS guard on the in-memory store
+                                   #   sessions -- a DoS guard on the in-memory store. Reaching
+                                   #   the bound sweeps the expired sessions and admits the login
+                                   #   if that freed a slot; no scheduler or periodic sweep exists
     cookie_name: __Host-sheriff
     encryption_key: ${SHERIFF_SESSION_KEY}   # cookie mode only (AES-256-GCM); OPTIONAL -- omit to
                                    #   generate a key on startup (sessions die on restart)
@@ -1659,6 +1661,15 @@ ignored when no route's effective auth is `require: session`.
   denial-of-service guard on the in-memory store, so an unbounded stream of logins cannot exhaust
   node memory. Unused in `cookie` mode (there is no server-side store to bound). Optional; omit it
   to leave the store unbounded.
+
+  The bound counts *live* sessions, not accumulated ones. An expired session keeps its slot until
+  something reclaims it, and reaching the bound is that trigger: a login arriving at a full store
+  sweeps the sessions expired at that instant and is admitted if the sweep freed a slot. A store
+  still full afterwards is genuinely full of live sessions and the login is refused fail-closed.
+  Nothing schedules that sweep -- there is no scheduler, timer thread or periodic task, and no knob
+  configures one -- so size this against expected peak concurrency. Re-storing an id already held
+  (how a rotated session is persisted) consumes no new capacity and is admitted at the bound
+  without consulting it.
 
 | `session.cookie_name`
 | Cookie name; the `+__Host-+` prefix (implying `Secure`, `Path=/`, no `Domain`) is the default

--- a/doc/plan/07-bff-server-session.adoc
+++ b/doc/plan/07-bff-server-session.adoc
@@ -130,10 +130,11 @@ In-memory store keyed by opaque session id, holding access + refresh + raw ID to
 metadata (`expiry`, `acr`, `auth_time`, `sid`); secondary index by `sid`/`sub` for O(1)
 back-channel destruction (variant doc, Token Storage). `memory` is the only store --
 single-node / sticky-session deployments; a shared store is deliberately unsupported.
-TTL (`ttl_seconds`) is absolute from login; eviction is lazy on access plus a periodic
-sweep (no per-session timer threads), and the store carries a documented max-session bound
-(sessions are created only after a successful IdP login, but the ceiling still belongs in
-the operator's capacity math). Session cookie: `HttpOnly`, `Secure`, `SameSite=Lax`,
+TTL (`ttl_seconds`) is absolute from login; eviction is lazy on access plus an opportunistic
+sweep triggered at capacity (no per-session timer threads, no scheduler, no periodic sweep),
+and the store carries a documented max-session bound (sessions are created only after a
+successful IdP login, but the ceiling still belongs in the operator's capacity math).
+Session cookie: `HttpOnly`, `Secure`, `SameSite=Lax`,
 `__Host-` prefix, opaque id only.
 
 === D4 -- `require: session` runtime (stage 4)

--- a/doc/user/bff-session.adoc
+++ b/doc/user/bff-session.adoc
@@ -116,7 +116,9 @@ site. See link:../variants/02-bff-session.adoc#_csrf_defence[CSRF Defence].
 == Operate
 
 * *Sessions are in-memory.* A gateway restart drops all sessions and users re-authenticate. Size
-  `max_sessions` for expected concurrency; it caps memory against a login flood.
+  `max_sessions` for expected concurrency; it caps memory against a login flood. Expired sessions
+  release their slot when the bound is reached -- a login arriving at a full store sweeps the
+  expired entries first, so only genuinely live sessions hold the ceiling.
 * *Absolute TTL.* `ttl_seconds` is counted from login and is not extended by refresh; on expiry the
   user re-authenticates.
 * *IdP reachability.* Provider metadata is discovered lazily on first use, so the gateway boots

--- a/doc/variants/02-bff-session.adoc
+++ b/doc/variants/02-bff-session.adoc
@@ -274,10 +274,12 @@ What to watch on this variant specifically:
   introduced, which is why it is called out separately from the cookie work that precedes it.
 * *`max_sessions` is a DoS guard, and it interacts with load testing.* A run whose virtual users
   each establish a session can approach the configured ceiling; a benchmark that starts refusing
-  sessions is measuring the guard, not the gateway. Expired sessions do *not* free their slot on
-  their own -- reclamation happens only when that session's id is looked up again, and no periodic
-  sweep is scheduled -- so successive runs accumulate against the ceiling instead of draining back
-  to zero. Restart the gateway between runs rather than assuming the store empties itself.
+  sessions is measuring the guard, not the gateway. Expired sessions are reclaimed at the ceiling:
+  a login that finds the store at the bound sweeps the entries that have expired and is admitted if
+  that freed a slot, so successive runs no longer accumulate indefinitely. A ceiling genuinely full
+  of *live* sessions still refuses fail-closed, so a run that establishes sessions faster than
+  `ttl_seconds` retires them will still hit the guard. Restarting the gateway between runs remains
+  the cleanest way to start from a known-empty store.
 * *Refresh is a background cost.* With `refresh.enabled: true`, a long run crosses token expiry and
   pays a refresh round trip mid-measurement. On a 60s load phase against a typical token lifetime
   this does not trigger -- but it is the first thing to suspect in a longer run that shows an


### PR DESCRIPTION
## Summary

Closes two independent, currently-shipped defects on the `oidc.session` configuration surface before the 0.1.0 cut.

1. **Cookie mode is unconfigurable exactly as documented.** `gateway.schema.json`'s `/oidc/session` node sets `additionalProperties: false` and omits `max_cookie_size`, so every `gateway.yaml` that declares the documented key is hard-rejected before binding — even though `ConfigValidator` already implements and bounds it.
2. **`max_sessions` is not the memory guard it is presented as.** `InMemorySessionStore.create` refused admission on `byId.size() >= maxSessions` counting *expired* entries, and `sweepExpired` had no production caller — degrading the bound from a concurrency guard into a lifetime login ceiling.

## Changes

- `api-sheriff/src/main/resources/schema/gateway.schema.json` — declare `max_cookie_size` on `/oidc/session` as a **type-only** `integer` property, in the exact shape of its sibling `max_sessions`. The `40..8192` range and `4096` default live in the description prose, never as machine-enforced `minimum`/`maximum` keywords, so `ConfigValidator` stays the single bounds authority and the codec-derived numerals are not copied a third time.
- `api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java` — extend the existing documentation-vs-code contract test so the shipped cookie-mode and `oidc` exhibits round-trip through the bundled schema, with a negative control proving the guard is non-vacuous.
- `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionStore.java`, `InMemorySessionStore.java`, `ServerSessionBinding.java` — wire `sweepExpired` to exactly one trigger: an opportunistic sweep at the capacity bound, reached by threading the `now` instant that `ServerSessionBinding` already holds through `SessionStore.create`.
- `api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java` — regression coverage for the capacity/expiry interaction (fill to the bound, advance past expiry, assert a subsequent `create` succeeds), plus a live-session control that still fails if the guard were deleted rather than reclaimed.
- Call-site updates for the new `create` signature across `TokenRefreshCoordinatorTest.java`, `GatewayEdgeRouteBffWiringTest.java`, `AuthenticationStageTest.java`, `SessionAuthenticationStageTest.java`, `LogoutEndpointTest.java`, `LoginInitiationEndpointTest.java`, `UserInfoEndpointTest.java`.
- Documentation reconciliation from a whole-inventory content census — `README.adoc` (both `Known Limitations` entries and the "subject to the schema limitation above" qualifier removed), `doc/configuration.adoc`, `doc/user/bff-session.adoc`, `doc/variants/02-bff-session.adoc`, `doc/plan/07-bff-server-session.adoc`, and the javadoc in `api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java`. The two documents that contradicted each other on `max_sessions` sizing now agree: size for expected concurrency.

## Test Plan

- [x] Quality gate passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [x] Full verify passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`)
- [x] Both new guards were confirmed red on the pre-fix tree before the fixes landed

## Related Issues

None.

---
Generated by plan-finalize skill

## Intent

**Problem.** Two shipped defects on `oidc.session`. The schema's `/oidc/session` node is `additionalProperties: false` and omits `max_cookie_size`, so the documented cookie-mode key is hard-rejected before binding despite `ConfigValidator` already implementing it. Separately, the `max_sessions` capacity check counted expired entries and `sweepExpired` had no production caller, so the bound behaved as a lifetime login ceiling rather than the memory guard it is documented as.

**Approach.** Minimal and symmetric. The schema gains one **type-only** property mirroring its sibling `max_sessions`: the 40..8192 range and 4096 default stay in description prose, never as `minimum`/`maximum` keywords, so `ConfigValidator` remains the single bounds authority and the codec-derived numerals are not copied a third time. A contract test round-trips the shipped doc exhibits through the bundled schema so the gap cannot silently reopen. `sweepExpired` gets exactly one trigger — an opportunistic sweep at the capacity bound, using the `now` instant `ServerSessionBinding` already holds, threaded through `SessionStore.create`. A scheduled executor was rejected: it leaves a burst able to hit the bound between sweeps, and adds a native-image constraint.

**Non-goals.** `ConfigValidator` is unchanged and stays the bounds authority. `SealedSessionCookieCodec` is read for constants only. No

_[Intent truncated — 1386 of 1594 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring `oidc.session.max_cookie_size`.
  * Session capacity now automatically reclaims expired sessions when new logins require space.
  * Existing sessions can be updated at capacity without consuming additional capacity.

* **Bug Fixes**
  * New logins fail closed only when all available slots contain active sessions.

* **Documentation**
  * Clarified session expiration, capacity limits, cookie mode, server-mode behavior, and opportunistic cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->