### PR TITLE
fix(gate): close build.map coverage gap, run release negative control

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -25,4 +25,4 @@ pages:
 
 github-automation:
   auto-merge-build-versions: true
-  auto-merge-build-timeout: 300
+  auto-merge-build-timeout: 900

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,10 @@ jobs:
   # WHY `needs.release.outputs.released-version != ''` IS THE RUN/SKIP DISCRIMINATOR.
   # At the pinned 937fbcf (v0.18.0) the reusable workflow DOES declare an `on.workflow_call.outputs`
   # block, so `released-version` is genuinely readable here. It is EMPTY exactly when the central
-  # guard decided the declared version had not changed and skipped the release — so the empty string
-  # IS that guard's own decision, surfaced. The caller consumes it and derives nothing. Without this
-  # `if:`, a guard-skipped merge would still spend 90 minutes on a native build and then re-push and
-  # re-sign an already-released tag.
+  # guard declined to release — the declared version did not move, or a tag for it already exists —
+  # so an empty string proves no release was produced, never which predicate refused. The caller
+  # consumes it and derives nothing. Without this `if:`, a guard-skipped merge would still spend 90
+  # minutes on a native build, then re-push and re-sign an already-released tag.
   #
   # The two obvious alternatives are both wrong. `needs.release.result` reports a non-failure for a
   # called workflow whose internal jobs all skipped, so it cannot tell a real release from a skipped

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -174,7 +174,17 @@
     "map": {
       "java": [
         {
+          "glob": "*.css",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
           "glob": "*.sh",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
+          "glob": "*.ts",
           "role": "config",
           "build_class": "verify"
         },
@@ -202,6 +212,21 @@
           "glob": "*/src/test/resources/*",
           "role": "test",
           "build_class": "module-tests"
+        },
+        {
+          "glob": ".github/workflows/*",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
+          "glob": "Dockerfile*",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
+          "glob": "docker-compose*.yml",
+          "role": "config",
+          "build_class": "verify"
         },
         {
           "glob": "pom.xml",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ Skip when **every** changed file is one of:
 or a build script. A mixed commit is *not* documentation-only: one Java file in an otherwise-prose
 change makes the whole commit subject to the gate.
 
+This enumeration and the `build.map` contract that `build-decision` reads now cover the same path
+classes, so what the rule declares gate-requiring is what the tooling actually gates. Naming that
+agreement next to the rule is what makes a future divergence visible — if the two ever stop covering
+the same classes, this paragraph is the claim that has become false. The cost is real and intended:
+every workflow, Dockerfile and compose change now pays a full gate instead of passing as
+documentation-only. That is the trade the rule above asks for, not a regression to be tuned away.
+
 Doubt resolves toward running it. The cost of an unnecessary build is minutes; the cost of a skipped
 one is a red `main`.
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.sheriff.gateway.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the {@code build.map.java} entries that make the repository's declared gate-requiring file
+ * classes actually reach a build, so erasing one becomes a red build instead of a silent hole.
+ * <p>
+ * <strong>Why this test exists.</strong> {@code CLAUDE.md} lines 65-66 declare which file classes
+ * oblige a full quality gate: {@code *.java}, {@code pom.xml}, {@code *.js}, {@code *.ts},
+ * {@code *.css}, {@code src/main/resources/**}, {@code .github/workflows/**}, {@code Dockerfile*}
+ * and {@code docker-compose*.yml}. That declaration is prose; the surface that <em>enforces</em> it
+ * is {@code .plan/marshal.json}'s {@code build.map}, which the {@code build-decision} verb consults
+ * to answer "does this footprint need a build?". The two had drifted: five of the declared classes
+ * were mapped by nothing at all, so a change touching only a workflow, a Dockerfile, a compose file,
+ * a stylesheet or a TypeScript source returned {@code not_necessary} and shipped without the gate
+ * the declaration demands. The gap is invisible from either side — the prose still reads as
+ * authoritative, and the map is well-formed — which is exactly the shape a contract test exists for.
+ * <p>
+ * <strong>Why the five entries need pinning specifically.</strong> They are <em>hand-added</em>. The
+ * build map is otherwise seeded from the applicable domain extensions, and an entry is preserved by
+ * a re-seed only when some extension's {@code classify_globs()} derives it. No extension derives
+ * these five, so they are re-derivable from nothing and are erased on either of two routes:
+ * {@code manage-config build-map seed --force}, which rewrites the block from the derivation, and a
+ * {@code marshall-steward} reconcile, which drives that same seeding path during configuration
+ * upgrade. {@code manage-config build-map drift} reports them as removed rather than restoring them.
+ * An erasure is therefore a normal-looking maintenance action with no local symptom — the map still
+ * parses, every remaining entry is correct, and the only observable consequence is that some future
+ * change quietly stops being gated. This guard converts that silence into a failing build.
+ * <p>
+ * <strong>Containment, not equality.</strong> The assertion is that each required glob is
+ * <em>present</em> with {@code role: config} and {@code build_class: verify} — deliberately not that
+ * the java block holds exactly twelve entries. A legitimate future seed adding a Maven route must
+ * not fail this guard; only losing one of the five, or weakening a required entry's
+ * {@code build_class} away from {@code verify}, may.
+ * <p>
+ * <strong>The required globs are hand-written here, not read from {@code CLAUDE.md}.</strong> The
+ * map's spellings deliberately differ from the human-readable declaration: the route contract admits
+ * single-{@code *} fnmatch globs and bare basenames but never a recursive {@code **}, so
+ * {@code .github/workflows/**} is respelled {@code .github/workflows/*} in the map. Deriving one
+ * from the other would encode that translation as a second piece of logic to keep correct. This test
+ * pins the <em>map</em> side only; it asserts nothing about what {@code CLAUDE.md} still says.
+ * <p>
+ * <strong>No vacuous pass.</strong> Both the required-glob set's cardinality and the parsed java
+ * array's non-emptiness are asserted before the per-glob loop, so neither a shrunken constant nor a
+ * lost {@code build.map.java} node can let the loop pass by iterating over nothing. A matched
+ * positive/negative control drives a synthetic map through the same extraction helper — one entry
+ * correct, one with the wrong {@code build_class}, one absent — so the primary assertion cannot be
+ * green merely because the detector accepts everything.
+ *
+ * @author API Sheriff Team
+ * @since 1.0
+ */
+@DisplayName("build.map covers every file class declared gate-requiring")
+class BuildGateCoverageContractTest {
+
+    /** The working directory the runner started in — the module root under surefire. */
+    private static final Path MODULE = Path.of(System.getProperty("user.dir"));
+
+    /**
+     * The repository-root marker, and the file this contract asserts over. It is tracked in git, so
+     * it resolves in a fresh checkout exactly as it does locally.
+     */
+    private static final String MARSHAL_JSON = ".plan/marshal.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String BUILD = "build";
+    private static final String MAP = "map";
+    private static final String JAVA_DOMAIN = "java";
+
+    private static final String GLOB = "glob";
+    private static final String ROLE = "role";
+    private static final String BUILD_CLASS = "build_class";
+
+    /** The role every required entry must carry: these are build-affecting configuration files. */
+    private static final String REQUIRED_ROLE = "config";
+
+    /**
+     * The build class every required entry must carry. {@code verify} is the strongest class and the
+     * only one that satisfies the declaration — a required entry demoted to {@code compile} would
+     * gate the change with something weaker than the full quality gate {@code CLAUDE.md} demands,
+     * which is why the assertion pins the class rather than merely the glob's presence.
+     */
+    private static final String REQUIRED_BUILD_CLASS = "verify";
+
+    /**
+     * The five globs whose absence from {@code build.map.java} is the gap this guard closes, written
+     * in the map's own route-contract spelling rather than derived from {@code CLAUDE.md}. Held as a
+     * set so a copy-paste duplicate collapses and is caught by the cardinality assertion below.
+     */
+    private static final Set<String> REQUIRED_GLOBS = new LinkedHashSet<>(List.of(
+            ".github/workflows/*",
+            "Dockerfile*",
+            "docker-compose*.yml",
+            "*.css",
+            "*.ts"));
+
+    /** How many distinct globs {@link #REQUIRED_GLOBS} must carry; see that field's rationale. */
+    private static final int REQUIRED_GLOB_COUNT = 5;
+
+    /**
+     * A synthetic {@code build.map.java} block for the detector control: one entry that must be
+     * accepted, and one whose {@code build_class} is deliberately wrong so it must be rejected even
+     * though its glob is present.
+     */
+    private static final String SYNTHETIC_JAVA_MAP = """
+            [
+              { "glob": "*.control-present",     "role": "config", "build_class": "verify" },
+              { "glob": "*.control-wrong-class", "role": "config", "build_class": "compile" }
+            ]
+            """;
+
+    private static final String CONTROL_PRESENT_GLOB = "*.control-present";
+    private static final String CONTROL_WRONG_CLASS_GLOB = "*.control-wrong-class";
+    private static final String CONTROL_ABSENT_GLOB = "*.control-absent";
+
+    @Test
+    @DisplayName("Every declared gate-requiring file class is mapped with role config and build_class verify")
+    void buildMapCoversEveryDeclaredGateRequiringFileClass() throws Exception {
+        // Arrange
+        JsonNode entries = javaBuildMap();
+
+        // Act + Assert — the two vacuity guards run BEFORE the loop: without them a shrunken
+        // constant or a lost build.map.java node would let the loop pass by iterating over nothing
+        assertEquals(REQUIRED_GLOB_COUNT, REQUIRED_GLOBS.size(),
+                "the required-glob set no longer carries " + REQUIRED_GLOB_COUNT + " distinct globs, so the"
+                        + " loop below would assert over a shrunken set and pass while a declared file class"
+                        + " went unmapped. Either a glob was deleted from the constant, or two entries were"
+                        + " spelled identically and collapsed");
+        assertFalse(entries.isEmpty(),
+                MARSHAL_JSON + ": build.map.java is an empty array, so this guard would assert over nothing."
+                        + " The whole java block is gone, not merely one entry — restore it rather than"
+                        + " relaxing this check");
+
+        for (String glob : REQUIRED_GLOBS) {
+            assertTrue(carriesGateEntry(entries, glob), () -> missingEntryMessage(glob));
+        }
+    }
+
+    /**
+     * Matched positive/negative control over the extraction helper itself. Without it the assertion
+     * above is unfalsifiable by inspection: it is green today because the map is complete, and it
+     * would be equally green if {@link #carriesGateEntry(JsonNode, String)} accepted every glob it
+     * was handed.
+     */
+    @Test
+    @DisplayName("The detector accepts a correct entry and rejects both a wrong build_class and an absent glob")
+    void detectorAcceptsOnlyAnEntryMatchingGlobRoleAndBuildClass() throws Exception {
+        // Arrange
+        JsonNode entries = MAPPER.readTree(SYNTHETIC_JAVA_MAP);
+
+        // Act
+        boolean acceptsCorrectEntry = carriesGateEntry(entries, CONTROL_PRESENT_GLOB);
+        boolean acceptsWrongBuildClass = carriesGateEntry(entries, CONTROL_WRONG_CLASS_GLOB);
+        boolean acceptsAbsentGlob = carriesGateEntry(entries, CONTROL_ABSENT_GLOB);
+
+        // Assert
+        assertTrue(acceptsCorrectEntry, "the detector rejected an entry carrying the requested glob with"
+                + " role '" + REQUIRED_ROLE + "' and build_class '" + REQUIRED_BUILD_CLASS + "'. It would"
+                + " then reject the real entries too, and the guard above would fail for a reason that has"
+                + " nothing to do with the map");
+        assertFalse(acceptsWrongBuildClass, "the detector accepted an entry whose glob matches but whose"
+                + " build_class is not '" + REQUIRED_BUILD_CLASS + "'. Demoting a required entry's"
+                + " build_class gates the change with something weaker than the declared quality gate, so"
+                + " it must be caught rather than tolerated");
+        assertFalse(acceptsAbsentGlob, "the detector accepted a glob the synthetic map does not contain,"
+                + " so it is not actually reading the entries and the guard above proves nothing");
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    /**
+     * The failure message for a required glob that {@code build.map.java} no longer carries. It names
+     * the glob, explains why the entry disappears without anyone deleting it on purpose, and points
+     * at the declaration the map is supposed to honour.
+     *
+     * @param glob the required glob that is missing or misconfigured
+     * @return the assertion message
+     */
+    private static String missingEntryMessage(String glob) {
+        return MARSHAL_JSON + ": build.map.java carries no entry for the glob '" + glob + "' with role '"
+                + REQUIRED_ROLE + "' and build_class '" + REQUIRED_BUILD_CLASS + "'. Without it a change"
+                + " touching that file class makes build-decision answer 'not_necessary', and the change"
+                + " ships without the quality gate CLAUDE.md lines 65-66 declare it requires."
+                + " This entry is hand-added: no extension's classify_globs() derives it, so it is"
+                + " re-derivable from nothing and is erased by 'manage-config build-map seed --force' and"
+                + " by a marshall-steward reconcile driving that same seeding path;"
+                + " 'manage-config build-map drift' reports it as removed rather than restoring it."
+                + " Re-add the entry to " + MARSHAL_JSON + " — do NOT delete this test to make the build"
+                + " green, because deleting it restores exactly the silent coverage gap it was written to"
+                + " close.";
+    }
+
+    /**
+     * Whether the entries carry one naming {@code glob} with the required role and build class. This
+     * is the extraction the control test exercises against a synthetic map.
+     *
+     * @param entries the {@code build.map.java} array
+     * @param glob    the glob to look for
+     * @return {@code true} when some entry matches on all three fields
+     */
+    private static boolean carriesGateEntry(JsonNode entries, String glob) {
+        for (JsonNode entry : entries) {
+            if (glob.equals(entry.path(GLOB).asText())
+                    && REQUIRED_ROLE.equals(entry.path(ROLE).asText())
+                    && REQUIRED_BUILD_CLASS.equals(entry.path(BUILD_CLASS).asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The {@code build.map.java} array parsed out of the repository's {@code marshal.json}.
+     * <p>
+     * The file is parsed as JSON rather than string-matched: a raw {@code contains} over the document
+     * text would match a glob mentioned anywhere — in the javascript block, or in a comment-shaped
+     * string — and would report success for an entry that is not where the build map reads it.
+     *
+     * @return the java domain's entry array
+     * @throws IOException when the file cannot be read
+     */
+    private static JsonNode javaBuildMap() throws IOException {
+        Path marshalJson = repoRoot().resolve(MARSHAL_JSON);
+        JsonNode entries = MAPPER.readTree(Files.readString(marshalJson)).path(BUILD).path(MAP).path(JAVA_DOMAIN);
+        if (!entries.isArray()) {
+            return fail(marshalJson + ": build.map.java is absent or is not an array, so the file-to-build"
+                    + " contract this guard asserts over does not exist. Restore the build.map.java block"
+                    + " rather than relaxing this check");
+        }
+        return entries;
+    }
+
+    /**
+     * The repository root — the nearest ancestor of the working directory that actually holds
+     * {@link #MARSHAL_JSON}.
+     * <p>
+     * The search walks up rather than taking a fixed one-level hop because the working directory is
+     * not the same everywhere: surefire runs with the module as its working directory, but an IDE
+     * runner or an aggregator invocation may use another. Probing for the marker resolves the root
+     * from a property of the tree instead of from an assumption about the runner, and a genuinely
+     * unresolvable root then fails naming the directory it started from rather than surfacing later
+     * as a {@code NoSuchFileException} on a path nobody asked for.
+     *
+     * @return the repository root
+     */
+    private static Path repoRoot() {
+        for (Path candidate = MODULE; candidate != null; candidate = candidate.getParent()) {
+            if (Files.isRegularFile(candidate.resolve(MARSHAL_JSON))) {
+                return candidate;
+            }
+        }
+        return fail("cannot resolve the repository root from the working directory " + MODULE
+                + ": no ancestor of it holds " + MARSHAL_JSON + ", which is this contract's root marker"
+                + " and the file it asserts over");
+    }
+}

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
@@ -95,14 +95,6 @@ class BuildGateCoverageContractTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private static final String BUILD = "build";
-    private static final String MAP = "map";
-    private static final String JAVA_DOMAIN = "java";
-
-    private static final String GLOB = "glob";
-    private static final String ROLE = "role";
-    private static final String BUILD_CLASS = "build_class";
-
     /** The role every required entry must carry: these are build-affecting configuration files. */
     private static final String REQUIRED_ROLE = "config";
 
@@ -232,9 +224,9 @@ class BuildGateCoverageContractTest {
      */
     private static boolean carriesGateEntry(JsonNode entries, String glob) {
         for (JsonNode entry : entries) {
-            if (glob.equals(entry.path(GLOB).asText())
-                    && REQUIRED_ROLE.equals(entry.path(ROLE).asText())
-                    && REQUIRED_BUILD_CLASS.equals(entry.path(BUILD_CLASS).asText())) {
+            if (glob.equals(entry.path("glob").asText())
+                    && REQUIRED_ROLE.equals(entry.path("role").asText())
+                    && REQUIRED_BUILD_CLASS.equals(entry.path("build_class").asText())) {
                 return true;
             }
         }
@@ -253,7 +245,7 @@ class BuildGateCoverageContractTest {
      */
     private static JsonNode javaBuildMap() throws IOException {
         Path marshalJson = repoRoot().resolve(MARSHAL_JSON);
-        JsonNode entries = MAPPER.readTree(Files.readString(marshalJson)).path(BUILD).path(MAP).path(JAVA_DOMAIN);
+        JsonNode entries = MAPPER.readTree(Files.readString(marshalJson)).path("build").path("map").path("java");
         if (!entries.isArray()) {
             return fail(marshalJson + ": build.map.java is absent or is not an array, so the file-to-build"
                     + " contract this guard asserts over does not exist. Restore the build.map.java block"

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
@@ -139,7 +139,7 @@ class BuildGateCoverageContractTest {
 
     @Test
     @DisplayName("Every declared gate-requiring file class is mapped with role config and build_class verify")
-    void buildMapCoversEveryDeclaredGateRequiringFileClass() throws IOException {
+    void buildMapCoversEveryDeclaredGateRequiringFileClass() throws Exception {
         // Arrange
         JsonNode entries = javaBuildMap();
 
@@ -168,7 +168,7 @@ class BuildGateCoverageContractTest {
      */
     @Test
     @DisplayName("The detector accepts a correct entry and rejects both a wrong build_class and an absent glob")
-    void detectorAcceptsOnlyAnEntryMatchingGlobRoleAndBuildClass() throws IOException {
+    void detectorAcceptsOnlyAnEntryMatchingGlobRoleAndBuildClass() throws Exception {
         // Arrange
         JsonNode entries = MAPPER.readTree(SYNTHETIC_JAVA_MAP);
 

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
@@ -139,7 +139,7 @@ class BuildGateCoverageContractTest {
 
     @Test
     @DisplayName("Every declared gate-requiring file class is mapped with role config and build_class verify")
-    void buildMapCoversEveryDeclaredGateRequiringFileClass() throws Exception {
+    void buildMapCoversEveryDeclaredGateRequiringFileClass() throws IOException {
         // Arrange
         JsonNode entries = javaBuildMap();
 
@@ -168,7 +168,7 @@ class BuildGateCoverageContractTest {
      */
     @Test
     @DisplayName("The detector accepts a correct entry and rejects both a wrong build_class and an absent glob")
-    void detectorAcceptsOnlyAnEntryMatchingGlobRoleAndBuildClass() throws Exception {
+    void detectorAcceptsOnlyAnEntryMatchingGlobRoleAndBuildClass() throws IOException {
         // Arrange
         JsonNode entries = MAPPER.readTree(SYNTHETIC_JAVA_MAP);
 

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -323,9 +323,13 @@ repository's history. It is retained because it corroborates the four rows, neve
 substitutes for them.
 
 *Provenance of the discriminator.* link:../../.github/workflows/release.yml[`release.yml`] lines
-87--101 state the workflow's own contract: `released-version` "is EMPTY exactly when the central
-guard decided the declared version had not changed and skipped the release". The evidence is the
-mechanism's declared contract, not an inference drawn over its behaviour.
+87--101 declare `released-version` the run/skip discriminator for the downstream jobs: an empty
+value skips them. What an empty value proves is exactly that *no release was produced* -- not that
+the declared version was unchanged. Emptiness is the union of both refusal predicates named in
+<<guard-refusal-predicates>>, so it cannot discriminate a version that did not move from a tag that
+already exists. Row 2 is therefore evidence drawn from the mechanism's declared contract rather
+than an inference over its behaviour -- but read as the narrower claim it would be the very
+one-predicate reading <<guard-refusal-predicates>> warns against.
 
 *Escalation condition.* If the observed rendering does not match the predicted signature, that is a
 finding about the guard, not a run id to file. It goes in-tree, in a follow-up PR, and the

--- a/doc/development/release-process.adoc
+++ b/doc/development/release-process.adoc
@@ -227,7 +227,8 @@ cryptographically verifying the published image.
 == Trigger rules
 
 Two rules govern how the release workflow may be triggered, and how a trigger may be changed. Both
-are normative.
+are normative. The two subsections following the first rule are not further rules: they record the
+empirical control run against that rule, and what that control does and does not establish.
 
 [#guard-refusal-predicates]
 === The version-changed guard is the release decision
@@ -274,6 +275,92 @@ snapshot deployment runs on that push (it is skipped on pull requests). So a mer
 The decision is recorded in
 link:../adr/0035-A_release_is_cut_by_a_guarded_version-bump_merge_or_a_deliberate_dispatch_and_the_version-changed_decision_is_centrally_owned.adoc[ADR-0035],
 which supersedes ADR-0034.
+
+[#guard-negative-control]
+=== The observed refusal: a negative control over the guard
+
+*This subsection was written before the merge it describes.* What follows is a prediction, not a
+report. That ordering is what makes it falsifiable: an artifact written afterwards can only agree
+with whatever happened, while this one can be shown wrong.
+
+*The design.* A change to one non-`release:` key of
+link:../../.github/project.yml[`.github/project.yml`] is merged. The `paths:` prefilter matches
+*every* edit to that file, so the workflow fires; both `if:` operands are true on a merged pull
+request, so the `release` job runs; and the version-changed guard executes inside it and refuses,
+because the declared `current-version` did not move. Nothing in the `release:` block is touched --
+not `current-version`, not `next-version`, not `create-github-release` -- and that is the whole
+point of the control. The guard's two refusal predicates and its central ownership are described in
+<<guard-refusal-predicates>> and decided by ADR-0035; they are consumed here, not restated.
+
+*The run is identified by a rule, not by a value:* *the Release workflow run attached to this pull
+request's merge commit*. No run id is committed here. An id would need a future edit to stay
+correct, and a placeholder for one would be an untrue statement sitting in the tree.
+
+*The predicted signature is a conjunction of four rows:*
+
+. `release / guard` -- *success*
+. `release.outputs.released-version` -- *empty*
+. `release / release` -- *skipped*
+. `Publish the tested image to GHCR` (`publish-image`) -- *skipped*
+
+*Row 4 alone is insufficient.* That same rendering also occurs when the `release` job *fails*.
+Without row 1 you cannot tell *refused by decision* from *died before deciding* -- and a crashed
+guard, the more alarming of the two, wears exactly the same clothes.
+
+*Two further rows are inert, and naming them is required.* `wait-for-maven-central` and
+`propagate-to-consumers` are `if:`-gated on a non-empty `consumers` output, and
+link:../../.github/project.yml[`.github/project.yml`] declares no `consumers` key at all. They skip
+on every run of this workflow and so carry no information in either direction. Left unnamed, a
+reader counts three skips and credits two of them.
+
+*Cite the specific prefixed rows, never "the release job".* The run renders the called workflow's
+inner jobs prefixed -- `release / guard`, `release / release`. There is no separate outer row to
+cite.
+
+*The absence evidence is end-state corroboration only.* No new tag, no Maven Central artifact, no
+GHCR push. On its own it passes vacuously: it is equally true of every non-release merge in this
+repository's history. It is retained because it corroborates the four rows, never because it
+substitutes for them.
+
+*Provenance of the discriminator.* link:../../.github/workflows/release.yml[`release.yml`] lines
+87--101 state the workflow's own contract: `released-version` "is EMPTY exactly when the central
+guard decided the declared version had not changed and skipped the release". The evidence is the
+mechanism's declared contract, not an inference drawn over its behaviour.
+
+*Escalation condition.* If the observed rendering does not match the predicted signature, that is a
+finding about the guard, not a run id to file. It goes in-tree, in a follow-up PR, and the
+artifact's claim is withdrawn until it does.
+
+The observed run id and the rendered conclusions are posted as a comment on the merged pull request
+-- public, permanent, and reachable from the merge commit -- not committed here.
+
+[#guard-negative-control-limits]
+=== What that control proves, and what it does not
+
+*The caveat, undiminished:* the four-row signature above is *also* exactly what a guard permanently
+stuck on "unchanged" would render. Such a guard refuses this merge for entirely the wrong reason and
+looks identical doing it. The control therefore proves the guard *refused*. It does *not* prove the
+guard *can proceed*, and it must never be cited as though it did.
+
+*Two things settle that, and both are cited rather than re-manufactured.* The 0.1.1 cut -- run
+`31157727796` -- is the positive control: the guard did let a release through when the declared
+version had genuinely moved, so a second deliberate release is not needed to re-establish it. And
+the checkout depth of the pinned reusable workflow is what settles the *mechanism*, because the
+guard decides by comparing the declared version against the parent commit and can only do so when
+the checkout actually reaches that commit. Citing one without the other lets the negative control
+imply more than it shows.
+
+*The asymmetry is recorded, not erased.* The two stuck-guard failure modes are not equally bad:
+
+* *Stuck on "unchanged" fails SAFE.* Releases are blocked -- visible, annoying, and recoverable
+  through the `workflow_dispatch` path, which carries no version-changed guard at all.
+* *Stuck on "changed" fails DANGEROUS.* It publishes irrevocably. A wrong GA coordinate cannot be
+  withdrawn, only abandoned and relocation-stubbed, as the 2026-07-12 defect required.
+
+The dangerous direction is therefore the one worth an empirical control, and it is the one this
+control covers -- deliberately, and first. *Anyone later tempted to "balance" the two directions
+must not do so by weakening the negative control.* The remedy for an under-evidenced safe direction
+is more evidence on that side, never less on this one.
 
 === A trigger removal merges on its own
 


### PR DESCRIPTION
## Summary

Closes a gate-coverage hole and runs the release guard's negative control, in that order.

`CLAUDE.md` enumerates the file classes whose change obliges a full quality gate. `.plan/marshal.json`'s
`build.map.java` block — the file-to-build contract `build-decision` is the sole authority over — did not
cover five of them: `.github/workflows/**`, `Dockerfile*`, `docker-compose*.yml`, `*.css`, `*.ts`. A
footprint made only of those paths answered `not_necessary` and reached `main` ungated. The direction of
the fix is not up for re-litigation: **the map was wrong, the declared rule is right** — `CLAUDE.md` was
never weakened to match the map.

The five entries are then **pinned by a test**, because the eraser is a command, not a reader: they are
hand-added, no extension's `classify_globs()` derives them, and `build-map seed --force` or a
`marshall-steward` reconcile rewrites the block from the derivation and drops them silently. The contract
test converts that silence into a red build.

Finally, one non-`release:` key of `.github/project.yml` is changed, which is the merge that exercises the
release guard's refusal path.

## Changes

- **`.plan/marshal.json`** — five `build.map.java` entries added, each `role: config` / `build_class: verify`:
  `.github/workflows/*`, `Dockerfile*`, `docker-compose*.yml`, `*.css`, `*.ts`. The recursive `**` spelling
  of the prose declaration is respelled `.github/workflows/*` because the route contract admits single-`*`
  fnmatch globs and bare basenames but never `**`. `*.ts` has no live file in the tree today and is added
  anyway — **the map encodes the rule, not the current file census**.
- **`api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java`** — new
  contract test pinning those five globs with their `role` and `build_class`. Containment, not equality, so
  a legitimate future seed adding a Maven route does not fail it; only losing one of the five, or demoting a
  required entry's `build_class` away from `verify`, may. Carries two vacuity guards (required-set
  cardinality, parsed-array non-emptiness) and a matched positive/negative control over the extraction
  helper, so the primary assertion cannot pass by iterating over nothing or by accepting everything.
- **`CLAUDE.md`** — one paragraph beside the Pre-Commit Process rule recording that the enumeration and the
  `build.map` contract now cover the same classes, and stating the cost.
- **`doc/development/release-process.adoc`** — two subsections under the existing `Trigger rules` spine: the
  negative-control design with its prediction, and what that control proves and does not.
- **`.github/project.yml`** — `github-automation.auto-merge-build-timeout` 300 → 900. A single non-`release:`
  key; the `release:` block is untouched. This edit is the negative control's trigger.

## What this costs, stated plainly

Every workflow, Dockerfile, compose, CSS and TypeScript change now pays a **full quality gate** instead of
passing as documentation-only. That is the intended trade — the price of the rule `CLAUDE.md` already
declared — not a regression to be tuned away later.

## Correction: the claimed "free self-test" is WITHDRAWN

The plan's request predicted a positive control obtained for free: sequence the map fix first, and the
`.github/project.yml` edit becomes the first footprint the fix gates. **That claim is false and is withdrawn
here rather than quietly dropped.** `.github/project.yml` is under neither `.github/workflows/**` (the class
actually added to the map) nor a bare `.github/**` (never proposed as an entry). The fix therefore never
installs the class the self-test needed, and this PR's own footprint is gated by its `*.java` and `*.adoc`
content, not by the new entries. The new globs are exercised by the contract test, not by this diff.

## The negative control is falsifiable, and NOT YET OBSERVED

The run this PR predicts **does not exist until this PR merges**. Everything below was written before the
merge that tests it; that ordering is the whole point, since an artifact written afterwards can only agree
with whatever happened.

**Identification rule** (no run id is committed, and no placeholder for one): *the Release workflow run
attached to this pull request's merge commit*.

**Predicted signature — a conjunction of four rows:**

1. `release / guard` — **success**
2. `release.outputs.released-version` — **empty**
3. `release / release` — **skipped**
4. `Publish the tested image to GHCR` (`publish-image`) — **skipped**

Row 4 alone is insufficient: the same rendering occurs when the `release` job *fails*. Without row 1 you
cannot distinguish *refused by decision* from *died before deciding*, and the crashed guard — the more
alarming case — wears exactly the same clothes.

**Two further rows are inert in both directions.** `wait-for-maven-central` and `propagate-to-consumers` are
`if:`-gated on a non-empty `consumers` output, and `.github/project.yml` declares no `consumers` key at all.
They skip on every run of this workflow and carry no information either way. Left unnamed, a reader counts
three skips and credits two of them.

**Escalation condition.** A rendering that does not match this prediction is **a finding about the guard, not
a run id to file**. It goes in-tree in a follow-up PR, and the artifact's claim is withdrawn until it holds.

The observed run id and the rendered conclusions are posted as a comment on this PR after the merge.

**The caveat is undiminished.** This signature is *also* what a guard permanently stuck on "unchanged" would
render. The control proves the guard **refused**; it does not prove the guard **can proceed**, and it must
never be cited as though it did. The positive direction is cited rather than re-manufactured (the 0.1.1 cut,
run `31157727796`) together with the pinned reusable workflow's checkout depth, which is what settles the
mechanism. The asymmetry is recorded rather than erased: stuck-unchanged fails SAFE, stuck-changed publishes
irrevocably — so the dangerous direction is the one worth an empirical control, and anyone later tempted to
"balance" the two must not do so by weakening this one.

## Test Plan

- [x] Quality gate passed (`verify -Ppre-commit`)
- [x] Full verify passed (`verify`)
- [x] `BuildGateCoverageContractTest` green, including its matched positive/negative detector control

The gate was run **explicitly for this footprint, regardless of the `build-decision` verdict**. The
deliverable that installs the gate must not itself ship through the hole it closes — accepting a
`not_necessary` verdict here would have been the exact failure this PR exists to remove.

## Intent

**The problem.** `CLAUDE.md` declares which file classes oblige a full quality gate, but `.plan/marshal.json`'s `build.map.java` — the contract `build-decision` actually reads — covered five of them with nothing: workflow YAML, `Dockerfile*`, `docker-compose*.yml`, `*.css`, `*.ts`. A footprint made only of those answered `not_necessary` and reached `main` ungated. Separately, this epic had verified the release guard only in the direction where it *permits* a release; it had never observed it *refuse*.

**The chosen approach.** Fix the map, not the rule — the declaration is right and was never weakened to match. Then pin the five entries with a JUnit contract test, because they are hand-added, no extension derives them, and `build-map seed --force` or a steward reconcile rewrites the block from the derivation and drops them with no local symptom. A caveat in prose does not survive a command; a red build does. Finally, change one non-`release:` key of `.github/project.yml`, which is the merge that exercises the guard's refusal path — and commit the prediction *before* that merge, so the observation is falsifiable rather than confirmatory.

**Explicit non-goals.** No file under `.github/workflows/` is edited, and the `release:` block is untouched. No release is cut and no second positive control is manufactured — the 0.1.1 cut is cited instead. No run id and no placeholder for

_[Intent truncated — 1396 of 1702 characters shown; full outline in the plan workspace]_

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Automation**
  * Increased the automatic merge build timeout to allow longer-running verification processes.
  * Expanded verification coverage for stylesheets, TypeScript, workflows, Dockerfiles, and Docker Compose files.
  * Clarified when release publication is skipped because the version is unchanged or its tag already exists.

* **Documentation**
  * Clarified pre-commit classification rules and full verification requirements.
  * Added release-process guidance for validation controls, expected outcomes, evidence, and escalation.

* **Tests**
  * Added contract coverage to detect missing or incorrect verification mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->