### PR TITLE
ci(release): re-arm the merge trigger behind the central guard

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -64,8 +64,8 @@ Consequently:
 
 | job | publishes |
 |---|---|
-| `release` (`release.yml:16-26`) — `uses: reusable-maven-release.yml` | Maven artifacts to Maven Central; the SCM tag; the GitHub release |
-| `publish-image` (`release.yml:45-365`) — local, `needs: [release]` | the container image to GHCR at the **same** version, plus an SPDX SBOM and a Cosign signature |
+| `release` (job `release` in `release.yml`) — `uses: reusable-maven-release.yml` | Maven artifacts to Maven Central; the SCM tag; the GitHub release |
+| `publish-image` (job `publish-image` in `release.yml`) — local, `needs: [release]` | the container image to GHCR at the **same** version, plus an SPDX SBOM and a Cosign signature |
 
 ---
 
@@ -83,7 +83,7 @@ the Maven version must be able to derive the image reference without a mapping t
 **This is a checked fact rather than a convention.** The `publish-image` job checks out the release
 tag the Maven release pushed, reads `current-version` from `.github/project.yml` with the same pinned
 action the release job used, and asserts the checked-out `project.version` equals it
-(`release.yml:125-134`). A mismatch fails the release **before the image is built or pushed to
+(step `Assert the checked-out project version matches the released version`). A mismatch fails the release **before the image is built or pushed to
 GHCR**.
 
 ### The release is NOT atomic
@@ -206,7 +206,8 @@ before the cut). `maven-release-plugin` owns the `X.Y.Z-SNAPSHOT` → `X.Y.Z` tr
 `release:prepare`.
 
 > **Do NOT hand-edit `project.version` in `pom.xml`.** It would collide with the release plugin and
-> break the version-identity assertion at `release.yml:125-134`.
+> break the version-identity assertion in the `Assert the checked-out project version matches the
+> released version` step.
 
 **If `current-version` is already the version you intend to release, there is nothing to change** —
 skip to Step 2. (This is the case for the `0.1.0` cut: `.github/project.yml` already declares
@@ -321,7 +322,7 @@ Then **`Read` every listed file** and confirm exactly one invokes `reusable-mave
 > **A CONTENT SEARCH IS NOT VALID EVIDENCE HERE.** The architecture inventory does not walk
 > `.github/**`. `architecture search --content --literal --pattern "reusable-maven-release.yml"`
 > returns `count: 0` with `files_scanned: 934`, **no unreadable entries and no elision** — a
-> clean-looking zero — **while the string is present at `release.yml:19`.** That zero is a
+> clean-looking zero — **while the string is present in `release.yml`'s `release` job.** That zero is a
 > **coverage gap, never an absence.** Use direct `Read` enumeration, always.
 
 **(iii) Confirm the merge queue is quiesced and `main` is settled — IMMEDIATELY before dispatching.**
@@ -440,10 +441,11 @@ run the two guarded commands above first and dispatch immediately after.)
 
 > **Why `--ref main` and not `--ref "$MAIN_SHA"`.** Dispatching at the gated SHA looks like the
 > tighter fix, and it is the wrong one here — for three independent reasons:
-> 1. **The signature identity is bound to `refs/heads/main`.** Step 8 verifies the Cosign signature
->    against `--certificate-identity …/release.yml@refs/heads/main`. That value is the OIDC
->    `job_workflow_ref` of the `publish-image` job, so it changes with the dispatch ref. A dispatch
->    at a SHA produces a certificate this runbook's own verification would reject.
+> 1. **The signature identity is bound to the ref, and the accepted set is closed.** Step 8 verifies
+>    the Cosign signature against a pattern accepting exactly `refs/heads/main` and
+>    `refs/pull/<N>/merge`. That value is the OIDC `job_workflow_ref` of the `publish-image` job, so
+>    it changes with the dispatch ref. A dispatch at a SHA is in neither branch of the pattern, so it
+>    produces a certificate this runbook's own verification would reject.
 > 2. **The release force-pushes to a branch.** `maven-release-plugin` commits the version transition
 >    and the workflow force-pushes it to `main`; a dispatch at a detached SHA has no branch to push.
 > 3. **`ref` is documented as a branch or tag name.** The workflow-dispatch API documents exactly
@@ -597,19 +599,32 @@ docker image inspect "$IMAGE@$VERSION_DIGEST" \
   --format '{{index .Config.Labels "org.opencontainers.image.version"}}'
 ```
 
-The label must equal `<version>`. The workflow already asserts the same-digest property at
-`release.yml:246-258`; the commands above are the **independent** confirmation, which is the whole
-point of this step — a check that only re-reads the workflow's own claim confirms nothing.
+The label must equal `<version>`. The workflow already asserts the same-digest property in its
+`Resolve the pushed manifest digest` step; the commands above are the **independent** confirmation,
+which is the whole point of this step — a check that only re-reads the workflow's own claim confirms
+nothing.
 
 Verify the Cosign signature **against that resolved digest**, using **exactly** these two identity
-values (they are derived from the `publish-image` job's identity and change silently if the workflow
-file is renamed or the release is dispatched from a ref other than `main`):
+values. They are derived from the `publish-image` job's OIDC identity, which embeds the ref the run
+was triggered from — so the accepted set is a pattern over the **two** refs a release can legitimately
+come from, not a single literal:
 
 ```bash
 cosign verify "$IMAGE@$VERSION_DIGEST" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main
+  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$'
 ```
+
+`refs/heads/main` is a `workflow_dispatch` release; `refs/pull/<N>/merge` is a merge-triggered one
+(a `pull_request` run's `GITHUB_REF` is the merge ref, and that path is legitimate because the central
+version-changed guard plus `merged == true` already decided it was a release). The pattern stays
+anchored at both ends and bound to this repository and this workflow file — **do not** relax it to a
+wildcard. The workflow runs this same command against every digest it signs, so a failure here is a
+real supply-chain signal, not a stale expectation.
+
+**Three files carry this pattern** — `.github/workflows/release.yml` (the `publish-image` verify
+step), `doc/user/container-image.adoc` (the operator-facing command), and this runbook. Nothing
+mechanical keeps them in sync; changing one means changing all three.
 
 > **Ignore the benchmark run this triggers.** `.github/workflows/benchmark.yml` fires on
 > `push: tags: ["*"]`, so the release's tag push **starts a benchmark run**. That run belongs to the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,14 @@ on:
   # pages and github-automation, and that list is open — a key added tomorrow matches too. So a merge
   # arriving here proves nothing about the version. The central guard is what decides; this only
   # keeps unrelated merges out.
+  # `branches:` filters on the PR's BASE, so only a PR merging INTO main can reach the release job at
+  # all. Without it a merge into any long-lived branch that touched .github/project.yml would enter
+  # this workflow and be decided solely by the central guard's parent comparison against THAT
+  # branch — a release cut from a non-main line. This is a base filter, not the version
+  # discriminator; it narrows what may ask, never what is answered.
   pull_request:
     types: [closed]
+    branches: [main]
     paths: ['.github/project.yml']
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,11 @@ name: Release
 # rather than restating it here.
 on:
   workflow_dispatch:
-  # PREFILTER ONLY, NEVER THE DECISION. Every non-release key in .github/project.yml (maven-build,
-  # sonar, pages, github-automation) matches this path too, so a merge arriving here proves nothing
-  # about the version. The central guard is what decides; this only keeps unrelated merges out.
+  # PREFILTER ONLY, NEVER THE DECISION. This path matches EVERY edit to .github/project.yml, not just
+  # a version bump: the file's non-release keys today include name, description, maven-build, sonar,
+  # pages and github-automation, and that list is open — a key added tomorrow matches too. So a merge
+  # arriving here proves nothing about the version. The central guard is what decides; this only
+  # keeps unrelated merges out.
   pull_request:
     types: [closed]
     paths: ['.github/project.yml']
@@ -381,16 +383,33 @@ jobs:
       # the registry alongside the image (the Sigstore sha256-<digest>.sig convention); there is no
       # key store, no COSIGN_PRIVATE_KEY and no new secret. `id-token: write` is declared on this job.
       #
-      # A CONSUMER VERIFIES WITH EXACTLY THESE TWO VALUES. Both are derived from THIS job's identity
-      # and will change silently if this workflow file is renamed or a release is dispatched from a
-      # ref other than main:
+      # A CONSUMER VERIFIES WITH EXACTLY THESE TWO VALUES:
       #
-      #   --certificate-oidc-issuer https://token.actions.githubusercontent.com
-      #   --certificate-identity    https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main
+      #   --certificate-oidc-issuer      https://token.actions.githubusercontent.com
+      #   --certificate-identity-regexp  ^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$
       #
-      # The identity names release.yml ITSELF, not the org reusable workflow, because publish-image
-      # is a local job in this caller. doc/user/container-image.adoc publishes the same two strings
-      # to operators; this comment is what keeps the two copies from drifting.
+      # THE IDENTITY HAS TWO LEGITIMATE REFS, NOT ONE. Fulcio puts the OIDC `job_workflow_ref` claim
+      # in the certificate SAN. publish-image is a CALLER-LOCAL job — it does not `uses:` a reusable
+      # workflow — so that claim names release.yml ITSELF (never the org reusable workflow) at the ref
+      # the run was triggered on, i.e. GITHUB_REF. This lane has two release paths and they carry
+      # different refs:
+      #
+      #   * workflow_dispatch from main  -> GITHUB_REF = refs/heads/main
+      #   * merge of a .github/project.yml PR -> GITHUB_REF = refs/pull/<N>/merge
+      #
+      # The merge ref is a FIRST-CLASS release path, not an anomaly to be excluded: the org
+      # version-changed guard plus `merged == true` already decided that this merge is a real release
+      # (see the trigger comment at the top of this file), and this job only runs when
+      # needs.release.outputs.released-version is non-empty. Pinning the accepted identity to
+      # @refs/heads/main alone would therefore reject the signature of a perfectly legitimate release.
+      #
+      # The regexp is TIGHTLY ANCHORED, not a wildcard: anchored at both ends, bound to this exact
+      # repository and this exact workflow file, and the PR number is digits-only. It admits exactly
+      # the two refs above and nothing else. Do NOT relax it to a `.*` — a loose identity would accept
+      # a signature from any workflow in any repository and the check would prove nothing.
+      #
+      # doc/user/container-image.adoc publishes the same two strings to operators, and the verify step
+      # below RUNS them — the lane proves its own signing identity rather than asserting it in prose.
       #
       # SLSA provenance and any further attestation are deliberately out of scope.
       - name: Sign the published digest (keyless)
@@ -398,6 +417,42 @@ jobs:
           DIGEST: ${{ steps.digest.outputs.value }}
         run: |
           cosign sign --yes "ghcr.io/cuioss/api-sheriff@${DIGEST}"
+
+      # PROVE WHAT WAS JUST SIGNED. This is the step whose absence let the identity drift ship: the
+      # lane signed, went green, and NOTHING ever asserted that the signature it had just produced was
+      # acceptable to the verification command this project publishes. A release that signs under an
+      # identity no operator command accepts is a supply-chain break that stays invisible until a
+      # consumer hits it.
+      #
+      # So this step runs EXACTLY the two values doc/user/container-image.adoc gives operators,
+      # against the digest just signed. If an operator's verification would fail, this job fails
+      # first — before the release is called done.
+      #
+      # The bounded retry covers Rekor/Fulcio propagation ONLY. A wrong identity fails identically on
+      # every attempt, so the retry cannot launder one into a pass; it just delays the loud failure by
+      # under a minute.
+      - name: Verify the signature under the published identity
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+          IDENTITY_REGEXP: '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$'
+        run: |
+          set -euo pipefail
+          REF="ghcr.io/cuioss/api-sheriff@${DIGEST}"
+          for attempt in 1 2 3 4 5; do
+            if cosign verify \
+              --certificate-identity-regexp "$IDENTITY_REGEXP" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "$REF"; then
+              echo "Signature verified under the published operator identity."
+              exit 0
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "Verification attempt ${attempt} failed; retrying in 10s (signature propagation)."
+              sleep 10
+            fi
+          done
+          echo "::error::cosign verify failed for ${REF} using the identity published in doc/user/container-image.adoc. The lane signed under an identity operators cannot verify — treat this as a supply-chain failure, not a flake."
+          exit 1
 
       # `|| true` is a deliberate guard, not sloppiness: this step runs on EVERY outcome, including
       # the paths where the smoke step failed before `docker run` and there is nothing to remove.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,7 +438,8 @@ jobs:
         run: |
           set -euo pipefail
           REF="ghcr.io/cuioss/api-sheriff@${DIGEST}"
-          for attempt in 1 2 3 4 5; do
+          ATTEMPTS=5
+          for attempt in $(seq 1 "$ATTEMPTS"); do
             if cosign verify \
               --certificate-identity-regexp "$IDENTITY_REGEXP" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
@@ -446,7 +447,7 @@ jobs:
               echo "Signature verified under the published operator identity."
               exit 0
             fi
-            if [ "$attempt" -lt 5 ]; then
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
               echo "Verification attempt ${attempt} failed; retrying in 10s (signature propagation)."
               sleep 10
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,45 @@
 # Configuration is read from .github/project.yml - no inputs needed!
 name: Release
 
-# Manual dispatch only. The former `pull_request: {types: [closed], paths: ['.github/project.yml']}`
-# trigger fired a real Maven Central release on 2026-07-12, accidentally publishing
-# de.cuioss.sheriff.api:*:1.0.0 when a PR touching .github/project.yml was merged.
-# Releases are now cut deliberately via workflow_dispatch — do not reintroduce an
-# event-driven trigger.
+# A merge can cut a release again — because the DECISION moved, not because the trigger was
+# forgiven.
+#
+# THE INCIDENT THIS TRIGGER CAUSED ONCE. On 2026-07-12 a `pull_request: {types: [closed], paths:
+# ['.github/project.yml']}` trigger of exactly this shape fired a real Maven Central release: merging
+# a PR that touched .github/project.yml published de.cuioss.sheriff.api:*:1.0.0. Maven Central
+# artifacts are superseded, never withdrawn, so that version was abandoned, relocation-stubbed at
+# 1.0.1, the coordinates moved to de.cuioss.sheriff.gateway, and the version line restarted.
+#
+# WHAT HAD TO BE TRUE BEFORE IT COULD RETURN. That trigger fired on MERGED-NESS — every merge
+# touching the file was a publication. The pinned cuioss-organization workflow below now owns a
+# version-changed guard, so the release is decided CENTRALLY, on whether the declared version
+# actually changed. That is precisely the discrimination the 2026-07-12 trigger lacked, and it is
+# consumed here, never re-implemented locally.
+#
+# The decision itself is recorded in ADR-0035 (doc/adr/), which supersedes ADR-0034 — read it there
+# rather than restating it here.
 on:
   workflow_dispatch:
+  # PREFILTER ONLY, NEVER THE DECISION. Every non-release key in .github/project.yml (maven-build,
+  # sonar, pages, github-automation) matches this path too, so a merge arriving here proves nothing
+  # about the version. The central guard is what decides; this only keeps unrelated merges out.
+  pull_request:
+    types: [closed]
+    paths: ['.github/project.yml']
 
 permissions:
   contents: read
 
 jobs:
   release:
+    # ANDed with the central version-changed guard inside the called workflow, NEVER an alternative
+    # to it. Its merit is defence-in-depth plus not spending a runner on a close-without-merge — it
+    # is NOT here because the central guard is blind to merged-ness; that guard checks merged-ness
+    # too.
+    # Written event-first so the dispatch path still runs: on workflow_dispatch there is no
+    # pull_request context, so the first operand is true and the condition short-circuits. This is
+    # the same shape .github/workflows/benchmark.yml already ships.
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       contents: write
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@937fbcf44d34d826b3bcd66d49d7a7d32030f39a # v0.18.0
@@ -27,16 +53,32 @@ jobs:
 
   # Publishes the container image at the SAME version the Maven release just cut.
   #
-  # COMPOSABILITY CAVEAT — read before "simplifying" the version lookup below.
-  # A caller workflow may hang a dependent sibling job off a `uses:` job; that part is ordinary
-  # GitHub Actions. But reusable-maven-release.yml@15376a19 declares NO `on.workflow_call.outputs`
-  # block — its `released-version` is a job-level output on the called workflow's own internal job
-  # and is therefore NOT readable by us. `needs.release.outputs.released-version` evaluates to the
-  # EMPTY STRING, which would tag and push `ghcr.io/cuioss/api-sheriff:` — a malformed reference, or
-  # worse, a silently mislabelled image. That is why the version is re-read from .github/project.yml
-  # with the same pinned action the release job used. Do not replace it with a `needs.` expression.
+  # WHY `needs.release.outputs.released-version != ''` IS THE RUN/SKIP DISCRIMINATOR.
+  # At the pinned 937fbcf (v0.18.0) the reusable workflow DOES declare an `on.workflow_call.outputs`
+  # block, so `released-version` is genuinely readable here. It is EMPTY exactly when the central
+  # guard decided the declared version had not changed and skipped the release — so the empty string
+  # IS that guard's own decision, surfaced. The caller consumes it and derives nothing. Without this
+  # `if:`, a guard-skipped merge would still spend 90 minutes on a native build and then re-push and
+  # re-sign an already-released tag.
   #
-  # The org workflow is NOT forked and the dispatch-only guarantee is NOT weakened by this job.
+  # The two obvious alternatives are both wrong. `needs.release.result` reports a non-failure for a
+  # called workflow whose internal jobs all skipped, so it cannot tell a real release from a skipped
+  # one. Re-deriving "the version changed" in this caller would re-implement centrally-owned logic —
+  # the thing this design exists to avoid.
+  #
+  # SCOPE SPLIT — two separate questions, two separate answers. Do not merge them.
+  #   * `needs.release.outputs.released-version` decides WHETHER this job runs (run/skip).
+  #   * `steps.config.outputs.current-version` supplies THE VALUE PUBLISHED. It comes from the
+  #     sparse checkout + `read-project-config` steps below, which are DELIBERATELY RETAINED rather
+  #     than replaced by a `needs.` expression — the retention rests on keeping this lane's version
+  #     lookup independent of the release job's output plumbing, not on that output being
+  #     unavailable. It is not a leftover of the retired caveat.
+  # Consuming the output for run/skip while retaining the re-read for the value is consistent, not
+  # contradictory. Collapsing the two would delete this job's guard discriminator and re-open the
+  # 90-minute no-op publish lane.
+  #
+  # The org workflow is NOT forked, and this job now runs only when the central guard let a release
+  # through.
   #
   # LATENCY NOTE — `needs: [release]` waits for the whole called workflow, including its
   # wait-for-maven-central (30-minute timeout) and propagate-to-consumers jobs. Both are `if:`-gated
@@ -45,6 +87,7 @@ jobs:
   publish-image:
     name: Publish the tested image to GHCR
     needs: [release]
+    if: needs.release.outputs.released-version != ''
     runs-on: ubuntu-latest
     # The native compile inside the integration-test lifecycle is the dominant term; the scan, push
     # and smoke together are minutes.

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -189,7 +189,7 @@ DIGEST="$(docker image inspect \
 [ "$(printf '%s\n' "$DIGEST" | grep -c .)" -eq 1 ] || { echo "expected exactly one digest, got: $DIGEST"; exit 1; }
 
 cosign verify \
-  --certificate-identity https://github.com/cuioss/API-Sheriff/.github/workflows/release.yml@refs/heads/main \
+  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   "${DIGEST}"
 ----
@@ -200,9 +200,9 @@ the same string.
 
 Both flags are mandatory, and each pins a different half of the claim:
 
-`--certificate-identity`::
-*Who* signed it -- the exact workflow, in the exact repository, on the exact ref. It is what binds
-the check to this project's release lane rather than to any workflow anywhere.
+`--certificate-identity-regexp`::
+*Who* signed it -- the exact workflow, in the exact repository, on one of exactly two accepted refs.
+It is what binds the check to this project's release lane rather than to any workflow anywhere.
 
 `--certificate-oidc-issuer`::
 *Which identity provider* vouched for that identity. It is what stops the same identity string,
@@ -226,6 +226,27 @@ The following checks were performed on each of these signatures:
 
 *A non-zero exit means the artifact must not be deployed.* Treat it as a supply-chain failure, not
 as a tooling problem to work around.
+
+=== Why the identity is a pattern, and why it is still exact
+
+The signing identity is the release workflow's ref, and this project cuts releases from two paths: a
+deliberate dispatch from `main`, and the merge of a version-changing `.github/project.yml` pull
+request. GitHub stamps the certificate with the ref the run was triggered on, so the first path signs
+under `@refs/heads/main` and the second under `@refs/pull/<number>/merge`. Both are legitimate
+releases -- the merge path only reaches the publishing job after the central version-changed guard
+has confirmed the declared version actually moved.
+
+*The pattern admits those two refs and nothing else.* It is anchored at both ends, so it matches the
+whole identity rather than appearing somewhere inside a longer one; it names this repository and this
+workflow file literally; and the pull-request number is digits-only. A signature from any other
+workflow, any other repository, or any other ref fails the check.
+
+Do not relax it to a wildcard. An identity pattern that accepts anything accepts a signature from any
+workflow in any repository, which turns the verification into a formality that always passes.
+
+*The release lane runs this exact command against every digest it signs, and fails the release if it
+does not verify.* The values above are not a transcription of what the workflow is believed to do --
+they are what it proves before calling a release complete.
 
 == See also
 


### PR DESCRIPTION
## Summary

Re-arms the merge-triggered release path in `.github/workflows/release.yml` —
`on: pull_request: {types: [closed], paths: ['.github/project.yml']}` restored alongside the existing
`workflow_dispatch` — with the version-changed decision **consumed** from the central
`cuioss-organization` guard and never re-implemented locally.

The trigger of exactly this shape caused the 2026-07-12 incident (merging a `.github/project.yml` PR
published `de.cuioss.sheriff.api:*:1.0.0` to Maven Central). What changed is not the trigger's
forgiveness but the location of the **decision**: the pinned org workflow now owns a version-changed
guard, so a merge that moves `release.current-version` publishes and a merge that touches anything
else does not.

## What this ships

**Both jobs are guarded, and the two guards are ANDed — never alternatives.**

- `release` carries `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true`.
  Written event-first so the dispatch path still runs (on `workflow_dispatch` there is no
  `pull_request` context, so the first operand short-circuits). Its merit is defence-in-depth plus not
  spending a runner on a close-without-merge — `types: [closed]` fires on close-without-merge too.
- The caller-local `publish-image` carries `if: needs.release.outputs.released-version != ''`. That
  output is empty exactly when the central guard decided the version had not changed, so the empty
  string **is** the guard's own decision surfaced to the caller. Without it, a guard-skipped merge
  would still spend 90 minutes on a native build and then re-push and re-sign the GHCR tags of an
  already-released version.

`paths: ['.github/project.yml']` is a **prefilter only, never the decision** — every non-release key
in that file (`maven-build`, `sonar`, `pages`, `github-automation`, …) matches it too, and that list
is open.

**No pin bump was needed.** The plan's premise that one was required was retired at outline: the
already-pinned `937fbcf` (v0.18.0) carries the guard, with `fetch-depth: 0`, event-awareness,
merged-ness detection, and the `released-version` output. The two obvious caller-side alternatives
were both rejected and the rejection is recorded in the file: `needs.release.result` reports a
non-failure for a called workflow whose internal jobs all skipped, and re-deriving "the version
changed" locally is exactly the re-implementation this design exists to avoid.

## The Cosign change, and why it belongs in this PR

Re-arming the trigger changes **the ref a release can run from**, which changes the OIDC-derived
Cosign certificate identity. A `pull_request` run's `GITHUB_REF` is `refs/pull/<N>/merge`, not
`refs/heads/main`, and `publish-image` is a caller-local job so the `job_workflow_ref` claim names
`release.yml` itself at that ref. Pinning the accepted identity to `@refs/heads/main` alone would
reject the signature of a perfectly legitimate merge-triggered release — so the identity change is a
direct consequence of the trigger change, not a drive-by.

Two things follow:

1. **The lane now verifies its own signing identity.** It previously asserted the accepted identity
   only in a comment; nothing ever checked that the signature it had just produced was acceptable to
   the command this project publishes to operators. A new `cosign verify` step runs exactly those two
   published values against the digest just signed, so an identity drift fails the release instead of
   shipping invisibly until a consumer hits it. Its bounded retry covers Rekor/Fulcio propagation
   only — a wrong identity fails identically on every attempt, so the retry cannot launder one into a
   pass.
2. **The accepted identity is an anchored regexp over the two legitimate release refs**, not a
   wildcard: anchored at both ends, bound to this exact repository and this exact workflow file, with
   a digits-only PR number.

   ```
   ^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$
   ```

Three files carry that pattern and are kept in step here: `.github/workflows/release.yml` (the
verify step), `doc/user/container-image.adoc` (the operator-facing command), and
`.claude/skills/release/SKILL.md` (the release runbook's own Step 8 verify gate). Nothing mechanical
keeps them in sync, which is why they move together.

## This PR merges alone, and the docs deliberately lag — PR 2 follows immediately

This is **PR 1 of three**, by the project's own standing rule that a change altering an event-driven
trigger merges by itself carrying no other change.

The following still describe the dispatch-only posture and are **known, tracked, transient** — they
are PR 2, not an oversight:

- `doc/development/release-process.adoc` — § "Why the `pull_request` trigger was removed" and § "Why
  the guard had to merge before anything else".
- `doc/adr/` — ADR-0034 is to be superseded by a new ADR-0035. `release.yml`'s new header comment
  already forward-references ADR-0035; that reference is dangling until PR 2 lands.
- `.claude/skills/release/SKILL.md` — Step 3(i)'s assertion about the `on:` block (the runbook's
  Cosign-identity content **is** updated here, because it is part of the identity change above).
- `doc/development/README.adoc` — its dispatch-only statement.

PR 3 is D2's empirical control pair: after this merges, a **non-release** `.github/project.yml` edit
is merged and both jobs must render skipped (observing only `release` would be a vacuous assertion
that passes while `publish-image` fires); the matched positive control is the next real release,
observed rather than manufactured.

## Merging this PR cannot fire the new trigger

For a `pull_request` event GitHub evaluates the workflow **from the base branch**, which does not yet
carry the trigger — and this PR touches no path the new `paths:` filter watches. The exposure begins
with the **next** `.github/project.yml`-touching merge, not with this one.

## Deliverable D2 — the enumeration below is its complete and only artifact

> Reproduced **verbatim**, deliberately not as a repo-tracked document: an enumeration produced after
> the merge would not be late, it would be lost, so this PR body carries it. It was read at commit
> `8cc87f4`. The three later commits on this branch (`a36fbc9`, `89924f1`, `fb00fda`) touch only the
> Cosign signing/verification lane and the runbook — they change no trigger and no
> `cuioss-organization` reference — so the enumeration stands unmodified at the current head
> `fb00fda`.

## Release blast-radius enumeration

Read directly, file by file, at a named commit — because a claim that names no commit is
unverifiable later.

- **Commit read:** `8cc87f469085fa6507e8affe7f284980d20a0b64` (head of `feature/plan-48-guarded-release-trigger`, i.e. **this PR's head, after the `release.yml` edit and before any merge**).
- **Method:** `git ls-files .github/workflows` returned **exactly 10** files; each of the 10 was then opened with a direct read. A content search was deliberately **not** used as evidence: the architecture inventory does not walk `.github/**` and returns a clean-looking `count: 0` with no unreadable and no elided entries — a coverage gap that reads exactly like an absence.
- **Scope honesty:** every statement below is read from this PR's head commit. **No post-merge behaviour is claimed here.**

### All 10 tracked workflows

| # | Workflow | `on:` triggers | `cuioss/cuioss-organization` reference | Can it reach a release? |
|---|----------|----------------|----------------------------------------|-------------------------|
| 1 | `benchmark.yml` | `pull_request` (branches `[main]`, types `[closed]`), `push` (tags `["*"]`), `workflow_dispatch` | none | **No** |
| 2 | `claude.yml` | `issue_comment` `[created]`, `pull_request_review_comment` `[created]`, `issues` `[opened, assigned]`, `pull_request_review` `[submitted]` | none | **No** |
| 3 | `demo-client-e2e.yml` | `push` (branches `[main]`), `workflow_dispatch` | none | **No** |
| 4 | `dependabot-auto-merge.yml` | `pull_request` | `reusable-dependabot-auto-merge.yml@937fbcf` | **No** |
| 5 | `dependency-review.yml` | `pull_request` (branches `[main]`) | `reusable-dependency-review.yml@937fbcf` | **No** |
| 6 | `integration-tests.yml` | `push` `[main]`, `pull_request` `[main]`, `merge_group`, `workflow_dispatch` | `reusable-maven-integration-tests.yml@937fbcf` | **No** |
| 7 | `maven.yml` | `push` (branches `[main, feature/*, fix/*, chore/*, release/*, dependabot/**]`), `pull_request` `[main]`, `merge_group`, `workflow_dispatch` | `reusable-maven-build.yml@937fbcf` | **No** — see note A |
| 8 | `pr-agent.yml` | `pull_request` `[opened, reopened, ready_for_review]`, `issue_comment` `[created]` | `reusable-pr-agent-review.yml@937fbcf` | **No** |
| 9 | `release.yml` | `workflow_dispatch`, `pull_request` (types `[closed]`, paths `['.github/project.yml']`) | `reusable-maven-release.yml@937fbcf` (line 45) and `actions/read-project-config@937fbcf` (line 126) | **YES — the only one** |
| 10 | `scorecards.yml` | `branch_protection_rule`, `schedule` (cron `20 7 * * 2`), `push` (branches `[main]`) | `reusable-scorecards.yml@937fbcf` | **No** |

All ten are accounted for; none omitted, none inferred from a search.

### `reusable-maven-release.yml` is invoked from exactly one workflow

`release.yml` line 45, and nowhere else in the tree. The nine other workflows either reference no
`cuioss-organization` workflow at all or reference a build, review, scan or auto-merge one. (This
line was `release.yml:19` before this PR; the header-comment rewrite in D1 moved it to line 45. The
line number above is read from this PR's head, not restated from the pre-change file.)

### Paths to a release: **one before this PR, two after**

| | Before this PR | After this PR |
|---|---|---|
| `workflow_dispatch` | ✅ cuts a release, unconditionally | ✅ unchanged — still cuts a release unconditionally, including a re-release of an unchanged version |
| `pull_request` `[closed]` on `.github/project.yml` | ❌ absent | ✅ cuts a release **only when the central pinned guard decides the declared version changed** |
| **Total paths to a release** | **1** | **2** |

The second path is guarded twice over, and neither guard is a local re-implementation of the other:

- **Caller-side, in this file:** job `release` carries
  `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true`, so a PR
  **closed without merging** starts no release job at all. This is ANDed with the central guard —
  defence-in-depth plus not spending a runner — never an alternative to it.
- **Centrally, in the pinned org workflow:** the version-changed decision lives in
  `reusable-maven-release.yml@937fbcf` (v0.18.0) and is consumed here, never re-derived. Job
  `publish-image` keys off its observable effect —
  `if: needs.release.outputs.released-version != ''` — so a guard-skipped run renders **skipped**
  rather than spending 90 minutes on a native build and then re-pushing and re-signing an
  already-released tag.

`paths: ['.github/project.yml']` is a **prefilter only, never the decision**: every non-release key
in that file (`maven-build`, `sonar`, `pages`, `github-automation`) matches it too.

### Two lanes that look release-adjacent and are not

- **Note A — `maven.yml`'s `push: [main]` lane deploys a SNAPSHOT, not a release.** It runs on every
  push to `main` and publishes a snapshot through `reusable-maven-build.yml`. A snapshot deployment
  is not a GA publication and reaches no release coordinate, so this lane is **not** a path to a
  release. It is named here explicitly so its absence from the release count reads as a known
  boundary rather than an oversight.
- **`benchmark.yml`'s tag lane is not a release either.** It triggers on `push: tags: ["*"]` and on
  merged PRs, and it publishes benchmark results to `cuioss.github.io`. It consumes tags; it never
  creates a release.

### What this enumeration does and does not establish

It establishes, by direct reading at commit `8cc87f4`, that exactly one workflow can reach a release
and that the count of release paths goes from one to two with this change. It establishes nothing
about behaviour after this PR merges — the post-merge negative and positive controls are separate,
later work and are not claimed here.

## Changes

- `.github/workflows/release.yml`
  - Restored the `pull_request: {types: [closed], paths: ['.github/project.yml']}` trigger alongside
    `workflow_dispatch`.
  - Rewrote the header comment: the 2026-07-12 incident is preserved, and the "do not reintroduce an
    event-driven trigger" assertion is replaced by an account of what had to be true before it could
    return.
  - Added `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true` to
    `release`.
  - Added `if: needs.release.outputs.released-version != ''` to `publish-image`, and replaced the
    stale composability caveat (which described a ref declaring no `workflow_call.outputs`) with the
    run/skip-vs-value scope split.
  - Widened the accepted Cosign identity to the anchored two-ref regexp and added a
    `cosign verify` step that runs the published operator values against the digest just signed.
- `doc/user/container-image.adoc` — operator verification command switched to
  `--certificate-identity-regexp`, with a new section explaining why the identity is a pattern and
  why it is still exact.
- `.claude/skills/release/SKILL.md` — Step 8's verify gate updated to the same pattern; the
  `--ref main` rationale restated against the closed accepted-ref set; brittle `release.yml:NNN` line
  references replaced with job/step names.

## Test Plan

- [x] Quality gate green (`verify -Ppre-commit`)
- [x] Full verify green (`verify`)
- [x] Pre-submission structural self-review: 2 passes, 7 findings — 4 fixed here, 3 deferred to PR 2
- [ ] **Post-merge negative control (PR 3):** merge a non-release `.github/project.yml` edit; both
      `release` and `publish-image` must render skipped
- [ ] **Post-merge positive control (PR 3):** the next real release, observed rather than manufactured

---
Generated by plan-finalize skill

## Intent

**Problem.** Releases have been dispatch-only since the 2026-07-12 incident, when a
`pull_request: {types:[closed], paths:['.github/project.yml']}` trigger published `1.0.0` to Maven
Central on a merge that never intended a release. That trigger decided on merged-ness alone; it could
not tell a version bump from any other edit to the file.

**Approach.** Restore the trigger, but move the decision. The pinned `cuioss-organization` workflow
owns the version-changed guard; this repo consumes it — `publish-image` keys off
`needs.release.outputs.released-version != ''`, which is that guard's verdict surfaced, never
re-derived. The caller's `merged == true` guard is ANDed with it, never an alternative. Re-arming
changes the ref a release runs from, so the Cosign identity becomes an anchored two-ref regexp and
the lane now verifies its own signature instead of asserting it in a comment.

**Non-goals.** No local re-implementation of the version-changed decision — a missing org guard is a
block to report, not to substitute. No edit to `.github/project.yml`, and no pin bump (`937fbcf`
already carries the guard). The remaining dispatch-only prose — `release-process.adoc`, ADR-0034 →
ADR-0035, `doc/development/README.adoc`, the runbook's `on:`-block assertion — is deliberately PR 2.
The post-merge controls are PR 3; nothing here claims post-merge behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Container image releases can now be triggered manually or automatically after eligible pull requests are merged.
  - Published images are signed and automatically verified before completion, with retries for temporary verification delays.

- **Documentation**
  - Updated container image verification guidance for releases from the main branch and merged pull requests.
  - Added clearer instructions for validating trusted release identities and rejecting overly broad identity patterns.
  - Clarified release procedures, version consistency requirements, and supported release paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->