### PR TITLE
fix(asset): strip the upstream's connection headers so h2 asset routes work (#172)

### DIFF
--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
@@ -49,6 +49,10 @@ import lombok.experimental.UtilityClass;
  *       authenticated content is never written to a shared cache.</li>
  *   <li><strong>No cookies.</strong> Any {@code Set-Cookie} the source emitted is
  *       stripped — an asset action never establishes a session.</li>
+ *   <li><strong>No borrowed connection state.</strong> Every connection-specific and
+ *       framing header the source proposed is stripped
+ *       ({@link #connectionSpecificHeaders()}), together with any HTTP/2 pseudo-header —
+ *       the gateway's own client connection owns those, never the source's.</li>
  *   <li><strong>Read-only verbs.</strong> Only {@code GET} and {@code HEAD} are
  *       served ({@link #isAllowedMethod(HttpMethod)}).</li>
  * </ul>
@@ -99,6 +103,37 @@ public class AssetResponseEnvelope {
             Map.entry("wasm", "application/wasm"));
 
     /**
+     * Hop-by-hop (RFC 7230 §6.1) plus framing headers, all lower case — the set a source's
+     * proposed headers are filtered against.
+     * <p>
+     * These describe the connection the <em>source</em> answered on, never the client connection
+     * the gateway answers on, so re-emitting them is wrong on every protocol and fatal on one:
+     * RFC 9113 §8.2.2 declares a response carrying a connection-specific header field malformed,
+     * and an HTTP/2 client answers the stream with {@code PROTOCOL_ERROR} — the whole response is
+     * discarded before a single header reaches the application. An upstream that answers
+     * {@code Connection: keep-alive} (any stock reverse proxy) or {@code Transfer-Encoding: chunked}
+     * (any streamed origin response) therefore made an {@code source: upstream} asset route
+     * unusable from a browser, while the very same route worked over HTTP/1.1, which tolerates the
+     * headers as no-ops.
+     * <p>
+     * {@code Content-Length} is stripped for a second, protocol-independent reason: the gateway
+     * writes the served body itself and the framework recomputes the length from the buffer it
+     * actually writes. A borrowed length is a claim about the <em>source's</em> body, and
+     * {@link AssetSource.Served} does not always carry that body — a {@code HEAD} and every error
+     * status are served with an empty one — so forwarding it declares bytes that never follow.
+     * <p>
+     * The set is deliberately identical to the response-direction strip the proxy data plane
+     * applies in {@code ResponseStage} — which is why a plain proxy route to the same origin never
+     * showed this fault. The two live in different packages and serve the strip differently (the
+     * proxy path re-establishes framing afterwards because it streams a body it does not hold),
+     * so {@code AssetResponseEnvelopeTest} pins every name here against {@code ResponseStage}'s own
+     * forwardability predicate rather than letting the agreement rest on a comment.
+     */
+    private static final Set<String> CONNECTION_SPECIFIC_HEADERS = Set.of(
+            "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+            "te", "trailer", "transfer-encoding", "upgrade", "content-length");
+
+    /**
      * The extensions the gateway maps itself — the mappings an operator can never
      * replace.
      * <p>
@@ -111,6 +146,21 @@ public class AssetResponseEnvelope {
      */
     public static Set<String> builtInExtensions() {
         return CONTENT_TYPES.keySet();
+    }
+
+    /**
+     * The connection-specific and framing header names a source can never place on a served
+     * response — see {@link #CONNECTION_SPECIFIC_HEADERS} for why each one is fatal or wrong.
+     * <p>
+     * Exposed so the parity assertion against the proxy data plane's response-direction strip can
+     * be written over the real set rather than a restated copy of it: the two strips implement the
+     * same rule on the two paths that reach a client, and a name added to one and forgotten in the
+     * other is exactly the shape of the defect this set exists to close.
+     *
+     * @return the lowercase stripped header names; immutable
+     */
+    public static Set<String> connectionSpecificHeaders() {
+        return CONNECTION_SPECIFIC_HEADERS;
     }
 
     /**
@@ -167,11 +217,16 @@ public class AssetResponseEnvelope {
     /**
      * Builds the final, gateway-governed response header set for a served asset.
      * <p>
-     * The source headers are copied verbatim except for the four the gateway owns:
+     * The source headers are copied verbatim except for the ones the gateway owns:
      * {@code Content-Type} is overridden from the extension map, {@code Set-Cookie}
      * is dropped, {@code X-Content-Type-Options: nosniff} is added, and — for
      * {@link AccessLevel#AUTHENTICATED} — {@code Cache-Control: no-store} overrides
-     * whatever the source declared. Header-name matching is case-insensitive.
+     * whatever the source declared. Every {@linkplain #connectionSpecificHeaders()
+     * connection-specific or framing header} is dropped as well, as is any HTTP/2
+     * pseudo-header ({@code :status} and friends, which a source reached over HTTP/2
+     * reports among its response headers): both describe the source's connection, and
+     * re-emitting either onto the client's connection makes the response malformed.
+     * Header-name matching is case-insensitive.
      *
      * @param filename      the served filename, used to resolve the content type
      * @param access        the effective access level of the serving route
@@ -208,6 +263,18 @@ public class AssetResponseEnvelope {
         return CONTENT_TYPE.equalsIgnoreCase(headerName)
                 || CONTENT_TYPE_OPTIONS.equalsIgnoreCase(headerName)
                 || SET_COOKIE.equalsIgnoreCase(headerName)
-                || (authenticated && CACHE_CONTROL.equalsIgnoreCase(headerName));
+                || (authenticated && CACHE_CONTROL.equalsIgnoreCase(headerName))
+                || isConnectionOwned(headerName);
+    }
+
+    /**
+     * @param headerName the source-proposed header name
+     * @return {@code true} when the name belongs to the source's own connection rather than to the
+     *         asset — a hop-by-hop/framing header, or an HTTP/2 pseudo-header, which is any name
+     *         beginning with {@code ':'} and is never a real field the gateway may re-emit
+     */
+    private static boolean isConnectionOwned(String headerName) {
+        return headerName.startsWith(":")
+                || CONNECTION_SPECIFIC_HEADERS.contains(headerName.toLowerCase(Locale.ROOT));
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import de.cuioss.sheriff.gateway.config.model.AccessLevel;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
+import de.cuioss.sheriff.gateway.http.ConnectionHeaders;
 
 import lombok.experimental.UtilityClass;
 
@@ -50,9 +51,10 @@ import lombok.experimental.UtilityClass;
  *   <li><strong>No cookies.</strong> Any {@code Set-Cookie} the source emitted is
  *       stripped — an asset action never establishes a session.</li>
  *   <li><strong>No borrowed connection state.</strong> Every connection-specific and
- *       framing header the source proposed is stripped
- *       ({@link #connectionSpecificHeaders()}), together with any HTTP/2 pseudo-header —
- *       the gateway's own client connection owns those, never the source's.</li>
+ *       framing header the source proposed is stripped, together with any HTTP/2
+ *       pseudo-header — the gateway's own client connection owns those, never the
+ *       source's. The rule itself is {@link ConnectionHeaders}, shared with the proxy
+ *       data plane's relay so the two response paths cannot diverge.</li>
  *   <li><strong>Read-only verbs.</strong> Only {@code GET} and {@code HEAD} are
  *       served ({@link #isAllowedMethod(HttpMethod)}).</li>
  * </ul>
@@ -103,37 +105,6 @@ public class AssetResponseEnvelope {
             Map.entry("wasm", "application/wasm"));
 
     /**
-     * Hop-by-hop (RFC 7230 §6.1) plus framing headers, all lower case — the set a source's
-     * proposed headers are filtered against.
-     * <p>
-     * These describe the connection the <em>source</em> answered on, never the client connection
-     * the gateway answers on, so re-emitting them is wrong on every protocol and fatal on one:
-     * RFC 9113 §8.2.2 declares a response carrying a connection-specific header field malformed,
-     * and an HTTP/2 client answers the stream with {@code PROTOCOL_ERROR} — the whole response is
-     * discarded before a single header reaches the application. An upstream that answers
-     * {@code Connection: keep-alive} (any stock reverse proxy) or {@code Transfer-Encoding: chunked}
-     * (any streamed origin response) therefore made an {@code source: upstream} asset route
-     * unusable from a browser, while the very same route worked over HTTP/1.1, which tolerates the
-     * headers as no-ops.
-     * <p>
-     * {@code Content-Length} is stripped for a second, protocol-independent reason: the gateway
-     * writes the served body itself and the framework recomputes the length from the buffer it
-     * actually writes. A borrowed length is a claim about the <em>source's</em> body, and
-     * {@link AssetSource.Served} does not always carry that body — a {@code HEAD} and every error
-     * status are served with an empty one — so forwarding it declares bytes that never follow.
-     * <p>
-     * The set is deliberately identical to the response-direction strip the proxy data plane
-     * applies in {@code ResponseStage} — which is why a plain proxy route to the same origin never
-     * showed this fault. The two live in different packages and serve the strip differently (the
-     * proxy path re-establishes framing afterwards because it streams a body it does not hold),
-     * so {@code AssetResponseEnvelopeTest} pins every name here against {@code ResponseStage}'s own
-     * forwardability predicate rather than letting the agreement rest on a comment.
-     */
-    private static final Set<String> CONNECTION_SPECIFIC_HEADERS = Set.of(
-            "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
-            "te", "trailer", "transfer-encoding", "upgrade", "content-length");
-
-    /**
      * The extensions the gateway maps itself — the mappings an operator can never
      * replace.
      * <p>
@@ -146,21 +117,6 @@ public class AssetResponseEnvelope {
      */
     public static Set<String> builtInExtensions() {
         return CONTENT_TYPES.keySet();
-    }
-
-    /**
-     * The connection-specific and framing header names a source can never place on a served
-     * response — see {@link #CONNECTION_SPECIFIC_HEADERS} for why each one is fatal or wrong.
-     * <p>
-     * Exposed so the parity assertion against the proxy data plane's response-direction strip can
-     * be written over the real set rather than a restated copy of it: the two strips implement the
-     * same rule on the two paths that reach a client, and a name added to one and forgotten in the
-     * other is exactly the shape of the defect this set exists to close.
-     *
-     * @return the lowercase stripped header names; immutable
-     */
-    public static Set<String> connectionSpecificHeaders() {
-        return CONNECTION_SPECIFIC_HEADERS;
     }
 
     /**
@@ -221,12 +177,12 @@ public class AssetResponseEnvelope {
      * {@code Content-Type} is overridden from the extension map, {@code Set-Cookie}
      * is dropped, {@code X-Content-Type-Options: nosniff} is added, and — for
      * {@link AccessLevel#AUTHENTICATED} — {@code Cache-Control: no-store} overrides
-     * whatever the source declared. Every {@linkplain #connectionSpecificHeaders()
-     * connection-specific or framing header} is dropped as well, as is any HTTP/2
-     * pseudo-header ({@code :status} and friends, which a source reached over HTTP/2
-     * reports among its response headers): both describe the source's connection, and
-     * re-emitting either onto the client's connection makes the response malformed.
-     * Header-name matching is case-insensitive.
+     * whatever the source declared. Everything {@link ConnectionHeaders#isConnectionSpecific
+     * ConnectionHeaders} rejects is dropped as well — the connection-specific and framing
+     * headers, and any HTTP/2 pseudo-header ({@code :status} and friends, which a source
+     * reached over HTTP/2 reports among its response headers): both describe the source's
+     * connection, and re-emitting either onto the client's connection makes the response
+     * malformed. Header-name matching is case-insensitive.
      *
      * @param filename      the served filename, used to resolve the content type
      * @param access        the effective access level of the serving route
@@ -264,17 +220,6 @@ public class AssetResponseEnvelope {
                 || CONTENT_TYPE_OPTIONS.equalsIgnoreCase(headerName)
                 || SET_COOKIE.equalsIgnoreCase(headerName)
                 || (authenticated && CACHE_CONTROL.equalsIgnoreCase(headerName))
-                || isConnectionOwned(headerName);
-    }
-
-    /**
-     * @param headerName the source-proposed header name
-     * @return {@code true} when the name belongs to the source's own connection rather than to the
-     *         asset — a hop-by-hop/framing header, or an HTTP/2 pseudo-header, which is any name
-     *         beginning with {@code ':'} and is never a real field the gateway may re-emit
-     */
-    private static boolean isConnectionOwned(String headerName) {
-        return headerName.startsWith(":")
-                || CONNECTION_SPECIFIC_HEADERS.contains(headerName.toLowerCase(Locale.ROOT));
+                || ConnectionHeaders.isConnectionSpecific(headerName);
     }
 }

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
@@ -62,11 +62,10 @@ import org.jspecify.annotations.Nullable;
  * taken from the fixed extension map (overriding the upstream's claim), {@code nosniff}
  * is set, an upstream {@code Set-Cookie} is stripped, and an
  * {@link AccessLevel#AUTHENTICATED} asset is forced to {@code no-store} even when the
- * upstream sent {@code Cache-Control: public}. The envelope also strips every
- * {@linkplain AssetResponseEnvelope#connectionSpecificHeaders() connection-specific and
- * framing header} the upstream answered with — this source is the only one that proposes
- * any, since {@code DirectoryAssetSource} has no connection to describe — so the upstream's
- * hop state never lands on the client's connection.
+ * upstream sent {@code Cache-Control: public}. The envelope also strips every header the
+ * shared {@link de.cuioss.sheriff.gateway.http.ConnectionHeaders} policy names — this source
+ * is the only one that proposes any, since {@code DirectoryAssetSource} has no connection to
+ * describe — so the upstream's hop state never lands on the client's connection.
  *
  * @author API Sheriff Team
  * @since 1.0

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
@@ -62,7 +62,11 @@ import org.jspecify.annotations.Nullable;
  * taken from the fixed extension map (overriding the upstream's claim), {@code nosniff}
  * is set, an upstream {@code Set-Cookie} is stripped, and an
  * {@link AccessLevel#AUTHENTICATED} asset is forced to {@code no-store} even when the
- * upstream sent {@code Cache-Control: public}.
+ * upstream sent {@code Cache-Control: public}. The envelope also strips every
+ * {@linkplain AssetResponseEnvelope#connectionSpecificHeaders() connection-specific and
+ * framing header} the upstream answered with — this source is the only one that proposes
+ * any, since {@code DirectoryAssetSource} has no connection to describe — so the upstream's
+ * hop state never lands on the client's connection.
  *
  * @author API Sheriff Team
  * @since 1.0

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
@@ -20,6 +20,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+
+import de.cuioss.sheriff.gateway.http.ConnectionHeaders;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpClientResponse;
@@ -33,8 +36,9 @@ import io.vertx.core.http.HttpServerResponse;
  * {@link HttpClientResponse#pipeTo(io.vertx.core.streams.WriteStream) pipeTo} — the body is never
  * materialized. Header rules:
  * <ul>
- *   <li><strong>Hop-by-hop headers</strong> (RFC 7230 §6.1) plus length/framing headers Vert.x
- *       recomputes are stripped in the response direction.</li>
+ *   <li><strong>Connection-specific headers</strong> plus the length/framing headers Vert.x
+ *       recomputes are stripped in the response direction, per the shared
+ *       {@link ConnectionHeaders} policy the asset envelope reads too.</li>
  *   <li><strong>Conditional-response headers</strong> ({@code ETag} / {@code Last-Modified}) pass
  *       through only when the route enables {@code not_modified}; on a disabled route they are
  *       stripped so no validator ever reaches the client. A {@code 304} on an enabled route relays
@@ -48,11 +52,6 @@ import io.vertx.core.http.HttpServerResponse;
  */
 public final class ResponseStage {
 
-    /** Hop-by-hop (RFC 7230 §6.1) plus framing headers Vert.x recomputes. All lower case. */
-    private static final Set<String> HOP_BY_HOP_HEADERS = Set.of(
-            "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
-            "te", "trailer", "transfer-encoding", "upgrade", "content-length");
-
     /** Conditional-response validators stripped unless the route enables {@code not_modified}. */
     private static final Set<String> CONDITIONAL_RESPONSE_HEADERS = Set.of("etag", "last-modified");
 
@@ -62,11 +61,14 @@ public final class ResponseStage {
      * @return {@code true} when the header crosses back to the client
      */
     public static boolean isForwardableResponseHeader(String name, boolean notModifiedEnabled) {
-        String lower = Objects.requireNonNull(name, "name").toLowerCase(Locale.ROOT);
-        if (HOP_BY_HOP_HEADERS.contains(lower)) {
+        Objects.requireNonNull(name, "name");
+        // The hop-by-hop / framing judgement is ConnectionHeaders', shared with the asset
+        // envelope: one protocol rule, read by both paths that answer a client. Only the
+        // conditional-validator gate below is this stage's own, since it turns on a route flag.
+        if (ConnectionHeaders.isConnectionSpecific(name)) {
             return false;
         }
-        return notModifiedEnabled || !CONDITIONAL_RESPONSE_HEADERS.contains(lower);
+        return notModifiedEnabled || !CONDITIONAL_RESPONSE_HEADERS.contains(name.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/ConnectionHeaders.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/ConnectionHeaders.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.http;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * The single response-direction connection-header policy — the set of header names an upstream
+ * or backing source may propose but the gateway must never place on the client's connection.
+ * <p>
+ * <strong>Every path that answers a client reads this one set.</strong> The gateway has two:
+ * the proxy data plane's streamed relay ({@code edge.ResponseStage}) and the asset terminal
+ * action's buffered envelope ({@code asset.AssetResponseEnvelope}). They apply the policy
+ * differently — the proxy path re-establishes framing afterwards because it streams a body it
+ * does not hold, the asset path lets the framework compute the length of the buffer it writes —
+ * but the <em>set</em> is one rule about one protocol, so it is declared once. Two copies of it
+ * is not a style objection: issue #172 was exactly a header the proxy path stripped and the asset
+ * path did not, and a mirrored list would have let the next such name diverge just as quietly.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@UtilityClass
+public class ConnectionHeaders {
+
+    /**
+     * The connection-specific and framing response headers, all lower case.
+     * <p>
+     * The membership has two independent sources, and it matters which name comes from which:
+     * <ul>
+     *   <li><strong>RFC 9113 §8.2.2</strong> names {@code Connection}, {@code Proxy-Connection},
+     *       {@code Keep-Alive}, {@code Transfer-Encoding} and {@code Upgrade} as connection-specific
+     *       and declares any HTTP/2 message carrying one <em>malformed</em>. This is not advisory:
+     *       the client discards the whole stream — the {@code PROTOCOL_ERROR} of issue #172, where
+     *       an origin's routine {@code Connection: keep-alive} made a served asset arrive as nothing
+     *       at all. {@code TE} is admitted by the RFC only with the value {@code trailers}; the
+     *       gateway does not relay it in the response direction at all.</li>
+     *   <li><strong>RFC 7230 §6.1</strong> adds the remaining hop-by-hop names ({@code Trailer},
+     *       {@code Proxy-Authenticate}, {@code Proxy-Authorization}), which describe the hop the
+     *       gateway terminates rather than the message it forwards.</li>
+     *   <li><strong>{@code Content-Length}</strong> is framing, not hop-by-hop, and is stripped for
+     *       a protocol-independent reason: it is a claim about the <em>source's</em> body, and
+     *       neither relay writes that body verbatim in every case. Each path re-establishes the
+     *       framing it can actually honour.</li>
+     * </ul>
+     */
+    public static final Set<String> RESPONSE_STRIP = Set.of(
+            "connection", "proxy-connection", "keep-alive", "proxy-authenticate",
+            "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade",
+            "content-length");
+
+    /**
+     * Whether {@code headerName} belongs to the source's own connection rather than to the message
+     * the gateway relays.
+     *
+     * @param headerName the source-proposed response-header name; never {@code null}
+     * @return {@code true} for a {@link #RESPONSE_STRIP} member (matched case-insensitively) or for
+     *         an HTTP/2 pseudo-header — any name beginning with {@code ':'}, which a source reached
+     *         over HTTP/2 reports among its response headers and which is malformed by definition
+     *         inside a normal header block
+     */
+    public static boolean isConnectionSpecific(String headerName) {
+        Objects.requireNonNull(headerName, "headerName");
+        return headerName.startsWith(":")
+                || RESPONSE_STRIP.contains(headerName.toLowerCase(Locale.ROOT));
+    }
+}

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Protocol-level HTTP rules shared by every path that answers a client.
+ * <p>
+ * The package sits <em>below</em> both response-producing paths — the proxy data plane's streamed
+ * relay in {@code edge} and the asset terminal action's buffered envelope in {@code asset} — and
+ * depends on neither, so a rule about the HTTP protocol itself is declared once and read by both
+ * rather than mirrored into each. {@link de.cuioss.sheriff.gateway.http.ConnectionHeaders} is that
+ * rule for connection-specific response headers.
+ * <p>
+ * <strong>Framework-agnostic.</strong> The package carries no {@code io.vertx..} /
+ * {@code io.quarkus..} / {@code jakarta..} imports and depends on no other gateway package, which
+ * is what lets the framework-coupled {@code edge} and the agnostic {@code asset} both read it
+ * without either acquiring a dependency on the other.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@NullMarked
+package de.cuioss.sheriff.gateway.http;
+
+import org.jspecify.annotations.NullMarked;

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import de.cuioss.sheriff.gateway.config.model.AccessLevel;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
 import de.cuioss.sheriff.gateway.edge.ResponseStage;
+import de.cuioss.sheriff.gateway.http.ConnectionHeaders;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -274,7 +275,7 @@ class AssetResponseEnvelopeTest {
          * is what is actually under test.
          */
         static Stream<String> strippedNames() {
-            return AssetResponseEnvelope.connectionSpecificHeaders().stream();
+            return ConnectionHeaders.RESPONSE_STRIP.stream();
         }
 
         @ParameterizedTest
@@ -302,6 +303,7 @@ class AssetResponseEnvelopeTest {
             Map<String, String> sourceHeaders = new LinkedHashMap<>();
             sourceHeaders.put("Connection", "keep-alive");
             sourceHeaders.put("Keep-Alive", "timeout=5");
+            sourceHeaders.put("Proxy-Connection", "keep-alive");
             sourceHeaders.put("Transfer-Encoding", "chunked");
             sourceHeaders.put("Content-Length", "530");
             sourceHeaders.put("Server", "nginx");
@@ -336,22 +338,17 @@ class AssetResponseEnvelopeTest {
         }
 
         /**
-         * The parity fence against the proxy data plane. Both paths answer a client and both must
-         * refuse to relay the same connection state, but the two strips are enforced in different
-         * packages, so the agreement is asserted rather than assumed.
-         * <p>
-         * The assertion runs through {@code ResponseStage}'s own public predicate rather than a
-         * restated copy of its set, so it stays true to whatever that stage actually does. It is
-         * deliberately one-directional — it proves the envelope strips nothing the proxy path
-         * forwards. The converse (a name {@code ResponseStage} strips and the envelope does not) is
-         * exactly issue #172 and cannot be derived here, because the stage exposes a predicate, not
-         * its set; {@link ConnectionSpecificStrip#shouldStripTheWholeHopSet()} pins the envelope's
-         * side against the concrete headers a real origin sends.
+         * The both-paths fence. {@link ConnectionHeaders} is the one declaration, but a shared
+         * constant only helps if both response paths actually consult it — a path that kept a local
+         * copy would compile, pass its own tests, and reintroduce issue #172 the moment a name was
+         * added here alone. This walks the shared set through the proxy relay's own public
+         * forwardability predicate, so the proxy path is proven to honour every name the asset path
+         * strips, not merely to have the same constant on its classpath.
          */
         @Test
         @DisplayName("Should strip nothing the proxy data plane's ResponseStage would forward")
         void shouldAgreeWithTheProxyResponseStrip() {
-            for (String name : AssetResponseEnvelope.connectionSpecificHeaders()) {
+            for (String name : ConnectionHeaders.RESPONSE_STRIP) {
                 assertFalse(ResponseStage.isForwardableResponseHeader(name, true),
                         () -> name + " is stripped by the asset envelope but forwarded by "
                                 + "ResponseStage — the two response paths have drifted");

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import de.cuioss.sheriff.gateway.config.model.AccessLevel;
 import de.cuioss.sheriff.gateway.config.model.HttpMethod;
+import de.cuioss.sheriff.gateway.edge.ResponseStage;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -250,6 +251,115 @@ class AssetResponseEnvelopeTest {
                             "an asset action must never establish a session"),
                     () -> assertEquals("kept", governed.get("X-Custom"),
                             "unrelated source headers pass through"));
+        }
+    }
+
+    /**
+     * The connection-specific strip — the governance that keeps an {@code source: upstream} asset
+     * route servable over HTTP/2 (issue #172).
+     * <p>
+     * A source's hop headers describe the source's connection, not the client's. Re-emitting one
+     * makes the response malformed under RFC 9113 §8.2.2, and an HTTP/2 client answers the stream
+     * with {@code PROTOCOL_ERROR} — the response is discarded whole, which is why the symptom was
+     * an empty reply rather than a wrong header.
+     */
+    @Nested
+    @DisplayName("The connection-specific and framing header strip")
+    class ConnectionSpecificStrip {
+
+        /**
+         * Every stripped name, sourced from the production set rather than restated — a name added
+         * there without a case here would otherwise go unexercised. The mixed casing is deliberate:
+         * an origin sends {@code Connection}, not {@code connection}, so the case-insensitive match
+         * is what is actually under test.
+         */
+        static Stream<String> strippedNames() {
+            return AssetResponseEnvelope.connectionSpecificHeaders().stream();
+        }
+
+        @ParameterizedTest
+        @MethodSource("strippedNames")
+        @DisplayName("Should strip each connection-specific header the source proposed")
+        void shouldStripConnectionSpecificHeader(String name) {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put(capitalized(name), "whatever");
+            sourceHeaders.put("X-Custom", "kept");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "index.html", AccessLevel.PUBLIC, sourceHeaders, Map.of());
+
+            assertAll(
+                    () -> assertFalse(governed.keySet().stream().anyMatch(name::equalsIgnoreCase),
+                            () -> name + " describes the source's connection, never the client's — "
+                                    + "re-emitting it makes an HTTP/2 response malformed"),
+                    () -> assertEquals("kept", governed.get("X-Custom"),
+                            "unrelated source headers still pass through"));
+        }
+
+        @Test
+        @DisplayName("Should strip the whole hop set at once, as a real origin sends it")
+        void shouldStripTheWholeHopSet() {
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put("Connection", "keep-alive");
+            sourceHeaders.put("Keep-Alive", "timeout=5");
+            sourceHeaders.put("Transfer-Encoding", "chunked");
+            sourceHeaders.put("Content-Length", "530");
+            sourceHeaders.put("Server", "nginx");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "index.html", AccessLevel.PUBLIC, sourceHeaders, Map.of());
+
+            assertAll(
+                    () -> assertEquals(Set.of(AssetResponseEnvelope.CONTENT_TYPE,
+                                    AssetResponseEnvelope.CONTENT_TYPE_OPTIONS, "Server"), governed.keySet(),
+                            "only the gateway's own headers and the end-to-end Server header survive"),
+                    () -> assertEquals("nginx", governed.get("Server")));
+        }
+
+        @Test
+        @DisplayName("Should strip an HTTP/2 pseudo-header a source reached over h2 reports")
+        void shouldStripPseudoHeaders() {
+            // The JDK HTTP client surfaces :status among the response headers when it negotiated
+            // HTTP/2 with the upstream, so an https asset upstream with h2 in its ALPN set hands
+            // the gateway one. A pseudo-header in a normal header block is malformed by definition.
+            Map<String, String> sourceHeaders = new LinkedHashMap<>();
+            sourceHeaders.put(":status", "200");
+            sourceHeaders.put("X-Custom", "kept");
+
+            Map<String, String> governed = AssetResponseEnvelope.governedHeaders(
+                    "app.js", AccessLevel.PUBLIC, sourceHeaders, Map.of());
+
+            assertAll(
+                    () -> assertFalse(governed.containsKey(":status"),
+                            "a pseudo-header is never a real field the gateway may re-emit"),
+                    () -> assertEquals("kept", governed.get("X-Custom")));
+        }
+
+        /**
+         * The parity fence against the proxy data plane. Both paths answer a client and both must
+         * refuse to relay the same connection state, but the two strips are enforced in different
+         * packages, so the agreement is asserted rather than assumed.
+         * <p>
+         * The assertion runs through {@code ResponseStage}'s own public predicate rather than a
+         * restated copy of its set, so it stays true to whatever that stage actually does. It is
+         * deliberately one-directional — it proves the envelope strips nothing the proxy path
+         * forwards. The converse (a name {@code ResponseStage} strips and the envelope does not) is
+         * exactly issue #172 and cannot be derived here, because the stage exposes a predicate, not
+         * its set; {@link ConnectionSpecificStrip#shouldStripTheWholeHopSet()} pins the envelope's
+         * side against the concrete headers a real origin sends.
+         */
+        @Test
+        @DisplayName("Should strip nothing the proxy data plane's ResponseStage would forward")
+        void shouldAgreeWithTheProxyResponseStrip() {
+            for (String name : AssetResponseEnvelope.connectionSpecificHeaders()) {
+                assertFalse(ResponseStage.isForwardableResponseHeader(name, true),
+                        () -> name + " is stripped by the asset envelope but forwarded by "
+                                + "ResponseStage — the two response paths have drifted");
+            }
+        }
+
+        private static String capitalized(String name) {
+            return Character.toUpperCase(name.charAt(0)) + name.substring(1);
         }
     }
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
@@ -143,6 +143,7 @@ class UpstreamAssetSourceTest {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers(
                 "Connection", "keep-alive",
                 "Keep-Alive", "timeout=5",
+                "Proxy-Connection", "keep-alive",
                 "Transfer-Encoding", "chunked",
                 "Content-Length", String.valueOf(BODY.length),
                 "Server", "nginx"), BODY);
@@ -155,6 +156,9 @@ class UpstreamAssetSourceTest {
                         "the upstream's connection state must never reach the client's connection"),
                 () -> assertFalse(served.headers().keySet().stream().anyMatch("Keep-Alive"::equalsIgnoreCase),
                         "Keep-Alive is connection-specific and malformed over HTTP/2"),
+                () -> assertFalse(
+                        served.headers().keySet().stream().anyMatch("Proxy-Connection"::equalsIgnoreCase),
+                        "RFC 9113 §8.2.2 names Proxy-Connection connection-specific alongside Connection"),
                 () -> assertFalse(
                         served.headers().keySet().stream().anyMatch("Transfer-Encoding"::equalsIgnoreCase),
                         "the client's framing is the edge's to choose, never the upstream's"),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
@@ -134,6 +134,70 @@ class UpstreamAssetSourceTest {
     }
 
     @Test
+    @DisplayName("Should strip the upstream's connection-specific headers (issue #172)")
+    void shouldStripUpstreamConnectionHeaders() {
+        // The header shape any stock origin answers with. Relayed onto the client's connection they
+        // make an HTTP/2 response malformed (RFC 9113 §8.2.2), and the client answers the stream
+        // with PROTOCOL_ERROR — the asset never arrives at all, while HTTP/1.1 tolerates them and
+        // the very same route works. That asymmetry is the whole bug.
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers(
+                "Connection", "keep-alive",
+                "Keep-Alive", "timeout=5",
+                "Transfer-Encoding", "chunked",
+                "Content-Length", String.valueOf(BODY.length),
+                "Server", "nginx"), BODY);
+
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertAll(
+                () -> assertEquals(OK, served.status()),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch("Connection"::equalsIgnoreCase),
+                        "the upstream's connection state must never reach the client's connection"),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch("Keep-Alive"::equalsIgnoreCase),
+                        "Keep-Alive is connection-specific and malformed over HTTP/2"),
+                () -> assertFalse(
+                        served.headers().keySet().stream().anyMatch("Transfer-Encoding"::equalsIgnoreCase),
+                        "the client's framing is the edge's to choose, never the upstream's"),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch("Content-Length"::equalsIgnoreCase),
+                        "the edge recomputes the length from the buffer it writes"),
+                () -> assertEquals("nginx", served.headers().get("Server"),
+                        "an end-to-end upstream header still passes through"),
+                () -> assertArrayEqualsBody(BODY, served.body()));
+    }
+
+    @Test
+    @DisplayName("Should strip the upstream Content-Length on a body-less outcome")
+    void shouldStripContentLengthOnBodylessOutcome() {
+        // A 404 is served with an empty body, so relaying the upstream's Content-Length would
+        // declare bytes that never follow — a hang on HTTP/1.1 and a mismatch on HTTP/2. The same
+        // holds for HEAD, which is why the strip is unconditional rather than status-dependent.
+        UpstreamFetcher fetcher = cannedFetcher(NOT_FOUND, headers("Content-Length", "1234"), BODY);
+
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "missing.js");
+
+        assertAll(
+                () -> assertEquals(NOT_FOUND, served.status()),
+                () -> assertEquals(0, served.body().length, "an upstream error status is served body-less"),
+                () -> assertFalse(served.headers().keySet().stream().anyMatch("Content-Length"::equalsIgnoreCase),
+                        "a length describing a body the gateway does not serve must not be relayed"));
+    }
+
+    @Test
+    @DisplayName("Should strip an HTTP/2 pseudo-header an h2-negotiated upstream fetch reports")
+    void shouldStripUpstreamPseudoHeader() {
+        // The JDK HTTP client negotiates HTTP/2 by default, so an https asset upstream advertising
+        // h2 in its ALPN set hands the fetch seam a ":status" entry among the response headers.
+        UpstreamFetcher fetcher = cannedFetcher(OK, headers(":status", "200", "X-Keep", "yes"), BODY);
+
+        AssetSource.Served served = source(AccessLevel.PUBLIC, fetcher).serve(HttpMethod.GET, "app.js");
+
+        assertAll(
+                () -> assertFalse(served.headers().containsKey(":status"),
+                        "a pseudo-header in a normal header block is malformed by definition"),
+                () -> assertEquals("yes", served.headers().get("X-Keep")));
+    }
+
+    @Test
     @DisplayName("Should force no-store for authenticated access even when the upstream sent Cache-Control: public")
     void shouldForceNoStoreForAuthenticatedOverUpstreamPublic() {
         UpstreamFetcher fetcher = cannedFetcher(OK, headers("Cache-Control", "public, max-age=99999"), BODY);

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
@@ -33,8 +33,9 @@ class ResponseStageTest {
 
         @ParameterizedTest
         @ValueSource(strings = {
-                "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
-                "TE", "Trailer", "Transfer-Encoding", "Upgrade", "Content-Length"})
+                "Connection", "Proxy-Connection", "Keep-Alive", "Proxy-Authenticate",
+                "Proxy-Authorization", "TE", "Trailer", "Transfer-Encoding", "Upgrade",
+                "Content-Length"})
         @DisplayName("strips hop-by-hop and framing headers regardless of not_modified")
         void stripsHopByHop(String header) {
             assertFalse(ResponseStage.isForwardableResponseHeader(header, true),

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/http/ConnectionHeadersTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/http/ConnectionHeadersTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link ConnectionHeaders}: the one response-direction connection-header policy both
+ * client-facing paths read — the proxy relay and the asset envelope.
+ * <p>
+ * The membership assertion is deliberately exhaustive rather than sampled. The set is a protocol
+ * fact, not a tuning knob: RFC 9113 §8.2.2 makes a response carrying one of these malformed, and
+ * an HTTP/2 client discards the stream outright, so a name silently dropped from the set does not
+ * degrade a response — it deletes it (issue #172). An exhaustive expectation is what makes such an
+ * edit fail here instead of in a browser.
+ */
+class ConnectionHeadersTest {
+
+    @Test
+    @DisplayName("Should carry exactly the RFC 9113 connection-specific set plus the hop and framing names")
+    void shouldCarryTheExactSet() {
+        assertEquals(
+                ConnectionHeaders.RESPONSE_STRIP, Set.of(
+                        // RFC 9113 §8.2.2 — a response carrying any of these is malformed over HTTP/2.
+                        "connection", "proxy-connection", "keep-alive", "transfer-encoding", "upgrade", "te",
+                        // RFC 7230 §6.1 — hop-by-hop, describing the hop the gateway terminates.
+                        "trailer", "proxy-authenticate", "proxy-authorization",
+                        // Framing: a claim about the source's body, which neither relay writes verbatim.
+                        "content-length"),
+                "the strip set is a protocol fact — a name removed here silently reopens issue #172");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Connection", "CONNECTION", "connection", "Transfer-Encoding", "TE"})
+    @DisplayName("Should match a connection-specific name whatever case the source sent it in")
+    void shouldMatchCaseInsensitively(String name) {
+        assertTrue(ConnectionHeaders.isConnectionSpecific(name),
+                () -> name + " must be recognised — an origin sends header names in its own casing");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {":status", ":authority", ":path"})
+    @DisplayName("Should reject any HTTP/2 pseudo-header, which is malformed in a normal header block")
+    void shouldRejectPseudoHeaders(String name) {
+        assertTrue(ConnectionHeaders.isConnectionSpecific(name),
+                () -> name + " is a pseudo-header the gateway may never re-emit as a real field");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Content-Type", "Cache-Control", "ETag", "Server", "Set-Cookie", "Location"})
+    @DisplayName("Should pass an end-to-end header through — the policy strips connection state only")
+    void shouldPassEndToEndHeaders(String name) {
+        assertFalse(ConnectionHeaders.isConnectionSpecific(name),
+                () -> name + " describes the message, not the connection, and must survive the strip");
+    }
+
+    @Test
+    @DisplayName("Should reject a null header name rather than silently treating it as forwardable")
+    void shouldRejectNullName() {
+        assertThrows(NullPointerException.class, () -> ConnectionHeaders.isConnectionSpecific(null));
+    }
+}

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -532,11 +532,11 @@ Three properties define the action:
   response metadata: the `Content-Type` is set from the gateway's own extension map, `nosniff`
   is always added, any source `Set-Cookie` is stripped, and an `access: authenticated` asset is
   forced to `Cache-Control: no-store`. The envelope also strips every connection-specific and
-  framing header the source proposed (`Connection`, `Keep-Alive`, `Transfer-Encoding`,
-  `Content-Length`, the rest of RFC 7230 §6.1) and any HTTP/2 pseudo-header, matching the
-  response-direction strip the proxy data plane applies in stage 7: those describe the *source's*
+  framing header the source proposed, plus any HTTP/2 pseudo-header: those describe the *source's*
   connection, and relaying one onto the client's makes an HTTP/2 response malformed (RFC 9113
-  §8.2.2), which a client answers by discarding the stream. Only `GET`/`HEAD` are served. The untrusted request
+  §8.2.2), which a client answers by discarding the whole stream. That strip is not the envelope's
+  own list -- it is the shared `ConnectionHeaders` policy stage 7's proxy relay reads as well, so
+  the two paths that answer a client cannot diverge on it. Only `GET`/`HEAD` are served. The untrusted request
   sub-path is canonicalized and confined under the configured root before the source is touched,
   closing the path-traversal class for the whole asset surface.
 * *The extension map is operator-extensible, add-only.* The global `asset_defaults.content_types`

--- a/doc/architecture.adoc
+++ b/doc/architecture.adoc
@@ -531,7 +531,12 @@ Three properties define the action:
   gateway -- never the backing directory or the (possibly hostile) upstream -- governs the
   response metadata: the `Content-Type` is set from the gateway's own extension map, `nosniff`
   is always added, any source `Set-Cookie` is stripped, and an `access: authenticated` asset is
-  forced to `Cache-Control: no-store`. Only `GET`/`HEAD` are served. The untrusted request
+  forced to `Cache-Control: no-store`. The envelope also strips every connection-specific and
+  framing header the source proposed (`Connection`, `Keep-Alive`, `Transfer-Encoding`,
+  `Content-Length`, the rest of RFC 7230 §6.1) and any HTTP/2 pseudo-header, matching the
+  response-direction strip the proxy data plane applies in stage 7: those describe the *source's*
+  connection, and relaying one onto the client's makes an HTTP/2 response malformed (RFC 9113
+  §8.2.2), which a client answers by discarding the stream. Only `GET`/`HEAD` are served. The untrusted request
   sub-path is canonicalized and confined under the configured root before the source is touched,
   closing the path-traversal class for the whole asset surface.
 * *The extension map is operator-extensible, add-only.* The global `asset_defaults.content_types`

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
@@ -16,8 +16,21 @@
 package de.cuioss.sheriff.gateway.integration;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +44,59 @@ import org.junit.jupiter.api.Test;
  * re-serves the response under the gateway-owned envelope. The envelope overrides the
  * {@code Content-Type} from the file extension (so a hostile or misconfigured origin cannot dictate
  * it), adds {@code X-Content-Type-Options: nosniff}, and serves only {@code GET}/{@code HEAD}.
+ * <p>
+ * <strong>The suite deliberately drives the route over both edge protocols.</strong> REST Assured
+ * speaks HTTP/1.1, and issue #172 was invisible to every HTTP/1.1 assertion in this class: the
+ * origin's connection-specific headers ({@code Connection}, {@code Keep-Alive},
+ * {@code Transfer-Encoding}) were relayed verbatim, which HTTP/1.1 tolerates as no-ops but which
+ * RFC 9113 §8.2.2 makes a malformed HTTP/2 response — the client discards the stream with
+ * {@code PROTOCOL_ERROR} and no header ever reaches the application. Since {@code tls.alpn} lists
+ * {@code h2} first, that is what every browser negotiates, so the route was unusable in a browser
+ * while this suite stayed green. {@link #getOverHttp2ServesGovernedUpstreamAsset()} closes that
+ * gap, with the directory-source control beside it holding the fault to the upstream source rather
+ * than to h2 support at large.
  */
 class UpstreamAssetServingIT extends BaseIntegrationTest {
+
+    /**
+     * The connection-specific response headers a stock origin answers with and the gateway must
+     * never re-emit. Asserted on the wire rather than only in
+     * {@code AssetResponseEnvelopeTest}: the unit test proves the envelope drops them, this proves
+     * nothing downstream of it puts them back on the client's connection.
+     */
+    private static final List<String> HOP_BY_HOP_NAMES =
+            List.of("Connection", "Keep-Alive", "Transfer-Encoding");
+
+    private static HttpClient http2Client;
+
+    /**
+     * A JDK HTTP client pinned to HTTP/2, so the request negotiates {@code h2} through ALPN against
+     * the edge's TLS listener. The JDK client validates the response header block and rejects a
+     * connection-specific field with {@code ProtocolException: malformed response} — its analogue of
+     * the {@code PROTOCOL_ERROR} curl reports — which is precisely what makes it a regression guard
+     * here rather than merely a second transport.
+     */
+    @BeforeAll
+    static void setUpHttp2Client() throws Exception {
+        // Trust-all TLS for the stack's self-signed localhost certificate, matching GrpcProxyIT's
+        // posture: scoped strictly to this black-box test against a throwaway local certificate,
+        // never production trust. Hostname verification is left ON — the certificate names
+        // localhost and the tests dial localhost, so nothing needs relaxing.
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
+        http2Client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    @AfterAll
+    static void tearDownHttp2Client() {
+        if (http2Client != null) {
+            http2Client.close();
+        }
+    }
 
     @Test
     @DisplayName("GET fetches the secondary origin and re-serves it under gateway governance")
@@ -65,6 +129,41 @@ class UpstreamAssetServingIT extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET over HTTP/2 serves the upstream asset — the origin's hop headers never relay (#172)")
+    void getOverHttp2ServesGovernedUpstreamAsset() throws Exception {
+        HttpResponse<String> response = fetchOverHttp2("/assets/cdn/logo.svg");
+
+        assertAll(
+                () -> assertEquals(HttpClient.Version.HTTP_2, response.version(),
+                        "the edge advertises h2 first in tls.alpn, so the request must negotiate HTTP/2"),
+                () -> assertEquals(200, response.statusCode()),
+                () -> assertTrue(response.body().contains("<svg"),
+                        "the whole governed response must arrive over h2, not just its status"),
+                () -> assertEquals("nosniff", response.headers().firstValue("X-Content-Type-Options").orElse(null)),
+                () -> assertTrue(response.headers().firstValue("Content-Type").orElse("").contains("image/svg+xml"),
+                        "the gateway still overrides the content type from the .svg extension over h2"),
+                () -> assertAll(HOP_BY_HOP_NAMES.stream().map(name -> () -> assertTrue(
+                        response.headers().firstValue(name).isEmpty(),
+                        () -> name + " describes the origin's connection and must never be relayed — "
+                                + "over h2 it makes the response malformed (RFC 9113 §8.2.2)"))));
+    }
+
+    @Test
+    @DisplayName("GET over HTTP/2 serves the directory-source control — the h2 edge itself is sound")
+    void getOverHttp2ServesDirectoryAssetControl() throws Exception {
+        // The control from the issue's table: the same anchor, the same edge, a directory source.
+        // It proposes no headers of its own, so it was never affected — its passing beside the
+        // upstream case is what attributes a failure there to the upstream source rather than to
+        // the h2 listener, the ALPN negotiation, or this test's client.
+        HttpResponse<String> response = fetchOverHttp2("/assets/static/app.css");
+
+        assertAll(
+                () -> assertEquals(HttpClient.Version.HTTP_2, response.version()),
+                () -> assertEquals(200, response.statusCode()),
+                () -> assertTrue(response.body().contains("color"), "the mounted file's content arrives over h2"));
+    }
+
+    @Test
     @DisplayName("POST is rejected 405 — an asset action serves only GET and HEAD")
     void postRejected() {
         given()
@@ -72,5 +171,24 @@ class UpstreamAssetServingIT extends BaseIntegrationTest {
                 .post("/assets/cdn/logo.svg")
                 .then()
                 .statusCode(405);
+    }
+
+    /**
+     * Fetches {@code path} from the public HTTPS edge over a negotiated {@code h2} connection.
+     *
+     * @param path the edge path to GET
+     * @return the response, body included
+     * @throws java.net.ProtocolException when the edge answered a malformed HTTP/2 response — the
+     *                                    failure mode issue #172 produced, surfaced as a test error
+     *                                    rather than an assertion failure because the JDK client
+     *                                    discards such a response before any of it is observable
+     */
+    private static HttpResponse<String> fetchOverHttp2(String path) throws Exception {
+        String port = System.getProperty("test.https.port", "10443");
+        HttpRequest request = HttpRequest.newBuilder(URI.create("https://localhost:" + port + path))
+                .timeout(Duration.ofSeconds(15))
+                .GET()
+                .build();
+        return http2Client.send(request, HttpResponse.BodyHandlers.ofString());
     }
 }


### PR DESCRIPTION
Fixes #172.

## The fault

`AssetResponseEnvelope.governedHeaders` copied the source's proposed headers verbatim apart from the four the gateway owns. `UpstreamAssetSource` is the only source that proposes any (`DirectoryAssetSource` passes an empty map), and the JDK HTTP client surfaces the origin's `Connection`, `Keep-Alive` and `Transfer-Encoding` among its response headers.

RFC 9113 §8.2.2 makes a response carrying a connection-specific header field **malformed**, so relaying one onto the client's h2 connection had the client discard the whole stream — the reported `PROTOCOL_ERROR` with no headers and no server-side log. HTTP/1.1 tolerates the same headers as no-ops, which is exactly why the route worked there and why every existing (REST Assured, HTTP/1.1) IT assertion stayed green while browsers, which negotiate `h2` first, saw the route break.

The proxy control in the issue's table never showed this because `ResponseStage` already strips the same set in the response direction; the asset envelope did not.

Reproduced end to end before fixing: a Vert.x HTTP/2 server writes `Connection: keep-alive` without complaint (matching "nothing is logged server-side"), and a JDK h2 client rejects it with `ProtocolException: malformed response: Prohibited header name 'connection'` — the JDK's analogue of curl's `PROTOCOL_ERROR`.

## The fix

The envelope now strips the same connection-specific/framing set the proxy path strips, so both paths that reach a client refuse to relay the source's connection state. Two related defects go with it:

- **`Content-Length` is stripped, not relayed.** The edge writes the served buffer and recomputes the length. The source's length describes a body the gateway does not always serve — HEAD and every error status are served body-less — so relaying it declared bytes that never followed (a hang on HTTP/1.1, a mismatch on h2).
- **HTTP/2 pseudo-headers are stripped.** The fetch seam's client negotiates h2 by default, so an https asset upstream advertising h2 hands back a `:status` entry, which is malformed by definition inside a normal header block.

## Verification

- `verify -Ppre-commit` and `verify`: green.
- Full containerised IT suite (native image): 107 tests, green.
- `UpstreamAssetServingIT` now drives the route over a **real ALPN-h2 connection** with a JDK client, plus the directory-source control from the issue's table beside it — which holds a failure to the upstream source rather than to h2 support, ALPN, or the test client. The guard is live rather than nominal: the IT origin is stock nginx and does answer `Connection: keep-alive`, so this test fails on the pre-fix code.
- `AssetResponseEnvelopeTest` pins every stripped name against `ResponseStage`'s own forwardability predicate, so the two response-direction strips cannot drift apart unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UWp1S8nH9pmGKBeXM1gLn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Responses now remove connection-specific, framing, and HTTP/2 pseudo-headers before delivery.
  - Prevents headers such as `Content-Length`, `Connection`, and `Transfer-Encoding` from being relayed incorrectly.
  - Authenticated asset responses now consistently enforce `Cache-Control: no-store`.

- **Documentation**
  - Updated architecture guidance to reflect response header filtering and caching behavior.

- **Tests**
  - Added coverage for governed responses, error responses, directory assets, and HTTP/2 delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->