### PR TITLE
chore(release): declare version 0.1.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: api-sheriff
 description: An API-Gateway focused on Security and a lightweight approach
 
 release:
-  current-version: 0.1.0
+  current-version: 0.1.1
   next-version: 0.2.0-SNAPSHOT
   create-github-release: true
 


### PR DESCRIPTION
Declare `current-version` `0.1.1`, `next-version` stays `0.2.0-SNAPSHOT`.

**MERGING THIS PR CUTS THE RELEASE.** The central version-changed guard sees `current-version` move
from `0.1.0` to `0.1.1` with no `0.1.1` tag present, so the merge publishes the jars to Maven Central
and the container image to GHCR. Do NOT merge until the release runbook
(`.claude/skills/release/SKILL.md`) Steps 2-4 have passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version from 0.1.0 to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->