### PR TITLE
fix(release): narrow signing identity and reconcile release posture

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -424,7 +424,8 @@ anything else open can land ahead of it and move the commit your release is cut 
 >    team, and do not merge anything yourself, from the cut until Step 7 reports the run finished.
 >    No branch policy, merge freeze or workflow check enforces this — it is an operator obligation,
 >    and a merge landing inside that window can still race the release force-push. Treat it as a
->    residual operator risk, not a closed safeguard (ADR-0035 records it as one).
+>    residual operator risk, not a closed safeguard — ADR-0035 records it as exactly that residual
+>    risk, and states plainly that nothing enforces the post-dispatch merge hold.
 
 **(iv) Confirm no tag for the release version already exists.**
 
@@ -551,8 +552,9 @@ gh run view "$RUN_ID" --repo cuioss/API-Sheriff --json displayTitle,headBranch,h
 > confirm it names the version-bump PR before watching it.
 
 **Now READ THE RUN. Do not infer the outcome from the merge having happened** — see *The guard has
-NEVER been observed* above; until a cut has actually been read off a run, every outcome here is a
-first observation rather than a confirmation:
+fired once and has never been observed refusing* above. Exactly one merge-triggered cut (`0.1.1`) has
+been read off a run, so a firing guard is a confirmation of that single precedent; a *refusing* guard
+would still be a first observation:
 
 | what the run shows | what decided it | published? |
 |---|---|---|

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -309,10 +309,10 @@ have passed.'
 > shell would run whatever sat between them.
 
 > **THIS PR IS THE RELEASE. Do not merge it here.** Steps 2, 3 and 4 are the pre-cut safety
-> assertions, and on Path A they exist to gate *this merge* — the Trivy posture, the stubs-branch
-> boundary, the tag-absence check, the green-`main` gate and the quiesced queue all belong **before**
-> the publishing act, not after it. Merging now would run every one of them on an irrevocable
-> release that has already happened.
+> assertions, and on Path A they exist to gate *this merge* — the Trivy posture, the tag-absence
+> check, the green-`main` gate and the quiesced queue all belong **before** the publishing act, not
+> after it. Merging now would run every one of them on an irrevocable release that has already
+> happened.
 
 ### Step 2 — Confirm the tree and the pull-request queue are clean
 
@@ -340,43 +340,6 @@ The working tree must be clean. On Path B, `HEAD` must equal `origin/main`. On P
 branch is **up to date with `origin/main`** (`git merge-base --is-ancestor origin/main HEAD`), so the
 commit the queue produces is the `origin/main` the rest of this step gates on plus the version bump
 and nothing else.
-
-> **HARD BOUNDARY — `release/relocation-stubs`.** That branch exists on the remote and **must NEVER
-> be merged**. It carries the relocation-only stubs published under the abandoned
-> `de.cuioss.sheriff.api` coordinates. The release must not pick it up. Confirm it is not in the
-> ancestry of what you are about to release:
->
-> ```bash
-> git fetch origin '+refs/heads/release/relocation-stubs:refs/remotes/origin/release/relocation-stubs' \
->   || { echo "ERROR: could not fetch the stubs branch - the check did not evaluate" >&2; exit 1; }
-> git merge-base --is-ancestor origin/release/relocation-stubs origin/main; case $? in
->   0) echo "STOP: stubs branch is in main" >&2; exit 1 ;;
->   1) echo "OK: stubs branch is not in main" ;;
->   *) echo "ERROR: the check did not evaluate - this is NOT a pass" >&2; exit 1 ;;
-> esac
-> ```
->
-> **FULLY QUALIFY THE SOURCE REF, AND FORCE IT — `+refs/heads/…`, never the bare branch name.**
-> The unqualified form `git fetch origin release/relocation-stubs:refs/remotes/origin/…` **DELETES
-> the remote-tracking ref instead of creating it** on any clone with `fetch.prune=true` (or
-> `remote.origin.prune=true`), which is a common global setting. `git fetch` then reports
-> `- [deleted] (none) -> origin/release/relocation-stubs`, the very next line dies with
-> `fatal: Not a valid object name origin/release/relocation-stubs`, and the guard lands on its
-> `*)` arm. Observed on the 0.1.0 cut: the branch was present on the remote the whole time.
->
-> **That failure looks exactly like the branch having been deleted, and it is not.** Before
-> concluding anything from an `ERROR` here, check the remote directly — `git ls-remote --heads
-> origin | grep relocation` — and re-run with the qualified refspec above. Never "resolve" it by
-> skipping the check or appending `|| true`; the whole point of this boundary is that it fails
-> closed.
->
-> **Branch on the exit code, never on `&&` / `||`.** `git merge-base --is-ancestor` exits `0` for
-> ancestor, `1` for not-ancestor and `128` on error — and an absent
-> `origin/release/relocation-stubs` remote-tracking ref (a single-branch or shallow clone, a clone
-> predating the branch, or the prune misfire above) is exactly such an error. A
-> `… && echo STOP || echo OK` idiom collapses `1` and `128` into the same branch, so a check that
-> never ran prints the reassuring `OK`. **An error is not a pass**, and the explicit `git fetch`
-> above is what stops the common case from reaching that arm at all.
 
 ### Step 3 — Re-assert the pre-cut safety evidence (MANDATORY)
 
@@ -1035,9 +998,6 @@ authenticated check passes.
 - **Nothing merges to `main` between the cut and run completion** — the release force-pushes to
   `main` twice as a queue bypass actor. On Path A that window opens at **enqueue**, not at run start.
   This one is unenforced: it is an operator obligation, not a mechanism.
-- **`release/relocation-stubs` must NEVER be merged**, and the release must not pick it up. Fetch it
-  with the **fully-qualified forced refspec** (`+refs/heads/…`); the bare branch name self-prunes
-  under `fetch.prune=true` and the guard then reports `ERROR` for a branch that is still there.
 - **Set the GHCR package to *public*, not *internal*, and assert the `visibility` field** rather than
   inferring it from a pull. Internal passes every authenticated check while anonymous pulls 401.
 - **Update the version-bearing examples (Step 10) after the image is public**, and delete any caveat

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1037,8 +1037,9 @@ authenticated check passes.
 
 - `doc/development/release-process.adoc` — the canonical process narrative, including the two release
   paths, the guard's role, and the rule that *a change which removes or weakens an event-driven
-  trigger merges on its own*. **This file is also the surviving narrative account of the 2026-07-12
-  incident** — see *How the release is wired* above. The former *Coordinate history* note in
+  trigger merges on its own*. **This runbook — not `release-process.adoc` — carries the surviving
+  narrative account of the 2026-07-12 incident**; see *How the release is wired* above, and ADR-0035
+  for the decision record. The former *Coordinate history* note in
   `README.adoc` was removed once `de.cuioss.sheriff.api` had been abandoned long enough that the
   history was of no use to a reader arriving at the project. **ADR-0034 is superseded by ADR-0035**,
   which records the guarded-merge-or-dispatch decision and which `release.yml`'s header references.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -365,8 +365,13 @@ Confirm **all four**, and treat any one of them failing as a stop:
 1. The `on:` block carries **exactly** `workflow_dispatch` plus the `pull_request` trigger with
    `types: [closed]`, `branches: [main]`, `paths: ['.github/project.yml']` — **and nothing else.** No
    `push`, no `schedule`, no additional path, no widened `branches:`, no extra `types:`.
-2. The `release` job still carries its merged-ness gate:
-   `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true`.
+2. The `release` job's `if:` still carries **both** operands, ANDed:
+   `(github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')` and
+   `(github.event_name != 'pull_request' || github.event.pull_request.merged == true)`. The second is
+   the merged-ness gate. The first is what confines a dispatch to `main` — `workflow_dispatch:`
+   carries no branch filter of its own, and the Cosign identity Step 8 verifies accepts only
+   `refs/heads/main`, so losing that operand would let a dispatch from any ref publish under an
+   identity the project's own verification command then rejects.
 3. The `publish-image` job still carries `if: needs.release.outputs.released-version != ''` — the
    central guard's own verdict, surfaced. Without it a guard-skipped merge would still spend 90
    minutes on a native build and then re-push and re-sign an already-released tag.
@@ -447,12 +452,12 @@ esac
 **Both must report `OK`. Anything else stops the release** — including `ERROR`, which means the
 check never evaluated and is therefore not a pass.
 
-> **Match the full ref, and branch on the exit code — the same discipline as the stubs check in
-> Step 2.** `git tag --list '<version>'` and `git ls-remote … | grep …` only *print*; a procedure
-> that reads their output by eye is not a guard, and a re-run that slips past it reaches the
-> workflow's `force: true` tag push. `grep -w '<version>'` is doubly wrong: `.` is a regex
-> any-character, and `-w` treats `-` as a word boundary, so `-w '0.1.0'` also matches
-> `refs/tags/0.1.0-rc1`. The exact `refs/tags/<version>` forms above match one ref and nothing else.
+> **Match the full ref, and branch on the exit code.** `git tag --list '<version>'` and
+> `git ls-remote … | grep …` only *print*; a procedure that reads their output by eye is not a guard,
+> and a re-run that slips past it reaches the workflow's `force: true` tag push. `grep -w '<version>'`
+> is doubly wrong: `.` is a regex any-character, and `-w` treats `-` as a word boundary, so
+> `-w '0.1.0'` also matches `refs/tags/0.1.0-rc1`. The exact `refs/tags/<version>` forms above match
+> one ref and nothing else.
 >
 > **Why this is checked directly:** the tag push is `force: true`, so a re-run can **MOVE** an
 > existing release tag rather than refusing. `release:prepare` would likely fail first, but that is

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -648,11 +648,11 @@ run the two guarded commands above first and dispatch immediately after.)
 
 > **Why `--ref main` and not `--ref "$MAIN_SHA"`.** Dispatching at the gated SHA looks like the
 > tighter fix, and it is the wrong one here — for three independent reasons:
-> 1. **The signature identity is bound to the ref, and the accepted set is closed.** Step 8 verifies
->    the Cosign signature against a pattern accepting exactly `refs/heads/main` and
->    `refs/pull/<N>/merge`. That value is the OIDC `job_workflow_ref` of the `publish-image` job, so
->    it changes with the dispatch ref. A dispatch at a SHA is in neither branch of the pattern, so it
->    produces a certificate this runbook's own verification would reject.
+> 1. **The signature identity is bound to the ref, and the accepted set is a single value.** Step 8
+>    verifies the Cosign signature against a pattern accepting exactly one ref, `refs/heads/main`.
+>    That value is the OIDC `job_workflow_ref` of the `publish-image` job, so it changes with the
+>    dispatch ref. A dispatch at a SHA does not match that pattern, so it produces a certificate this
+>    runbook's own verification would reject.
 > 2. **The release force-pushes to a branch.** `maven-release-plugin` commits the version transition
 >    and the workflow force-pushes it to `main`; a dispatch at a detached SHA has no branch to push.
 > 3. **`ref` is documented as a branch or tag name.** The workflow-dispatch API documents exactly
@@ -816,25 +816,29 @@ nothing.
 
 Verify the Cosign signature **against that resolved digest**, using **exactly** these two identity
 values. They are derived from the `publish-image` job's OIDC identity, which embeds the ref the run
-was triggered from — so the accepted set is a pattern over the **two** refs a release can legitimately
-come from, not a single literal:
+was triggered from — and every release this project has cut embedded the **same** one,
+`refs/heads/main`:
 
 ```bash
 cosign verify "$IMAGE@$VERSION_DIGEST" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$'
+  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/heads/main$'
 ```
 
-`refs/heads/main` is a `workflow_dispatch` release; `refs/pull/<N>/merge` is a merge-triggered one
-(a `pull_request` run's `GITHUB_REF` is the merge ref, and that path is legitimate because the central
-version-changed guard plus `merged == true` already decided it was a release). The pattern stays
-anchored at both ends and bound to this repository and this workflow file — **do not** relax it to a
-wildcard. The workflow runs this same command against every digest it signs, so a failure here is a
-real supply-chain signal, not a stale expectation.
+**Both release paths sign under `refs/heads/main`, and that is read off the certificates rather than
+inferred from the trigger config.** 0.1.0 (`github_workflow_trigger = workflow_dispatch`) and 0.1.1
+(`github_workflow_trigger = pull_request`) both carry
+`job_workflow_ref = .../workflows/release.yml@refs/heads/main`. A pull request closed *by being
+merged* runs against the branch it was merged into, so the merge path never produces a merge-ref
+identity. The value is a *regexp* only because the identity string contains dots that must be
+escaped; it stays anchored at both ends and bound to this repository and this workflow file — **do
+not** relax it to a wildcard. The workflow runs this same command against every digest it signs, so a
+failure here is a real supply-chain signal, not a stale expectation.
 
-**Three files carry this pattern** — `.github/workflows/release.yml` (the `publish-image` verify
-step), `doc/user/container-image.adoc` (the operator-facing command), and this runbook. Nothing
-mechanical keeps them in sync; changing one means changing all three.
+**Four sites in three files carry this pattern** — `.github/workflows/release.yml` **twice** (the
+`A CONSUMER VERIFIES WITH EXACTLY THESE TWO VALUES` comment block and the `publish-image` verify
+step's `IDENTITY_REGEXP` env value), `doc/user/container-image.adoc` (the operator-facing command),
+and this runbook. Nothing mechanical keeps them in sync; changing one means changing all four.
 
 > **Ignore the benchmark run this triggers.** `.github/workflows/benchmark.yml` fires on
 > `push: tags: ["*"]`, so the release's tag push **starts a benchmark run**. That run belongs to the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -75,8 +75,9 @@ trigger fired on *merged-ness* — every merge touching the file was a publicati
 `cuioss-organization` workflow now owns the version-changed decision, which is precisely the
 discrimination that trigger lacked. It is **consumed** here and **never re-implemented locally**:
 `publish-image` keys off `needs.release.outputs.released-version != ''`, which is the guard's own
-verdict surfaced. `release.yml`'s header forward-references **ADR-0035** for the decision; that ADR is
-still owed, so **the reference is dangling and this section is the current account.**
+verdict surfaced. The decision is recorded in **ADR-0035** (`doc/adr/`), which `release.yml`'s header
+references and which supersedes ADR-0034; read it there for the reasoning. This section remains the
+narrative account of the 2026-07-12 incident.
 
 Consequently:
 
@@ -87,15 +88,20 @@ Consequently:
   a block to report, never something to substitute locally.
 - A change that removes or weakens an event-driven trigger must merge **on its own**, before any
   change that would fire that trigger — for a `pull_request` event GitHub evaluates the workflow
-  definition **from the base branch**. `doc/development/release-process.adoc` records that rule (see
-  *See also* for the caveat about that document's current state); do not restate it from memory.
+  definition **from the base branch**. `doc/development/release-process.adoc` records that rule; do
+  not restate it from memory.
 
-### The guard has NEVER been observed — read this before cutting
+### The guard has fired once and has never been observed refusing — read this before cutting
 
-**No merge-triggered release has ever run in this repository, and the central version-changed guard
-has never been observed either refusing or firing.** The `0.1.0` cut went out by `workflow_dispatch`,
-which is the *unconditional* path — so the guard's discrimination was never exercised even then. It
-ships proven in self-test and **unproven in production**.
+**The merge path has run exactly once.** `0.1.1` was cut on 2026-08-07 by merging the version-bump
+PR (#186): its signing certificate carries `github_workflow_trigger = pull_request` at
+`github_workflow_sha = f3b9ed6`, the merge commit. The central version-changed guard has therefore
+been observed **firing** on a real version change. The `0.1.0` cut before it went out by
+`workflow_dispatch`, the *unconditional* path, which exercises no discrimination at all.
+
+**What has never been observed is the guard REFUSING.** No merge leaving the declared version
+unchanged has been watched arriving at the workflow and being turned away. That half ships proven in
+self-test and **unproven here**.
 
 That is not a reason to avoid the merge path. It is a reason to **read the run** rather than assume
 it: after the merge, open the `Release` run and observe what the `release` and `publish-image` jobs
@@ -113,9 +119,8 @@ actually did (Step 5, *Path A*), instead of inferring the outcome from the merge
 ## Ported reference — the facts this procedure depends on
 
 These six sections are the operative content of `doc/development/release-process.adoc`. They are
-reproduced here so the runbook can be followed cold; that document remains the canonical narrative
-**for everything except the trigger, where it is currently stale** — see *See also*. None of the six
-sections below concerns the trigger, so all six stand.
+reproduced here so the runbook can be followed cold; that document remains the canonical narrative.
+None of the six sections below concerns the trigger, so all six stand on their own terms.
 
 ### The image version is the Maven version
 
@@ -456,7 +461,7 @@ anything else open can land ahead of it and move the commit your release is cut 
 >    team, and do not merge anything yourself, from the cut until Step 7 reports the run finished.
 >    No branch policy, merge freeze or workflow check enforces this — it is an operator obligation,
 >    and a merge landing inside that window can still race the release force-push. Treat it as a
->    residual operator risk, not a closed safeguard (ADR-0034 records it as one).
+>    residual operator risk, not a closed safeguard (ADR-0035 records it as one).
 
 **(iv) Confirm no tag for the release version already exists.**
 
@@ -1068,18 +1073,13 @@ authenticated check passes.
 
 ## See also
 
-- `doc/development/release-process.adoc` — the canonical process narrative. **It is currently STALE
-  on the trigger and must not be read as authoritative there:** it still describes the dispatch-only
-  posture (§ *Why the `pull_request` trigger was removed*, § *Why the guard had to merge before
-  anything else*), which PR #171 superseded. Its rewrite is tracked follow-up work. What it records
-  that **does** still hold is the rule that *a change which removes or weakens an event-driven
-  trigger merges on its own*. For everything about **what fires a release**, this file and
-  `.github/workflows/release.yml` are the current sources; **this file is also the surviving
-  narrative account of the 2026-07-12 incident** — see *How the release is wired* above. The former
-  *Coordinate history* note in `README.adoc` was removed once `de.cuioss.sheriff.api` had been
-  abandoned long enough that the history was of no use to a reader arriving at the project.
-  **ADR-0034 is likewise stale** — it records the dispatch-only decision and is superseded by
-  ADR-0035, which `release.yml`'s header already references.
+- `doc/development/release-process.adoc` — the canonical process narrative, including the two release
+  paths, the guard's role, and the rule that *a change which removes or weakens an event-driven
+  trigger merges on its own*. **This file is also the surviving narrative account of the 2026-07-12
+  incident** — see *How the release is wired* above. The former *Coordinate history* note in
+  `README.adoc` was removed once `de.cuioss.sheriff.api` had been abandoned long enough that the
+  history was of no use to a reader arriving at the project. **ADR-0034 is superseded by ADR-0035**,
+  which records the guarded-merge-or-dispatch decision and which `release.yml`'s header references.
 - `.github/workflows/release.yml` — the release workflow, and the authoritative statement of both
   triggers. Its in-file comments carry the guard rationale, the run/skip-vs-value scope split, and
   the composability, ordering and attestation caveats behind the steps above.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1039,10 +1039,8 @@ authenticated check passes.
   paths, the guard's role, and the rule that *a change which removes or weakens an event-driven
   trigger merges on its own*. **This runbook — not `release-process.adoc` — carries the surviving
   narrative account of the 2026-07-12 incident**; see *How the release is wired* above, and ADR-0035
-  for the decision record. The former *Coordinate history* note in
-  `README.adoc` was removed once `de.cuioss.sheriff.api` had been abandoned long enough that the
-  history was of no use to a reader arriving at the project. **ADR-0034 is superseded by ADR-0035**,
-  which records the guarded-merge-or-dispatch decision and which `release.yml`'s header references.
+  for the decision record. **ADR-0034 is superseded by ADR-0035**, which records the
+  guarded-merge-or-dispatch decision and which `release.yml`'s header references.
 - `.github/workflows/release.yml` — the release workflow, and the authoritative statement of both
   triggers. Its in-file comments carry the guard rationale, the run/skip-vs-value scope split, and
   the composability, ordering and attestation caveats behind the steps above.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -43,7 +43,7 @@ on:
 | Path | When it fires | Role |
 |---|---|---|
 | **Merge of a version bump** — a `pull_request` closed with `merged == true`, base `main`, touching `.github/project.yml` | only when the **central guard** inside the pinned `cuioss-organization` reusable workflow sees `release.current-version` actually changed between the merge commit and its first parent, **and** no tag for that version already exists | the ordinary way a release is cut |
-| **`workflow_dispatch`** | always, unconditionally — nothing gates this path but the operator, and that includes re-releasing an unchanged version | the deliberate fallback: recover a failed lane, or cut a version whose declaration already landed |
+| **`workflow_dispatch`** | whenever dispatched **from `main`** — the `release` job's `if:` confines the dispatch path to `refs/heads/main`, and nothing else gates it, which includes re-releasing an unchanged version | the deliberate fallback: recover a failed lane, or cut a version whose declaration already landed |
 
 **State them as a pair.** An operator whose merge did *not* cut a release needs to know which
 mechanism decided that before reaching for the other path — Step 5 *Path A* carries that diagnosis.
@@ -588,9 +588,11 @@ git ls-remote --refs --tags origin 'refs/tags/<version>'
 
 #### Path B — dispatch, deliberately
 
-The unconditional fallback: recover a lane that failed after a correct guard decision, or cut a
-version whose declaration already landed on `main`. **Nothing central refuses on this path** — the
-operator is the only gate, which is why Steps 2–4 are not optional here either.
+The fallback: recover a lane that failed after a correct guard decision, or cut a version whose
+declaration already landed on `main`. The `release` job's `if:` confines a dispatch to
+`refs/heads/main` — a dispatch from any other ref is skipped, silently. Past that ref test
+**nothing central refuses on this path**: the operator is the only remaining gate, which is why
+Steps 2–4 are not optional here either.
 
 **Record the pre-dispatch high-water mark first.** Run ids increase monotonically, so the newest
 existing `Release` run id is what lets the next step tell *your* dispatch apart from one that was
@@ -996,7 +998,7 @@ authenticated check passes.
   Never merge a version bump and then run the safety work.
 - **A merge that cut no release is a verdict to read, not a reason to dispatch.** Diagnose which
   mechanism refused — prefilter, `merged == true`, or the central guard — before reaching for Path B.
-  Dispatch is unconditional and will publish over an undiagnosed refusal.
+  A dispatch from `main` faces no central refusal and will publish over an undiagnosed one.
 - **Re-assert items (i), (iii) and (iv) at cut time.** They are time-varying and are never inherited
   from a recorded baseline.
 - **Dispatch only after re-reading `origin/main`.** Step 5 Path B aborts non-zero unless it still

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,11 +397,13 @@ jobs:
       # THE IDENTITY NAMES EXACTLY ONE REF. Fulcio puts the OIDC `job_workflow_ref` claim in the
       # certificate SAN. publish-image is a CALLER-LOCAL job — it does not `uses:` a reusable
       # workflow — so that claim names release.yml ITSELF (never the org reusable workflow) at the ref
-      # the run was triggered on, i.e. GITHUB_REF. This lane has two release paths and they carry
-      # different refs:
+      # the run was triggered on, i.e. GITHUB_REF. Only two events can reach this job, and BOTH of
+      # them yield refs/heads/main:
       #
-      #   * workflow_dispatch from main  -> GITHUB_REF = refs/heads/main
-      #   * merge of a .github/project.yml PR -> GITHUB_REF = refs/pull/<N>/merge
+      #   * workflow_dispatch from main -> GITHUB_REF = refs/heads/main
+      #   * a MERGED-close .github/project.yml PR -> GITHUB_REF = refs/heads/main, the base branch it
+      #     was merged INTO. A close WITHOUT a merge never reaches here at all: the
+      #     `merged == true` gate on the release job above refuses it before anything runs.
       #
       # THIS IS NOT ARGUED FROM DOCUMENTATION — IT IS READ OFF OUR OWN CERTIFICATES. Both signed
       # digests this project has ever published carry the same single ref in their SAN:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,10 +392,10 @@ jobs:
       # A CONSUMER VERIFIES WITH EXACTLY THESE TWO VALUES:
       #
       #   --certificate-oidc-issuer      https://token.actions.githubusercontent.com
-      #   --certificate-identity-regexp  ^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$
+      #   --certificate-identity-regexp  ^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/heads/main$
       #
-      # THE IDENTITY HAS TWO LEGITIMATE REFS, NOT ONE. Fulcio puts the OIDC `job_workflow_ref` claim
-      # in the certificate SAN. publish-image is a CALLER-LOCAL job — it does not `uses:` a reusable
+      # THE IDENTITY NAMES EXACTLY ONE REF. Fulcio puts the OIDC `job_workflow_ref` claim in the
+      # certificate SAN. publish-image is a CALLER-LOCAL job — it does not `uses:` a reusable
       # workflow — so that claim names release.yml ITSELF (never the org reusable workflow) at the ref
       # the run was triggered on, i.e. GITHUB_REF. This lane has two release paths and they carry
       # different refs:
@@ -403,16 +403,24 @@ jobs:
       #   * workflow_dispatch from main  -> GITHUB_REF = refs/heads/main
       #   * merge of a .github/project.yml PR -> GITHUB_REF = refs/pull/<N>/merge
       #
-      # The merge ref is a FIRST-CLASS release path, not an anomaly to be excluded: the org
-      # version-changed guard plus `merged == true` already decided that this merge is a real release
-      # (see the trigger comment at the top of this file), and this job only runs when
-      # needs.release.outputs.released-version is non-empty. Pinning the accepted identity to
-      # @refs/heads/main alone would therefore reject the signature of a perfectly legitimate release.
+      # THIS IS NOT ARGUED FROM DOCUMENTATION — IT IS READ OFF OUR OWN CERTIFICATES. Both signed
+      # digests this project has ever published carry the same single ref in their SAN:
+      #
+      #   * 0.1.0 (sha256:937b3995...) — github_workflow_trigger = workflow_dispatch,
+      #                                  job_workflow_ref = .../release.yml@refs/heads/main
+      #   * 0.1.1 (sha256:dbd73c2e...) — github_workflow_trigger = pull_request,
+      #                                  job_workflow_ref = .../release.yml@refs/heads/main
+      #
+      # 0.1.1 is the decisive one: a MERGE-triggered run that signed at refs/heads/main. No release
+      # this project has cut has ever carried a merge-ref identity, so an accepted set widened to
+      # admit one was widened for a ref that has never been used. GitHub's
+      # events-that-trigger-workflows reference agrees — on a close-by-merge GITHUB_REF is the base
+      # branch — but it is corroboration here, not the premise the identity rests on.
       #
       # The regexp is TIGHTLY ANCHORED, not a wildcard: anchored at both ends, bound to this exact
-      # repository and this exact workflow file, and the PR number is digits-only. It admits exactly
-      # the two refs above and nothing else. Do NOT relax it to a `.*` — a loose identity would accept
-      # a signature from any workflow in any repository and the check would prove nothing.
+      # repository and this exact workflow file, and it admits that one ref and nothing else. Do NOT
+      # relax it to a `.*` — a loose identity would accept a signature from any workflow in any
+      # repository and the check would prove nothing.
       #
       # doc/user/container-image.adoc publishes the same two strings to operators, and the verify step
       # below RUNS them — the lane proves its own signing identity rather than asserting it in prose.
@@ -440,7 +448,7 @@ jobs:
       - name: Verify the signature under the published identity
         env:
           DIGEST: ${{ steps.digest.outputs.value }}
-          IDENTITY_REGEXP: '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$'
+          IDENTITY_REGEXP: '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/heads/main$'
         run: |
           set -euo pipefail
           REF="ghcr.io/cuioss/api-sheriff@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,37 @@ permissions:
 
 jobs:
   release:
-    # ANDed with the central version-changed guard inside the called workflow, NEVER an alternative
-    # to it. Its merit is defence-in-depth plus not spending a runner on a close-without-merge — it
-    # is NOT here because the central guard is blind to merged-ness; that guard checks merged-ness
-    # too.
-    # Written event-first so the dispatch path still runs: on workflow_dispatch there is no
-    # pull_request context, so the first operand is true and the condition short-circuits. This is
-    # the same shape .github/workflows/benchmark.yml already ships.
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    # TWO OPERANDS DOING TWO DIFFERENT JOBS. Both are ANDed with the central version-changed guard
+    # inside the called workflow, NEVER an alternative to it.
+    #
+    # THE DISPATCH OPERAND — `github.event_name != 'workflow_dispatch' || github.ref ==
+    # 'refs/heads/main'`. `workflow_dispatch:` above takes no branch filter (GitHub offers none), so
+    # a dispatch can be launched from any branch or tag. The signing-identity block on publish-image
+    # below (§ "THE IDENTITY NAMES EXACTLY ONE REF") narrows the accepted Cosign identity to the
+    # single ref refs/heads/main, resting that narrowing on the claim that both events able to reach
+    # the lane yield refs/heads/main. On the merge path `branches: [main]` above ENFORCES that claim;
+    # on the dispatch path nothing did — it was assumed. This operand is what makes it a checked
+    # fact, and it sits on the release job so a non-main dispatch is refused BEFORE the Maven
+    # publication rather than after it. The Cosign verify step is not the enforcement point: it
+    # matches a certificate against an already-produced signature, which is long after the jars are
+    # on Maven Central. Do not restate the certificate evidence here — it lives in that block.
+    #
+    # THE MERGE OPERAND — `github.event_name != 'pull_request' || github.event.pull_request.merged
+    # == true`. Its merit is defence-in-depth plus not spending a runner on a close-without-merge —
+    # it is NOT here because the central guard is blind to merged-ness; that guard checks
+    # merged-ness too.
+    #
+    # Both operands are written event-first so each path still runs: the event a given operand does
+    # not govern makes its first disjunct true and short-circuits the operand. This is the same shape
+    # .github/workflows/benchmark.yml already ships.
+    #
+    # The main-ref test is DELIBERATELY dispatch-scoped. The merge path is already base-filtered by
+    # `branches: [main]`, so extending the ref test to it would stake this project's primary release
+    # path on an assumption about github.ref under a closed-merge event, buying no guarantee that the
+    # base filter does not already provide.
+    if: >-
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
+      && (github.event_name != 'pull_request' || github.event.pull_request.merged == true)
     permissions:
       contents: write
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@937fbcf44d34d826b3bcd66d49d7a7d32030f39a # v0.18.0
@@ -398,12 +421,17 @@ jobs:
       # certificate SAN. publish-image is a CALLER-LOCAL job — it does not `uses:` a reusable
       # workflow — so that claim names release.yml ITSELF (never the org reusable workflow) at the ref
       # the run was triggered on, i.e. GITHUB_REF. Only two events can reach this job, and BOTH of
-      # them yield refs/heads/main:
+      # them yield refs/heads/main — each one because the release job's `if:` or the trigger's own
+      # filter refuses the alternative, never because the alternative is merely unlikely:
       #
-      #   * workflow_dispatch from main -> GITHUB_REF = refs/heads/main
+      #   * workflow_dispatch -> GITHUB_REF = refs/heads/main. `workflow_dispatch:` carries no branch
+      #     filter, so this is not a property of the trigger; the `github.ref == 'refs/heads/main'`
+      #     operand on the release job above is what refuses a dispatch from any other ref, and it
+      #     refuses it before the Maven release runs.
       #   * a MERGED-close .github/project.yml PR -> GITHUB_REF = refs/heads/main, the base branch it
-      #     was merged INTO. A close WITHOUT a merge never reaches here at all: the
-      #     `merged == true` gate on the release job above refuses it before anything runs.
+      #     was merged INTO, which `branches: [main]` on the trigger confines to main. A close
+      #     WITHOUT a merge never reaches here at all: the `merged == true` gate on the release job
+      #     above refuses it before anything runs.
       #
       # THIS IS NOT ARGUED FROM DOCUMENTATION — IT IS READ OFF OUR OWN CERTIFICATES. Both signed
       # digests this project has ever published carry the same single ref in their SAN:

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -286,7 +286,7 @@ ever produced (see link:configuration.adoc#_rate_limit[Configuration -- `rate_li
   a set literal. *(Status: proposed.)*
 |===
 
-NOTE: This index is *not exhaustive* -- ADR-0020 through ADR-0034 are recorded in
+NOTE: This index is *not exhaustive* -- ADR-0020 through ADR-0035 are recorded in
 link:adr/[`doc/adr/`] without a row here. Treat the directory as the authoritative list and this
 table as a curated entry point; a missing row is index drift, never a withdrawn decision.
 

--- a/doc/adr/0034-Publication_is_triggered_only_by_a_deliberate_standalone_invocation_never_by_a_repository_event_or_an_automated_lifecycle_step.adoc
+++ b/doc/adr/0034-Publication_is_triggered_only_by_a_deliberate_standalone_invocation_never_by_a_repository_event_or_an_automated_lifecycle_step.adoc
@@ -12,7 +12,11 @@
 
 == Status
 
-Proposed
+Superseded
+
+Superseded by
+link:0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc[ADR-0035].
+The body below is left verbatim as the record of what was decided at the time.
 
 == Context
 

--- a/doc/adr/0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc
+++ b/doc/adr/0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc
@@ -1,0 +1,223 @@
+= ADR-0035: A release is cut by a guarded version-bump merge or a deliberate dispatch, and the version-changed decision is centrally owned
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: The release workflow carries two triggers -- a pull_request: closed event narrowed by a base filter, a paths prefilter and a merged == true gate, and an unconditional workflow_dispatch -- and the question "is this merge a release?" is answered by the pinned cuioss-organization workflow's version-changed guard, which is consumed and never re-implemented locally; the paths filter is a prefilter and never the decision, and ADR-0034's trigger-removal-merges-on-its-own rule and residual operator risks carry forward unchanged.
+// tags: release, publication, irreversibility, workflow-trigger, version-changed-guard, central-ownership, prefilter, deliberate-action, runbook, supply-chain, check-then-act
+// affects: api-sheriff-parent, documentation
+// supersedes: 0034
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+NOTE: This record fills a numbering gap out of sequence -- ADR-0036 and ADR-0037 already exist. The
+number is not free choice: `.github/workflows/release.yml` forward-references *ADR-0035* by name for
+the decision recorded here, and that reference was written before this file existed. Filling the gap
+is intentional, not an error.
+
+== Context
+
+link:0034-Publication_is_triggered_only_by_a_deliberate_standalone_invocation_never_by_a_repository_event_or_an_automated_lifecycle_step.adoc[ADR-0034]
+decided that an irreversible publication is fired only by a person deciding to fire it, and realised
+that decision with a single mechanism: `workflow_dispatch` as the release workflow's *only* trigger.
+That mechanism has since been replaced. This record states what replaced it and why the replacement
+is not a reversal of ADR-0034's reasoning.
+
+*What ADR-0034 was actually defending against.* On 2026-07-12 a `pull_request: {types: [closed],
+paths: ['.github/project.yml']}` trigger fired a real Maven Central release: merging a pull request
+that touched the version-declaration file published `de.cuioss.sheriff.api:*:1.0.0`. Central
+artifacts are superseded, never withdrawn, so that version was abandoned, relocation-stubbed at
+1.0.1, the coordinates moved to `de.cuioss.sheriff.gateway`, and the version line restarted. The
+defect was not that an *event* fired the workflow. The defect was that the event fired on
+*merged-ness* -- every merge touching that file was a publication, because nothing in the lane ever
+asked whether the declared version had actually changed. A path filter cannot answer that question:
+`.github/project.yml` carries `name`, `description`, `maven-build`, `sonar`, `pages` and
+`github-automation` today, and that list is open. Editing any of them matched the filter and cut a
+release.
+
+*What changed.* The pinned `cuioss-organization` reusable release workflow now owns a
+*version-changed guard*: it compares the declared version against the parent commit's and refuses to
+release when it did not move. That is precisely the discrimination the 2026-07-12 trigger lacked, and
+it lives one level up -- in a versioned, centrally-maintained workflow consumed by every project in
+the organisation -- rather than in each caller's own YAML.
+
+*Why this reopens the trigger question rather than settling it by itself.* A guard that lives
+upstream is only as good as the caller's discipline in *consuming* it. A caller that re-implements
+the same comparison locally gets two answers that can disagree, and the local copy is the one that
+rots. A caller that treats its `paths:` filter as the decision reproduces the 2026-07-12 defect under
+a new name. And a guard that decides correctly still leaves ADR-0034's *other* residual risks
+untouched: nothing rejects a change that both removes a trigger and edits the paths it watches, and
+nothing enforces a merge hold while a release run is in flight.
+
+So the structural choice point is narrower than ADR-0034's, and different in kind: *given that the
+release decision can now be made correctly and centrally, where does that decision live, and what
+must the caller refrain from doing?*
+
+== Decision
+
+*A release is cut by either of two paths, and the question "is this merge a release?" is answered
+centrally, never locally.*
+
+The mechanisms that realise this:
+
+* *Two triggers, deliberately asymmetric.* `.github/workflows/release.yml` declares
+  `workflow_dispatch` and a `pull_request` event narrowed by `types: [closed]`, `branches: [main]`
+  and `paths: ['.github/project.yml']`. The merge path is *conditional* -- it publishes only when the
+  central guard says the declared version moved. The dispatch path is *unconditional* -- it publishes
+  whatever the version declaration says at the dispatched ref, including a re-declaration of an
+  unchanged version. That asymmetry is the design, not an oversight: the merge path is the ordinary
+  route and is guarded; the dispatch is the operator-gated fallback for when the ordinary route
+  cannot or did not fire, and its lack of a guard is exactly what makes it a fallback.
+* *The version-changed decision is consumed, never re-implemented.* The caller declares the trigger
+  and delegates the decision. There is no local version comparison, no local "did the version move"
+  step, and none may be added. A second implementation of a security-relevant decision is a second
+  answer, and the local copy is the one that drifts out of sync with the upstream it was copied from.
+* *The `paths:` filter is a prefilter and never the decision.* It matches *every* edit to
+  `.github/project.yml`, not just a version bump, so a merge arriving at the workflow proves nothing
+  about the version. Its only job is to keep unrelated merges from spending a runner. Reading it as
+  the release condition is the 2026-07-12 defect restated, and the workflow says so in-file at the
+  trigger.
+* *The `branches: [main]` filter bounds who may ask.* `branches:` filters on the pull request's
+  *base*, so only a pull request merging into the main line can reach the release job at all. Without
+  it, a merge into any long-lived branch that touched the declaration file would enter the workflow
+  and be decided by the central guard's comparison against *that* branch -- a release cut from a
+  non-main line. This is a base filter, not the version discriminator: it narrows what may ask, never
+  what is answered.
+* *`merged == true` is defence in depth, not the guard's substitute.* The release job additionally
+  refuses any `pull_request` close that was not a merge. The central guard checks merged-ness too, so
+  this is not here because the guard is blind to it; its merit is not spending a runner on a
+  close-without-merge, and one more independent refusal on the path to an irreversible act.
+* *Both reachable paths sign under the same ref.* A pull request closed *by being merged* runs
+  against the branch it was merged into, so `GITHUB_REF` is `refs/heads/main` on the merge path
+  exactly as on the dispatch path. This is read off the project's own signing certificates -- 0.1.0
+  (`workflow_dispatch`) and 0.1.1 (`pull_request`) both carry
+  `job_workflow_ref = .../release.yml@refs/heads/main` -- not inferred from the trigger
+  configuration. The accepted Cosign identity is therefore a single anchored ref, and widening it to
+  admit a merge ref would accept a ref no release has ever used.
+* *ADR-0034's carried-forward rules stand unchanged.* A change that removes or weakens an
+  event-driven trigger still merges on its own, ahead of any change that would fire that trigger,
+  because a `pull_request` workflow is evaluated from the *base* branch and a mixed change fires the
+  old definition on the very merge that removes it. The post-dispatch merge hold and the "exactly one
+  of each" verification carry forward likewise. Re-arming a trigger does not retire the rules that
+  make changing one safe -- it makes them load-bearing again.
+
+== Consequences
+
+=== Positive
+
+* *The publication decision is made where it can be made correctly.* Whether a version moved is a
+  fact about the declaration, and the guard that reads it is maintained once for the organisation
+  rather than once per repository. A defect in it is fixed in one place.
+* *The ordinary release path costs no separate act.* Landing the version bump is the release. The
+  step that ADR-0034 deliberately kept separate is re-merged, but only because the thing that makes
+  the merge safe is now checked rather than assumed.
+* *The 2026-07-12 failure mode is closed by mechanism rather than by prohibition.* ADR-0034 closed it
+  by forbidding the trigger; this closes it by answering the question the trigger could not. The
+  earlier defence depended on nobody re-adding an event; this one survives the event being present.
+* *A fallback exists when the guarded path does not fire.* An operator whose merge cut no release has
+  a documented, unconditional route -- and, because the two paths differ in exactly one respect, a
+  short explanation of why the merge did nothing.
+
+=== Negative
+
+* *Reviewing a version bump is again reviewing a publication.* The merge of a version-changing
+  `.github/project.yml` pull request *is* the irrevocable act. ADR-0034 rejected this shape outright;
+  this record accepts it, and accepts that the safety now rests on the guard rather than on the
+  reviewer's framing of what they are approving.
+* *The safety of the ordinary path depends on an upstream this repository does not own.* The guard is
+  consumed from a pinned `cuioss-organization` workflow. Pinning bounds the exposure to a deliberate
+  bump, but the decision itself is no longer inspectable in this repository's own YAML.
+* *Two paths mean two behaviours to document and to keep in agreement.* The runbook, the process
+  narrative, the workflow's own comments and the operator-facing verification command all state the
+  posture, and nothing mechanical keeps them in sync.
+
+=== Risks
+
+Every entry below is a *residual risk*, not a closed safeguard. As in ADR-0034, they are listed
+separately from the Decision precisely so the mechanisms above are never read as covering them.
+
+* *Nothing rejects a mixed trigger-removal change.* Unchanged from ADR-0034, and now materially more
+  likely to matter: an event-driven trigger exists again, so a future change that both weakens it and
+  edits the paths it watches will fire the *old* definition on the merge that removes it. Closing
+  this needs an executable check under `.github/workflows/`; until one exists the merges-on-its-own
+  rule is operator discipline.
+* *Nothing enforces the post-dispatch merge hold.* Unchanged from ADR-0034. No branch policy, merge
+  freeze or workflow check prevents a merge landing between the trigger and the run's completion, so
+  a queue landing can race the release's force-push to the protected branch. The merge path narrows
+  the window rather than closing it -- the run starts at the merge rather than at a separate operator
+  act -- but nothing bounds the far end.
+* *The `paths:` prefilter can be mistaken for the guard by a later reader.* The two are adjacent in
+  the same `on:` block and the prefilter is the visible one; the decision is in a workflow this
+  repository only references. The defence is the in-file comment at the trigger and this record. A
+  future change that narrows or widens the prefilter believing it is tuning the release condition
+  would be tuning nothing.
+* *A local re-implementation of the version check would be invisible until it disagreed.* Nothing
+  rejects a caller-local version comparison. The prohibition is normative prose, and a second answer
+  is only detectable at the moment it differs from the first -- during a release.
+* *Post-publication actions outside the repository still cannot be verified by the run itself.*
+  Unchanged from ADR-0034; registry package visibility remains the standing case.
+
+== Alternatives Considered
+
+*Keep `workflow_dispatch` as the only trigger (ADR-0034 as it stood).* The 2026-07-12 failure mode
+stays closed by construction and no upstream is trusted with the release decision. Rejected because
+the reason the event trigger was banned has been addressed at its root: the trigger fired on
+merged-ness, and now something asks whether the version moved. Retaining the ban would preserve the
+*remedy* after the *defect* was fixed, at the standing cost of a manual act on every release and of a
+runbook whose pre-dispatch gate asserts a trigger shape that is no longer true. A prohibition kept
+past its cause becomes folklore.
+
+*Re-implement the version-changed check locally, in this repository's workflow.* The release
+condition becomes inspectable in the file that carries the trigger, with no dependency on an upstream
+for a security-relevant decision. Rejected because it produces two implementations of one decision.
+They agree on the day the copy is made and diverge silently afterwards, and the divergence surfaces
+only during a release -- either as a release that should not have happened or as one that mysteriously
+did not. Central ownership is the point: consuming one answer is what makes the answer improvable.
+
+*Trigger on the merge but require a separate confirmation before publishing.* The merge starts the
+lane and an approval gate holds it short of the irrevocable act, restoring a deliberate human
+decision without losing the automatic path. Rejected as the worst of both: it reintroduces the manual
+act ADR-0034's critics find costly while leaving the reviewer of the version bump still unsure
+whether their approval was the decision, and it adds a second place a release can stall unnoticed. An
+approval that always follows a merge degenerates into a formality, which is the same substitution of
+a proxy for a decision that ADR-0034 rejected.
+
+*Drop the `paths:` prefilter and let the central guard decide every merge to the main line.* One less
+filter to reason about, and the guard is the decision anyway. Rejected because the prefilter is cheap
+and its job is real -- keeping unrelated merges from spending a runner and from appearing in the
+release workflow's run history, where a long list of no-op runs would make a genuine one harder to
+notice.
+
+== Generalisation
+
+When a mechanism is banned because it produced a bad outcome, distinguish the *mechanism* from the
+*missing discrimination* that let it misfire. A ban is the right immediate response and the wrong
+permanent one: it is cheap, verifiable and total, but it fixes the symptom by removing capability,
+and it survives its own justification because nothing forces a re-examination when the underlying gap
+is later closed. Two questions decide whether a ban may be lifted. Has something been added that
+answers the question the banned mechanism could not answer -- not merely narrowed the circumstances in
+which it fires? And is that answer owned somewhere it can be maintained and corrected, rather than
+copied into each consumer? Where both hold, the ban may be replaced by the guard, and the ban's
+*residual* rules -- the ones that were about operating the mechanism safely rather than about
+forbidding it -- must be carried forward explicitly, because lifting the ban is exactly when they
+start mattering again. Where either fails, a filter that narrows *when* the mechanism fires is not a
+substitute for a check on *whether it should*: narrowing reduces the frequency of the bad outcome
+while leaving it reachable, and a rare irreversible failure is harder to catch than a common one.
+
+== References
+
+* link:0034-Publication_is_triggered_only_by_a_deliberate_standalone_invocation_never_by_a_repository_event_or_an_automated_lifecycle_step.adoc[ADR-0034]
+  -- the superseded decision. Its 2026-07-12 incident record, its base-branch trigger-removal rule
+  and its residual operator risks remain the reasoning this record builds on.
+* link:../development/release-process.adoc[Release Process] -- the canonical process narrative: the
+  two release paths, the guard's role, and the surviving trigger rule.
+* link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] -- the two triggers, the
+  `merged == true` gate, the prefilter comment, and the signing identity assertion.
+* link:../user/container-image.adoc[Container Image] -- the operator layer for the published image:
+  digest pinning and signature verification under the single accepted ref.
+* The repository's standalone `release` runbook under `.claude/skills/release/` -- the two-path
+  procedure, the pre-cut assertions, and the "exactly one of each" verification.

--- a/doc/development/README.adoc
+++ b/doc/development/README.adoc
@@ -30,13 +30,15 @@ to *run* the finished gateway).
   merging over a red or stale-green gate, PR-new-code vs post-merge project-gate auditability,
   and the fix-by-default / suppress-with-rationale escape hatch.
 
-| link:release-process.adoc[Release Process -- dispatch-only]
-| How a release is cut -- declare the version in `.github/project.yml`, then deliberately dispatch
-  the Release workflow -- what one dispatch produces (Maven coordinates, the GHCR image, its SBOM
-  and its Cosign signature), why the image version is a checked fact rather than a convention, the
-  test-which-builds/push-that-digest inversion that makes "push exactly what was tested" true by
+| link:release-process.adoc[Release Process]
+| How a release is cut -- merge a version change in `.github/project.yml`, which is the publishing
+  act once the centrally-owned version-changed guard lets it through, with `workflow_dispatch` as the
+  unconditional fallback -- what one release run produces (Maven coordinates, the GHCR image, its
+  SBOM and its Cosign signature), why the image version is a checked fact rather than a convention,
+  the test-which-builds/push-that-digest inversion that makes "push exactly what was tested" true by
   construction, the two-tag scheme and the deliberate absence of `:latest`, and the two trigger
-  rules -- dispatch is the only trigger, and a trigger removal merges on its own.
+  rules -- the version-changed guard is the release decision, and a trigger removal merges on its
+  own.
 
 | link:protocol-processors.adoc[Protocol Processors -- SPI and dispatch seam]
 | The `ProtocolProcessor` SPI, the boot-time registry that binds a protocol to its processor, and

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -18,7 +18,8 @@ The ordinary path is a single act -- merge the version declaration:
   version. Open a pull request with that change.
 . *Merge it.* Merging into `main` cuts the release. The Release workflow runs on the merged close,
   and the pinned cuioss-organization workflow's *version-changed guard* decides whether this merge
-  is a release: it publishes when the declared version actually moved, and refuses when it did not.
+  is a release. It publishes when the declared version actually moved *and* no tag for that version
+  exists yet, and refuses on either condition failing -- see <<guard-refusal-predicates>>.
 
 *The merge is the publishing act, so review the pull request as one.* Approving a version bump is
 approving a Maven Central publication, and a published coordinate can be superseded but never
@@ -27,8 +28,10 @@ withdrawn.
 *`workflow_dispatch` is the fallback, and it is unconditional.* Actions -> Release -> Run workflow
 publishes whatever `.github/project.yml` declares at the dispatched ref, including a re-declaration
 of a version already published; nothing central refuses it. Reach for it when the merge path did not
-fire -- and when a merge cut no release, check whether the declared version actually moved before
-dispatching, because that is what the guard was answering.
+fire -- and when a merge cut no release, establish *which* of the guard's two conditions refused it
+before dispatching (<<guard-refusal-predicates>>). Only an unmoved version is a reason to dispatch.
+An already-existing tag means that version was already released, and dispatching then republishes a
+published coordinate.
 
 link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] delegates to the
 cuioss-organization reusable Maven release workflow, pinned to a specific commit SHA. Neither the
@@ -81,8 +84,18 @@ a step runs "before anything is pushed", read it as *before anything is pushed t
 
 . *Do not re-trigger the whole workflow.* A second dispatch would attempt another Maven release of a
   version that is already published -- the dispatch path is unconditional and nothing central refuses
-  it. The merge path is no remedy either: re-merging the same version declaration moves nothing, so
-  the version-changed guard refuses it and no release runs at all.
+  it. The merge path is no remedy either, and *for two reasons rather than one*: re-merging the same
+  version declaration moves nothing, so the guard's version condition refuses it; and an edit that
+  makes the released version look like it moved again still publishes nothing, because the release
+  job pushed that version's tag before this lane failed and tag-absence is the guard's second
+  condition (<<guard-refusal-predicates>>). You are in the tag-exists case here by definition.
++
+[WARNING]
+====
+Do not read that silent no-release as "the version didn't move" and reach for the dispatch on the
+strength of it. The dispatch refuses nothing, so acting on that diagnosis republishes an
+already-published coordinate -- the failure class this whole procedure exists to prevent.
+====
 . *Classify the failure first -- a re-run cannot pick up a fix.* *Re-run failed jobs* creates a new
   *attempt of the same run*: it reuses the original event context and the original workflow
   definition, and `publish-image` checks out the *release tag*, not `main`. A commit merged to `main`
@@ -214,13 +227,23 @@ cryptographically verifying the published image.
 Two rules govern how the release workflow may be triggered, and how a trigger may be changed. Both
 are normative.
 
+[#guard-refusal-predicates]
 === The version-changed guard is the release decision
 
 link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] declares two triggers: an
 unconditional `workflow_dispatch`, and a `pull_request` narrowed by `types: [closed]`,
 `branches: [main]` and `paths: ['.github/project.yml']`. On the merge path the question *"is this
-merge a release?"* is answered by the pinned cuioss-organization workflow's *version-changed guard*,
-which compares the declared version against the parent commit's and refuses when it did not move.
+merge a release?"* is answered by the pinned cuioss-organization workflow's *version-changed guard*.
+
+*It refuses on either of two conditions, and a refusal announces neither of them:*
+
+. The declared `current-version` did not move against the parent commit.
+. A tag for the declared version already exists.
+
+Both must be false for the merge to publish. The guard is named for the first condition because that
+is what it was added for, but reading a no-release outcome as "the version didn't move" is a
+one-predicate reading of a two-predicate guard -- and it is exactly the misreading that sends an
+operator to the unconditional dispatch after a partial release (see <<release-not-atomic>>).
 
 *That guard is consumed, never re-implemented here.* A local copy of a security-relevant decision is
 a second answer, and the local copy is the one that drifts out of sync. Do not add a caller-local

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -1,25 +1,34 @@
-= Release Process -- dispatch-only
+= Release Process
 :toc:
 :toclevels: 2
 :sectnums:
 
-How a release of API Sheriff is cut. Releases are *never* triggered by merging a pull request:
-the Release workflow runs only when a maintainer deliberately dispatches it. This page states the
-process and the rules that keep it deliberate.
+How a release of API Sheriff is cut. A release has two entry points: merging a pull request that
+changes the declared version in `.github/project.yml`, which *is* the publishing act once the
+centrally-owned version-changed guard lets it through, and a deliberate `workflow_dispatch`, which
+publishes unconditionally and is the operator-gated fallback. This page states the process and the
+rules that keep it safe.
 
 == Cutting a release
 
-A release is a two-part act -- declare the version, then deliberately publish it:
+The ordinary path is a single act -- merge the version declaration:
 
 . *Declare the version.* Edit link:../../.github/project.yml[`.github/project.yml`], setting
   `current-version` to the version being released and `next-version` to the following development
-  version. Open a pull request with that change and merge it in the normal way.
-. *Publish deliberately.* Once the version change is on `main`, dispatch the *Release* workflow by
-  hand (Actions -> Release -> Run workflow). This is the only way a release is cut.
+  version. Open a pull request with that change.
+. *Merge it.* Merging into `main` cuts the release. The Release workflow runs on the merged close,
+  and the pinned cuioss-organization workflow's *version-changed guard* decides whether this merge
+  is a release: it publishes when the declared version actually moved, and refuses when it did not.
 
-Merging the `project.yml` change publishes nothing on its own. The two steps are separate on
-purpose: the merge records *what* the next version is, and the dispatch is the explicit decision to
-*publish* it.
+*The merge is the publishing act, so review the pull request as one.* Approving a version bump is
+approving a Maven Central publication, and a published coordinate can be superseded but never
+withdrawn.
+
+*`workflow_dispatch` is the fallback, and it is unconditional.* Actions -> Release -> Run workflow
+publishes whatever `.github/project.yml` declares at the dispatched ref, including a re-declaration
+of a version already published; nothing central refuses it. Reach for it when the merge path did not
+fire -- and when a merge cut no release, check whether the declared version actually moved before
+dispatching, because that is what the guard was answering.
 
 link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] delegates to the
 cuioss-organization reusable Maven release workflow, pinned to a specific commit SHA. Neither the
@@ -27,7 +36,7 @@ pin nor the `secrets:` block is part of the release decision -- they are build w
 
 == What a release contains
 
-One dispatch produces one coherent set of artifacts, all carrying the same version:
+One release run produces one coherent set of artifacts, all carrying the same version:
 
 * *Maven coordinates on Maven Central* -- `de.cuioss.sheriff.gateway:api-sheriff` and its reactor
   siblings, published by the reusable release workflow.
@@ -40,7 +49,7 @@ release artifact*: it lives in the repository at `deployment/compose-sample/` an
 the source tree rather than pulled from a registry. Both are named here so their absence from the
 artifact list reads as a known boundary rather than an oversight.
 
-image::../resources/diagrams/release-publish-flow.svg[Release publish flow -- one dispatch drives the Maven release and a single image build whose output is scanned, pushed, smoked and signed, while an independent non-gating pull-request lane scans the pinned base image and the repository filesystem, align=center]
+image::../resources/diagrams/release-publish-flow.svg[Release publish flow -- one release run, entered by a guarded version-bump merge or a deliberate dispatch, drives the Maven release and a single image build whose output is scanned, pushed, smoked and signed, while an independent non-gating pull-request lane scans the pinned base image and the repository filesystem, align=center]
 
 === The image version is the Maven version
 
@@ -70,19 +79,21 @@ a step runs "before anything is pushed", read it as *before anything is pushed t
 
 ==== If the image lane fails after the Maven release
 
-. *Do not re-run the whole workflow.* A second dispatch would attempt another Maven release of a
-  version that is already published.
+. *Do not re-trigger the whole workflow.* A second dispatch would attempt another Maven release of a
+  version that is already published -- the dispatch path is unconditional and nothing central refuses
+  it. The merge path is no remedy either: re-merging the same version declaration moves nothing, so
+  the version-changed guard refuses it and no release runs at all.
 . *Classify the failure first -- a re-run cannot pick up a fix.* *Re-run failed jobs* creates a new
   *attempt of the same run*: it reuses the original event context and the original workflow
   definition, and `publish-image` checks out the *release tag*, not `main`. A commit merged to `main`
-  after the dispatch is therefore invisible to it. "Fix it on `main`, then re-run" does not work
-  here and must not be attempted.
+  after the release run started is therefore invisible to it. "Fix it on `main`, then re-run" does
+  not work here and must not be attempted.
 +
 --
 Transient job or runtime failure::
 A registry timeout, a runner flake, a Maven Central propagation race. *Re-run the failed
 `publish-image` job alone* from the Actions UI. It reads its version from `.github/project.yml` at
-the dispatch SHA and checks out the release tag, so it reproduces the same inputs without touching
+the triggering SHA and checks out the release tag, so it reproduces the same inputs without touching
 Maven Central.
 
 Anything carried in the tree or the workflow::
@@ -181,8 +192,8 @@ The human-facing release reference. `<version>` is the Maven version, verbatim.
 `ghcr.io/cuioss/api-sheriff:sha-<commit>`::
 *Provenance, not immutability.* `<commit>` is the *full 40-character SHA of the commit the release
 tag points at* -- the `release:prepare` commit whose poms carry the released version -- and *not* the
-`main` HEAD the release was dispatched from. That is the commit whose source produced the image;
-naming the dispatch commit would point at a tree that never built it. The tag answers "which source
+`main` HEAD the release ran from. That is the commit whose source produced the image; naming the
+triggering commit would point at a tree that never built it. The tag answers "which source
 produced this?" unambiguously, but it remains an ordinary mutable registry tag and is not the image
 digest -- which is exactly why Cosign signs the digest rather than either tag.
 
@@ -201,24 +212,39 @@ cryptographically verifying the published image.
 == Trigger rules
 
 Two rules govern how the release workflow may be triggered, and how a trigger may be changed. Both
-are normative, and both are load-bearing for the dispatch-only guarantee.
+are normative.
 
-=== Dispatch is the only trigger
+=== The version-changed guard is the release decision
 
-link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] declares
-`on: workflow_dispatch` and nothing else. *No merge -- of any pull request, touching any path --
-can cut a release.* Releasing is always an explicit act by a maintainer.
+link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] declares two triggers: an
+unconditional `workflow_dispatch`, and a `pull_request` narrowed by `types: [closed]`,
+`branches: [main]` and `paths: ['.github/project.yml']`. On the merge path the question *"is this
+merge a release?"* is answered by the pinned cuioss-organization workflow's *version-changed guard*,
+which compares the declared version against the parent commit's and refuses when it did not move.
 
-The scope of that statement is *release publication*, and it is stated narrowly on purpose. A merge
-to `main` is not inert: link:../../.github/workflows/maven.yml[`maven.yml`] runs on
-`push: branches: [main]`, and its snapshot deployment runs on that push (it is skipped on pull
-requests). So a merge can publish a *snapshot* -- what it cannot do is cut a release. The
-irrevocable act, a Maven Central GA coordinate, is reachable only through the dispatch.
+*That guard is consumed, never re-implemented here.* A local copy of a security-relevant decision is
+a second answer, and the local copy is the one that drifts out of sync. Do not add a caller-local
+version comparison.
 
-Do not add an event-driven trigger to the release workflow. A `pull_request` trigger scoped to
-`.github/project.yml` reads as a convenience -- merge the version bump, get the release -- but it
-makes every merge that touches that file a publication, and a Maven Central publication is
-irrevocable. Convenience is not worth an unintended GA.
+*The `paths:` filter is a prefilter, never the decision.* It matches *every* edit to
+`.github/project.yml` -- `name`, `description`, `maven-build`, `sonar`, `pages`, `github-automation`,
+and whatever key is added tomorrow -- so a merge arriving at the workflow proves nothing about the
+version. Its only job is to keep unrelated merges from spending a runner. Reading it as the release
+condition is precisely the 2026-07-12 defect: a trigger of exactly that shape fired on merged-ness
+and published an unintended GA coordinate that had to be abandoned and relocation-stubbed.
+
+`branches: [main]` filters on the pull request's *base*, so only a pull request merging into `main`
+can reach the release job at all, and the job additionally refuses any close that was not a merge.
+Both narrow *what may ask*, never *what is answered*.
+
+The scope of all this is *release publication*. A merge to `main` is not otherwise inert:
+link:../../.github/workflows/maven.yml[`maven.yml`] runs on `push: branches: [main]`, and its
+snapshot deployment runs on that push (it is skipped on pull requests). So a merge can publish a
+*snapshot* -- and, when the guard says the declared version moved, a release.
+
+The decision is recorded in
+link:../adr/0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc[ADR-0035],
+which supersedes ADR-0034.
 
 === A trigger removal merges on its own
 
@@ -234,8 +260,8 @@ is gone from `main` before relying on it being gone.
 
 == See also
 
-* link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] -- the dispatch-only
-  release workflow.
+* link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] -- the release workflow
+  and its two triggers.
 * link:../../.github/project.yml[`.github/project.yml`] -- where the released version is declared.
 * link:../user/container-image.adoc[Container Image] -- the operator layer for the published image.
 * link:README.adoc[Contributor Guide] -- the index for this documentation layer.

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -5,9 +5,9 @@
 
 How a release of API Sheriff is cut. A release has two entry points: merging a pull request that
 changes the declared version in `.github/project.yml`, which *is* the publishing act once the
-centrally-owned version-changed guard lets it through, and a deliberate `workflow_dispatch`, which
-publishes unconditionally and is the operator-gated fallback. This page states the process and the
-rules that keep it safe.
+centrally-owned version-changed guard lets it through, and a deliberate `workflow_dispatch` from
+`main`, which faces no central refusal and is the operator-gated fallback. This page states the
+process and the rules that keep it safe.
 
 == Cutting a release
 
@@ -25,9 +25,11 @@ The ordinary path is a single act -- merge the version declaration:
 approving a Maven Central publication, and a published coordinate can be superseded but never
 withdrawn.
 
-*`workflow_dispatch` is the fallback, and it is unconditional.* Actions -> Release -> Run workflow
-publishes whatever `.github/project.yml` declares at the dispatched ref, including a re-declaration
-of a version already published; nothing central refuses it. Reach for it when the merge path did not
+*`workflow_dispatch` is the fallback, and past one ref test it is unconditional.* The `release`
+job's `if:` confines the dispatch path to `refs/heads/main`; a dispatch from any other ref is
+skipped silently and publishes nothing. Dispatched from `main`, Actions -> Release -> Run workflow
+publishes whatever `.github/project.yml` declares there, including a re-declaration of a version
+already published -- nothing central refuses it. Reach for it when the merge path did not
 fire -- and when a merge cut no release, establish *which* of the guard's two conditions refused it
 before dispatching (<<guard-refusal-predicates>>). Only an unmoved version is a reason to dispatch.
 An already-existing tag means that version was already released, and dispatching then republishes a
@@ -230,10 +232,13 @@ are normative.
 [#guard-refusal-predicates]
 === The version-changed guard is the release decision
 
-link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] declares two triggers: an
-unconditional `workflow_dispatch`, and a `pull_request` narrowed by `types: [closed]`,
-`branches: [main]` and `paths: ['.github/project.yml']`. On the merge path the question *"is this
-merge a release?"* is answered by the pinned cuioss-organization workflow's *version-changed guard*.
+link:../../.github/workflows/release.yml[`.github/workflows/release.yml`] declares two triggers: a
+`workflow_dispatch` carrying no branch filter, and a `pull_request` narrowed by `types: [closed]`,
+`branches: [main]` and `paths: ['.github/project.yml']`. The `release` job's `if:` then narrows each
+path once more -- the dispatch path to `refs/heads/main`, the merge path to `merged == true` -- so a
+dispatch from a non-`main` ref is skipped before anything is published. On the merge path the
+question *"is this merge a release?"* is answered by the pinned cuioss-organization workflow's
+*version-changed guard*.
 
 *It refuses on either of two conditions, and a refusal announces neither of them:*
 
@@ -243,7 +248,8 @@ merge a release?"* is answered by the pinned cuioss-organization workflow's *ver
 Both must be false for the merge to publish. The guard is named for the first condition because that
 is what it was added for, but reading a no-release outcome as "the version didn't move" is a
 one-predicate reading of a two-predicate guard -- and it is exactly the misreading that sends an
-operator to the unconditional dispatch after a partial release (see <<release-not-atomic>>).
+operator to the dispatch fallback after a partial release (see <<release-not-atomic>>), where no
+central guard refuses at all.
 
 *That guard is consumed, never re-implemented here.* A local copy of a security-relevant decision is
 a second answer, and the local copy is the one that drifts out of sync. Do not add a caller-local

--- a/doc/resources/diagrams/release-publish-flow.svg
+++ b/doc/resources/diagrams/release-publish-flow.svg
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Release publish flow — two independent tracks: the release lane (one dispatch, one image build,
-  everything downstream addressing that one image) and the pull-request lane (an independent,
-  non-gating early signal). The two tracks deliberately never converge.
+  Release publish flow — two independent tracks: the release lane (one release run, entered by a
+  guarded version-bump merge or a deliberate dispatch, one image build, everything downstream
+  addressing that one image) and the pull-request lane (an independent, non-gating early signal).
+  The two tracks deliberately never converge.
   theme-handling: A (theme-neutral)
   see  pm-documents:ref-svg-diagrams/standards/diagram-type-flow.md
 -->
@@ -10,7 +11,7 @@
      role="img" aria-labelledby="title desc"
      font-family="ui-sans-serif, -apple-system, system-ui, 'Segoe UI', sans-serif">
   <title id="title">API Sheriff release publish flow</title>
-  <desc id="desc">Two independent tracks. On the release lane, a manual workflow_dispatch cuts the Maven release, the publish job checks out the release tag and asserts the version, and the integration-test suite runs — that suite's docker compose build is the ONE and ONLY image build in the lane, so what is published is by construction exactly what was tested. A Syft SBOM and a gating Trivy scan at HIGH and CRITICAL then run before any registry write; a finding at either severity fails the release. Only then are the two tags pushed, the published digest pulled back and asserted identical to the tested image, and that same digest signed keylessly with Cosign. On the pull-request lane, an independent non-gating scan of the pinned base image and the repository filesystem reports on every change without ever building an image or failing the check. The two lanes never converge.</desc>
+  <desc id="desc">Two independent tracks. The release lane is entered by either of two triggers — merging a version change that the centrally-owned version-changed guard admits, or a deliberate workflow_dispatch. From there the Maven release is cut, the publish job checks out the release tag and asserts the version, and the integration-test suite runs — that suite's docker compose build is the ONE and ONLY image build in the lane, so what is published is by construction exactly what was tested. A Syft SBOM and a gating Trivy scan at HIGH and CRITICAL then run before any registry write; a finding at either severity fails the release. Only then are the two tags pushed, the published digest pulled back and asserted identical to the tested image, and that same digest signed keylessly with Cosign. On the pull-request lane, an independent non-gating scan of the pinned base image and the repository filesystem reports on every change without ever building an image or failing the check. The two lanes never converge.</desc>
 
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -31,7 +32,7 @@
   </defs>
 
   <!-- ============================ release lane ============================ -->
-  <text x="580" y="24" class="note">Manual dispatch is the only trigger &#8212; no event-driven trigger exists on the release workflow</text>
+  <text x="580" y="24" class="note">Two entry paths &#8212; a version-bump merge the central guard admits, or a deliberate dispatch</text>
   <text x="20" y="54" class="lane">Release lane</text>
 
   <!-- track line (passes through every stage) -->
@@ -51,7 +52,7 @@
   <path class="stroke" d="M574,136 L629,98 L684,136 L629,174 Z"/>
 
   <!-- stage labels (above the track) -->
-  <text x="85"   y="88" class="stage">Dispatch</text>
+  <text x="85"   y="88" class="stage">Trigger</text>
   <text x="221"  y="88" class="stage">Maven release</text>
   <text x="357"  y="88" class="stage">Check out tag</text>
   <text x="493"  y="88" class="stage">IT suite</text>
@@ -61,7 +62,7 @@
   <text x="1037" y="88" class="stage">Cosign sign</text>
 
   <!-- stage sub-detail (below the track) -->
-  <text x="85"   y="192" class="sub">operator-initiated</text>
+  <text x="85"   y="192" class="sub">guarded merge<tspan x="85" dy="13">or dispatch</tspan></text>
   <text x="221"  y="192" class="sub">pushes the release tag</text>
   <text x="357"  y="192" class="sub">assert version match</text>
   <text x="493"  y="192" class="sub">THE one image build</text>

--- a/doc/user/container-image.adoc
+++ b/doc/user/container-image.adoc
@@ -189,7 +189,7 @@ DIGEST="$(docker image inspect \
 [ "$(printf '%s\n' "$DIGEST" | grep -c .)" -eq 1 ] || { echo "expected exactly one digest, got: $DIGEST"; exit 1; }
 
 cosign verify \
-  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/(heads/main|pull/[0-9]+/merge)$' \
+  --certificate-identity-regexp '^https://github\.com/cuioss/API-Sheriff/\.github/workflows/release\.yml@refs/heads/main$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   "${DIGEST}"
 ----
@@ -201,8 +201,9 @@ the same string.
 Both flags are mandatory, and each pins a different half of the claim:
 
 `--certificate-identity-regexp`::
-*Who* signed it -- the exact workflow, in the exact repository, on one of exactly two accepted refs.
-It is what binds the check to this project's release lane rather than to any workflow anywhere.
+*Who* signed it -- the exact workflow, in the exact repository, on the single accepted ref
+`refs/heads/main`. It is what binds the check to this project's release lane rather than to any
+workflow anywhere.
 
 `--certificate-oidc-issuer`::
 *Which identity provider* vouched for that identity. It is what stops the same identity string,
@@ -229,17 +230,29 @@ as a tooling problem to work around.
 
 === Why the identity is a pattern, and why it is still exact
 
-The signing identity is the release workflow's ref, and this project cuts releases from two paths: a
-deliberate dispatch from `main`, and the merge of a version-changing `.github/project.yml` pull
-request. GitHub stamps the certificate with the ref the run was triggered on, so the first path signs
-under `@refs/heads/main` and the second under `@refs/pull/<number>/merge`. Both are legitimate
-releases -- the merge path only reaches the publishing job after the central version-changed guard
-has confirmed the declared version actually moved.
+The signing identity is the release workflow's ref, and every release this project has cut signed
+under the same one -- `@refs/heads/main`. That is not inferred from the trigger configuration; it is
+read off the certificates themselves. Both published digests carry an identical `job_workflow_ref`
+SAN even though they were produced by *different* triggers:
 
-*The pattern admits those two refs and nothing else.* It is anchored at both ends, so it matches the
-whole identity rather than appearing somewhere inside a longer one; it names this repository and this
-workflow file literally; and the pull-request number is digits-only. A signature from any other
-workflow, any other repository, or any other ref fails the check.
+* *0.1.0*, cut by `workflow_dispatch` -- `job_workflow_ref` =
+  `.../workflows/release.yml@refs/heads/main`.
+* *0.1.1*, cut by merging a version-changing `.github/project.yml` pull request --
+  `job_workflow_ref` = `.../workflows/release.yml@refs/heads/main`.
+
+The 0.1.1 case is the one that settles it: a merge-triggered release signed under `@refs/heads/main`,
+not under a merge ref. A pull request closed *by being merged* runs against the branch it was merged
+into, so both of this project's release paths converge on the same ref.
+
+*So why a pattern, if the accepted set is a single value?* Because the flag is
+`--certificate-identity-regexp`, and the identity string contains regexp metacharacters -- the dots
+in `github.com` and in `.github/workflows/release.yml`. Escaping those and anchoring the expression
+is what makes the pattern behave as the literal it is meant to be.
+
+*And it is still exact.* It is anchored at both ends, so it matches the whole identity rather than
+appearing somewhere inside a longer one, and it names this repository and this workflow file
+literally. A signature from any other workflow, any other repository, or any other ref fails the
+check.
 
 Do not relax it to a wildcard. An identity pattern that accepts anything accepts a signature from any
 workflow in any repository, which turns the verification into a formality that always passes.


### PR DESCRIPTION
## Summary

The repository's prose still asserted a **dispatch-only** release posture that PR #171 retired, and
the Cosign signing identity had been widened to accept `refs/pull/<N>/merge` on a premise this
project's own signing certificates refute. This PR narrows the identity back to a single exact ref
and reconciles every statement of the release posture with the two-path trigger that is actually
live.

Seven peer deliverables:

1. **D1** — narrow the Cosign signing identity to `...release.yml@refs/heads/main` in every carrier
   and rewrite the justification around decoded first-party certificate evidence.
2. **D2** — correct `.github/workflows/release.yml`'s account of `GITHUB_REF` under
   `pull_request: closed`.
3. **D3** — author ADR-0035 and supersede ADR-0034 by status only.
4. **D4** — reconcile `doc/development/release-process.adoc` across its full posture surface.
5. **D5** — clear the residual drift in `.claude/skills/release/SKILL.md`.
6. **D6** — sweep the remaining posture carriers outside that narrative.
7. **D7** — retire the `release/relocation-stubs` branch together with **both** runbook guards that
   reference it.

## Changes

- `.github/workflows/release.yml` — signing identity narrowed to the single anchored ref in both the
  `Sign the published digest` comment block and the verify step's `IDENTITY_REGEXP`; the `GITHUB_REF`
  commentary corrected to state that the signing job is reachable only on merged-close and on
  dispatch, and that both yield `refs/heads/main`. The `cosign verify` step's other flags and the
  `branches: [main]` base filter are untouched.
- `doc/user/container-image.adoc` — the operator-facing verify command, the surrounding prose and the
  *why the identity is a pattern* subsection rewritten for the single-ref form.
- `doc/adr/0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc`
  — new ADR recording the live two-path trigger and the central version-changed ownership. The number
  `0035` is pinned by `release.yml`, so it fills a gap out of sequence; that is intended.
- `doc/adr/0034-Publication_is_triggered_only_by_a_deliberate_standalone_invocation_never_by_a_repository_event_or_an_automated_lifecycle_step.adoc`
  — status flipped to *Superseded* with a pointer to ADR-0035. The body is left verbatim.
- `doc/development/release-process.adoc` — the dispatch-only narrative replaced by the guarded
  merge-plus-dispatch account, across the title, the intro, *Cutting a release* and the trigger-rules
  section.
- `.claude/skills/release/SKILL.md` — residual drift cleared (the dangling-ADR-0035 statements, the
  stale *See also* entry), and D7's two `release/relocation-stubs` guards removed together: the
  `HARD BOUNDARY` block with its fetch and ancestry check, and the Critical-rules restatement with its
  qualified-refspec fetch.
- `doc/development/README.adoc`, `doc/README.adoc` — remaining statements of the retired posture
  corrected.
- `doc/resources/diagrams/release-publish-flow.svg` — the published flow diagram updated to show both
  trigger paths.

## Post-merge follow-up (required)

**This PR leaves exactly one action outstanding.** It is deferred by explicit operator ruling, not
forgotten. Whoever merges this PR owns it.

```bash
git push origin --delete release/relocation-stubs
```

**Precondition — merge this PR first.** Until these runbook edits are on `main`, `main` still carries
a live ancestry check against `refs/heads/release/relocation-stubs`. Deleting the branch while that
check is live leaves `git merge-base --is-ancestor` unable to resolve the ref, so the check lands on
the runbook's own arm:

> `ERROR: the check did not evaluate - this is NOT a pass`

That fail-closed state is precisely what this plan exists to remove, so running the delete early would
reintroduce it. Merge first, then delete.

**The safety is already in place.** The tag `relocation-stubs-published` is pushed and confirmed at
`67c8339` — the same commit `release/relocation-stubs` points at — so the published relocation stubs
keep a durable provenance pointer whether or not the branch is deleted. Maven Central artifacts are
never withdrawn, so nothing further is owed once the delete is done.

**Completion check.** The follow-up is complete when

```bash
git ls-remote --heads origin release/relocation-stubs
```

returns empty. A run that shows neither the branch nor the tag is the irreversible failure state and
must be escalated immediately, never retried.

## Evidence note on D1

D1's narrowing is backed by **first-party evidence, not by vendor documentation**. Both signed image
digests were pulled anonymously from GHCR and their signing certificates decoded:

| Release | Trigger | `job_workflow_ref` in the signing certificate |
|---------|---------|-----------------------------------------------|
| 0.1.0 | `workflow_dispatch` | `.../release.yml@refs/heads/main` |
| 0.1.1 | `pull_request` (merged close) | `.../release.yml@refs/heads/main` |

Both triggers — including the merge-triggered one that motivated the widening — sign at
`refs/heads/main`. There is no counterexample, so narrowing the Cosign identity to that single ref
cannot break verification of any published artifact. GitHub's `events-that-trigger-workflows`
reference is retained in the prose only as corroboration.

## Test Plan

- [x] Quality gate green (`verify -Ppre-commit`) — the footprint touches
  `.github/workflows/release.yml`, so the documentation-only skip does not apply.
- [x] Full `verify` green.
- [x] Pre-submission self-review: 3 findings across 2 rounds, all fixed and verified.
- [x] D1 acceptance gate: every carrier on the outline-fixed named list read and confirmed to carry
  zero occurrences of the widened form and the narrowed form in the expected count. **Stated
  limitation:** this gate is exhaustive over the named list only — no sanctioned tool in this project
  can run a repository-wide content search across `.github/**` and `.claude/**`, so a carrier in an
  unnamed file under those trees would not have been caught.
- [ ] Post-merge: run the branch delete above.

## Related Issues

None — this plan originates from an orchestrator epic, not from a GitHub issue.

## Intent

**The problem.** Two independent defects, both about the release path. First, the repository's prose still asserts a *dispatch-only* release posture that PR #171 retired: `release.yml` has carried a guarded `pull_request: closed` trigger alongside `workflow_dispatch` since then, and the version-changed decision is centrally owned. Second, PLAN-48 widened the Cosign signing identity to also accept `refs/pull/<N>/merge`, on the premise that a merge-triggered run signs under the merge ref. This project's own signing certificates refute that premise: the 0.1.1 release was cut by a `pull_request`-triggered run and signed at `refs/heads/main`.

**The approach.** Narrow the identity back to a single anchored ref (`...release.yml@refs/heads/main`) in every carrier, keeping `--certificate-identity-regexp` so the operator-facing command shape is unchanged, and rewrite the justification to lead with the decoded certificate rather than with vendor documentation. Then reconcile the prose with the trigger that is actually live: correct `release.yml`'s account of `GITHUB_REF`, author ADR-0035 (the number pinned by `release.yml:19`) superseding ADR-0034, rewrite the release-process narrative, clear the residual runbook drift, and retire the `release/relocation-stubs` branch guard now that the branch's provenance is pinned by a tag.

**Explicit non-goals.** `.github/project.yml` is not

_[Intent truncated — 1391 of 2226 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases can now be initiated by merged version changes or manual dispatch from the main branch.
  * Release outputs, recovery guidance, tagging, and tested-image promotion are documented.

* **Security**
  * Container signature verification accepts only releases signed by the main-branch workflow.

* **Documentation**
  * Added ADR-0035 and marked the previous release-trigger ADR as superseded.
  * Updated release-process, container-image, and ADR index documentation with the new release paths and safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->