### PR TITLE
feat(pr-agent): add the Java instruction pack and the missing AGENTS.md

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,50 @@
+# Repository-local PR-Agent configuration — GENERATED, do not edit by hand.
+#
+# Pack: java. Regenerate with:
+#   python3 marketplace/targets/generate.py --target pr-agent --output . --packs java
+#
+# Merged ABOVE the organisation-wide cuioss/pr-agent-settings configuration, so this
+# file carries the per-domain reviewer pack ONLY and inherits every other key — model,
+# token budgets, output suppression — from that file. Restating those here would
+# decentralize the configuration that file exists to centralize.
+#
+# A repository carries exactly ONE pack: a regeneration REPLACES the pack below rather
+# than appending to it. One pack may COMPOSE several derived domains — a repository is
+# not always one language — and the composed pack still contributes exactly one review
+# category, so composition never widens the category ceiling.
+
+[pr_reviewer]
+extra_instructions = '''
+Prioritise security and correctness over style. This pack is scoped to the java domain.
+
+Report every issue you can substantiate, in these categories:
+- Concurrency and time-of-check/time-of-use races; non-atomic file or state mutation; operations that are unsafe to retry or to run twice.
+- Resource lifecycle: handles, locks, temporary files and subprocesses that leak or are not released on the error path.
+- Fail-open error handling where fail-closed is required; swallowed exceptions; a guard whose predicate cannot fire; validation that admits the empty or degenerate input.
+- Correctness bugs whose impact is data loss, state corruption, or a silently wrong result.
+- Injection, deserialization, path traversal, SSRF and unsafe reflection.
+- Authentication, authorization and trust-boundary errors; privilege escalation.
+- Secret and credential handling, including values reaching logs or error messages.
+- Dependency and supply-chain risk introduced by the change.
+- Missing negative or adversarial test coverage for any of the above.
+- Defects specific to java: the rules this organisation enforces for java code are listed under "Domain rules" below.
+
+Cross-cutting foundations to apply in every review: adversarial refute, authentication authorization, cryptography key management, dependency supply chain, input validation trust boundaries, owasp top ten, secrets handling, secure design principles, secure logging, threat modeling stride.
+
+Domain rules — this organisation's own standards for java code. A diff that breaks one of these is a finding, and the rule already names the mechanism:
+- Do not log authentication tokens, passwords, secrets, certificate contents, PII, or session identifiers
+- Do not hardcode secrets in source; resolve all secrets from external configuration
+- Do not silently coerce invalid inbound data; reject on any constraint violation at the trust boundary
+- Do not leak internal details (paths, credentials, stack internals) in error messages returned to callers
+- Externally-sourced data (deserialized payloads, file inputs, CLI arguments, message-queue bodies) must be validated at the trust boundary before use
+- Security configuration must be validated fail-fast at startup, not lazily at runtime
+- Security events are logged; sensitive data is masked or omitted
+
+For each finding, name the input or state that triggers it and what goes wrong. Overlap with other reviewers is acceptable — report the issue regardless of whether another tool might also catch it. Do not withhold a substantiated finding because it seems minor or obvious.
+
+If the pull request description states what the change is intended to do, treat that as a claim to be checked, not as established fact. Report where the implementation diverges from the stated intent, and never treat agreement with it as evidence that the code is correct.
+
+Severity is not a reporting threshold. Report a finding you can substantiate even when it is narrow, cheap to fix, or confined to test code — the reader decides what to act on, and a finding declined as minor costs one line of triage. Do not weigh whether an issue is important enough to mention.
+
+An empty list remains the correct answer when the diff genuinely carries nothing substantiable, and you must never invent a finding, pad the list, or report an issue whose mechanism you have not traced in the code shown. But do not return an empty list because nothing reached a bar of severity or importance. There is no such bar.
+'''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AGENTS.md
+
+Guidelines for AI assistants working in the API-Sheriff repository.
+
+## What This Repository Is
+
+A security-focused API Gateway taking a lightweight approach, in pre-1.0 development. Maven,
+Java 25 (compile and runtime; CI matrix 25 and 26), Quarkus 3.37.4, following CUI (CUIoss)
+standards.
+
+Modules:
+
+- `api-sheriff/` — deployable Quarkus application: core library, CDI producers, REST endpoints,
+  native executable
+- `integration-tests/` — integration test coordinator: Docker infrastructure, IT suites, scripts
+- `benchmarks/` — WRK HTTP load-testing benchmarks
+
+Because the product is a security gateway, every change is a security change until shown
+otherwise. Treat security implications as part of the diff, not as a separate review pass.
+
+## Build Commands
+
+Never hard-code a Maven binary (`mvn`, `./mvnw`). Every Maven invocation goes through the
+executor, which supplies the wrapper:
+
+```bash
+python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "<goals and options>" [--project-dir <path>]
+```
+
+`--command-args` takes any goals and options — profiles, `-pl`, `-Dtest=…`, system properties —
+and never the binary itself. `--project-dir` builds a checkout outside the main tree (an ad-hoc
+worktree, for instance) and replaces `cd`-ing into it.
+
+Common invocations, examples rather than a closed set:
+
+```bash
+--command-args "compile"                                              # compile
+--command-args "verify -Ppre-commit"                                  # quality gate
+--command-args "verify"                                               # full verify
+--command-args "verify -Pcoverage"                                    # coverage
+--command-args "test -pl api-sheriff -am"                             # module tests
+--command-args "verify -Pintegration-tests -pl integration-tests -am" # integration tests
+--command-args "verify -Pbenchmark -pl benchmarks -am"                # benchmarks
+--command-args "test -pl api-sheriff -Dtest=ConfigLoaderTest"         # one test
+```
+
+Use a 10-minute Bash timeout (600000ms) for build invocations, and read the TOON result —
+`status`, `errors[N]{file,line,message,category}`, `log_file` — rather than the exit code.
+
+The executor rule covers Maven only. The one genuinely non-Maven tool is the production image
+build, which runs directly:
+
+```bash
+docker build -f api-sheriff/src/main/docker/Dockerfile.native -t api-sheriff:latest api-sheriff/
+```
+
+## Before Every Commit
+
+Both must pass with zero errors and zero warnings:
+
+1. The quality gate (`verify -Ppre-commit`)
+2. Full verify (`verify`)
+
+This applies to every commit, including a commit that only fixes a review comment.
+
+## Pre-1.0 Rules (highest priority)
+
+The project is pre-1.0 and behaves like it. These override the usual instinct toward caution:
+
+- Never deprecate — remove the code directly
+- Never add `@Deprecated`
+- Never preserve backward compatibility — make breaking changes freely
+- Clean APIs aggressively: unused methods, classes and patterns go
+
+A change that keeps an old surface alive "to be safe" is wrong here, not conservative.
+
+## Code Standards
+
+- Java 25 features are encouraged: records, sealed classes, pattern matching, text blocks,
+  virtual threads
+- Lombok: `@Builder`, `@Value`, `@NonNull`, `@ToString`, `@EqualsAndHashCode`
+- Prefer immutable objects and final fields; return empty collections rather than null, and
+  `Optional` for a genuinely nullable return
+- 4-space indentation, LF line endings, UTF-8
+
+### Logging
+
+- `de.cuioss.tools.logging.CuiLogger`, held as `private static final LOGGER`
+- Always `%s` for substitution — never `{}`, `%.2f` or `%d`
+- `de.cuioss.tools.logging.LogRecord` for INFO, WARN and ERROR
+- Identifier ranges: INFO 001-099, WARN 100-199, ERROR 200-299
+- The exception parameter always comes first
+- Document messages in `doc/LogMessages.adoc`
+- Never log tokens, passwords, secrets, certificate contents, PII or session identifiers
+
+### Testing
+
+- JUnit 5 only, arranged as Arrange-Act-Assert
+- Minimum 80% coverage
+- CUI Test Generator for test data, `@GeneratorsSource` preferred
+- Forbidden: Mockito, PowerMock, Hamcrest
+
+### Javadoc
+
+- Every public and protected class and method is documented, with `@since`, thread-safety notes
+  and usage examples
+- Every package carries a `package-info.java`
+
+## OpenRewrite Markers
+
+A marker such as `/*~~(TODO: INFO needs LogRecord)~~>*/` marks an actual bug, not a suggestion.
+Fix placeholder and parameter mismatches and wrong format specifiers, create `LogRecord`
+constants for production INFO/WARN/ERROR logs, and replace generic `Exception` or
+`RuntimeException` with a specific type. For diagnostic logging in tests, suppress with
+`// cui-rewrite:disable CuiLogRecordPatternRecipe`. Never commit code with a marker still in it.
+
+## Security
+
+- Validate all inputs and outputs at the trust boundary, and reject rather than coerce
+- Never expose sensitive data in logs or in error messages returned to callers
+- Follow OWASP guidance and prefer secure defaults
+- Resolve secrets from external configuration; never hardcode them
+- Validate security configuration fail-fast at startup rather than lazily at runtime
+
+## Sonar
+
+The cuioss-organization SonarCloud gate (project `cuioss_API-Sheriff`, declared in
+`.github/project.yml`) is authoritative and blocking. Target zero new findings. Never merge over
+a red gate, nor over a green one that is stale while analysis is still pending. Thresholds are
+organization-owned — reference the gate rather than restating them.
+
+Fix by default. Where a fix is genuinely not sensible — a false positive, a deliberate idiom, a
+rule fighting the design — suppress in code with a rationale (`// NOSONAR java:SXXXX <why>` or
+`@SuppressWarnings("java:SXXXX")`), never by marking the issue won't-fix or false-positive in the
+Sonar UI. See `doc/development/sonar-quality-gate.adoc`.
+
+## Dependencies
+
+Parent POM is `de.cuioss:cui-java-parent`. Never add a dependency without explicit user approval.
+
+## Git Workflow
+
+This section governs ad-hoc changes. Work executed through plan-marshall is governed by
+`.plan/marshal.json` and the per-plan execution manifest instead, including merge behaviour,
+review triage and branch cleanup.
+
+`main` is branch-protected in every cuioss repository — a direct push is never allowed. Batch
+related changes into one pull request; open a second only when one would exceed 150 changed
+files.
+
+1. Branch: `git checkout -b <branch-name>`
+2. Commit, then push with `git push -u origin <branch-name>`
+3. Open the pull request against `main`
+4. Wait for CI and the three automated reviewers — CodeRabbit, Sourcery and PR-Agent
+5. Treat the union of all three reviewers' comments as the work list. Every comment gets a reply
+   and is resolved: fix and explain, or explain why not. When not fully confident, ask the user
+   rather than deciding
+6. Re-review after a fix push is not uniform — CodeRabbit and Sourcery re-review automatically,
+   PR-Agent does not. Request it explicitly by posting a `/review` comment
+7. Do not enable auto-merge unless told to
+8. After the merge, check both the PR-attached post-merge run and the main-branch run (the
+   snapshot deployment appears only on the merge commit, never on the pull request), and assert
+   there are no unresolved review threads
+9. Return to `main` and pull
+
+## Temporary Files
+
+Use `.plan/temp/` for all temporary and generated files.
+
+## Tool Usage
+
+Use the Edit, Read and Write tools rather than shell commands such as `echo` or `cat`, and use
+Glob, Read and Grep rather than `find`, `grep`, `cat` or `ls` for file operations.


### PR DESCRIPTION
## Intent

Give this repository a Java instruction pack for the org's third reviewer, and close the
`AGENTS.md` gap that has been silently starving it of project context.

This is deliverable 8 of PLAN-PR-022 (`a-generic-charter-cannot-see-a-language-specific-defect`),
whose host-side work landed in `cuioss/plan-marshall#1130`.

## The measured problem

The org's PR-Agent reviewer runs **one generic charter** against every repository, and a 58-PR
sweep measured what that costs here: findings on 4 of 13 Python/markdown pull requests and on
**0 of 19 Java** ones — this repository and `TokenSheriff` being the Java half.

That zero is not diff clipping. `API-Sheriff#196`'s run logged
`Tokens: 14603, total tokens under limit: 256000, returning full diff` and
`PR main language: Java`, and the model still returned `key_issues_to_review: []`. The reviewer
saw the whole diff and had nothing to say about it.

The cause is the charter's vocabulary. Its concrete cues — file handles, temp files, subprocesses,
`os.open`, `shutil` — are Python-shaped. No Java, Maven/Gradle or JVM defect vocabulary reached the
model at all.

## What changed

- **`.pr_agent.toml`** — a repo-local file carrying the generated **Java** instruction pack. A
  repo-local `.pr_agent.toml` is read and merged *above* the org file (`use_repo_settings_file`
  is true), so this is a swap of the domain rules rather than an accumulation on top of them.
  The pack is generated from `plan-marshall`'s own Java security standards by the new `pr-agent`
  export target, so the rules are instrumented rather than freshly invented.
- **`AGENTS.md`** — new. It was configured in `repo_context_files` but **absent from this
  repository** (HTTP 404 on the contents API), and the run log said so plainly:
  `Repo context file is empty or missing: AGENTS.md`. The reviewer was being pointed at a document
  that did not exist, so this repo's project rules have never reached it.

## Why the pack does not simply grow the charter

Accumulating categories is refuted by the org's own rule: *"If the category list keeps expanding
past roughly ten entries, the answer is a second focused pass — not an eleventh bullet."* The
central charter already carries nine categories, so appending language bullets would cross that
ceiling immediately. The packs are therefore **selected and swapped**, and the generator holds any
composed pack at exactly ten category bullets regardless of how many domains it covers — pinned by
a regression guard on the `plan-marshall` side that also fails if a generated pack drops the
anti-fabrication clause.

## Merge order

This PR is the **third** of three coupled changes:

1. `cuioss/pr-agent-settings#14` — adds the central `[pr_code_suggestions]` block
2. `cuioss/cuioss-organization#237` — label-gates `/improve` behind `pr-agent-improve`
3. **this PR** (and its `TokenSheriff` twin) — roll the generated Java packs out

The pack itself is independent of (1) and (2) — it changes what the reviewer is told, not whether
`/improve` runs — so this can land on its own if the other two are delayed.

## How to tell whether it worked

The falsifiable check is a re-review of a closed Java pull request that CodeRabbit found
in-charter defects on — `API-Sheriff#185` (26 CodeRabbit inline items) or `#154` (47) — with this
pack installed, compared against the recorded empty result.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project guidance covering development practices, testing, security, compatibility, and contribution workflows.
  * Documented Java-specific review standards and required issue classifications to support more consistent quality and security assessments.

* **Chores**
  * Added configuration for automated reviews, emphasizing correctness, security, and actionable findings without speculative issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->