### PR TITLE
docs: point the version-bearing examples at 0.1.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ A security-focused API Gateway with a lightweight approach, built with Quarkus.
 
 [IMPORTANT]
 ====
-*0.1.0 is an ALPHA release.* The configuration surface and the APIs *may change without a
+*0.1.1 is an ALPHA release.* The configuration surface and the APIs *may change without a
 migration path*. Per this project's pre-1.0 rules, breaking changes are made freely: keys are
 renamed or removed, values change meaning, and no deprecation shim, compatibility alias or
 upgrade tooling is provided. A `gateway.yaml` that boots today may fail to boot on the next
@@ -131,7 +131,7 @@ docker run -p 8443:8443 -p 127.0.0.1:9000:9000 \
 [[_known_limitations]]
 == Known Limitations
 
-Verified as still open at the 0.1.0 cut. Each is a deliberate boundary or a known gap, not a
+Verified as still open at the 0.1.1 cut. Each is a deliberate boundary or a known gap, not a
 surprise waiting to be discovered.
 
 A route with no `forward` block now forwards everything (behaviour change on upgrade)::

--- a/deployment/compose-sample/.env
+++ b/deployment/compose-sample/.env
@@ -12,4 +12,4 @@
 # Keep this pin on the current release. The release runbook
 # (.claude/skills/release/SKILL.md, Step 10) updates it as part of cutting a version, so that a
 # freshly cloned sample always pulls an image that exists.
-API_SHERIFF_IMAGE=ghcr.io/cuioss/api-sheriff:0.1.0
+API_SHERIFF_IMAGE=ghcr.io/cuioss/api-sheriff:0.1.1

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -17,7 +17,7 @@ This directory holds the design documentation; these documents define *what is b
 
 [IMPORTANT]
 ====
-*0.1.0 is an ALPHA release.* The configuration surface and the APIs described here *may change
+*0.1.1 is an ALPHA release.* The configuration surface and the APIs described here *may change
 without a migration path* -- pre-1.0 rules apply, so breaking changes are made freely and no
 deprecation shim or upgrade tooling is provided. Alpha is a statement about the *stability of the
 surface*, not about code quality: the intended use is evaluation, integration and feedback. The

--- a/doc/user/README.adoc
+++ b/doc/user/README.adoc
@@ -15,7 +15,7 @@ contract; the guides in this layer are task-oriented entry points into it.
 
 [IMPORTANT]
 ====
-*0.1.0 is an ALPHA release.* The `gateway.yaml` surface and the APIs *may change without a
+*0.1.1 is an ALPHA release.* The `gateway.yaml` surface and the APIs *may change without a
 migration path*: keys may be renamed or removed and values may change meaning between releases,
 with no deprecation shim and no upgrade tooling. A descriptor that boots today may fail to boot on
 the next release -- deliberately and loudly, rather than silently changing behaviour.

--- a/doc/user/compose-sample.adoc
+++ b/doc/user/compose-sample.adoc
@@ -39,7 +39,7 @@ reach `ghcr.io`:
 
 [source,bash]
 ----
-docker pull ghcr.io/cuioss/api-sheriff:0.1.0
+docker pull ghcr.io/cuioss/api-sheriff:0.1.1
 ----
 
 The bring-up script pulls it for you if it is missing, so this step is optional. For what the


### PR DESCRIPTION
Post-release Step 10 of the release runbook (`.claude/skills/release/SKILL.md`), run after the
`0.1.1` image was verified and confirmed public.

Every example and maturity callout that names a concrete cut now names `0.1.1`:

* `deployment/compose-sample/.env` — image pin `0.1.0` → `0.1.1`
* `doc/user/compose-sample.adoc` — the Route A `docker pull`
* `README.adoc` — the ALPHA callout and the known-limitations preamble
* `doc/README.adoc`, `doc/user/README.adoc` — the same ALPHA callout

`doc/user/container-image.adoc` is deliberately untouched: its `<version>` is a placeholder written
to stay true across releases, not a stale pin.

Documentation-only footprint (`*.adoc` plus the sample `.env`), so the Maven pre-commit gate is
skipped per `CLAUDE.md`.