### PR TITLE
chore: declare inceptionYear 2025 and drop the local year hardcode

### DIFF
--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffApplication.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffLogMessages.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/ApiSheriffLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/AssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/PathConfinement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/asset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/AuthenticationStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/AuthenticationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/GatewayValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/GatewayValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/BffLogMessages.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/BffLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/CookieKeyMaterial.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/CookieKeyMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/CookieSessionBinding.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/CookieSessionBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionCookieCodec.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionCookieCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionPayload.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/cookie/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/csrf/CsrfDefence.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/csrf/CsrfDefence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/csrf/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/csrf/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/LoginFlow.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/LoginFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/QueryResponseModeAuthorizationRequestBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/QueryResponseModeAuthorizationRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/login/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/BackchannelLogoutReceiver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/BackchannelLogoutReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/LogoutTokenValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/LogoutTokenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/RpInitiatedLogout.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/RpInitiatedLogout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/logout/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/BindingCookieCodec.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/BindingCookieCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationRecord.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/pending/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/StepUpCoordinator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/StepUpCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/refresh/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/BackchannelLogoutEndpoint.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/BackchannelLogoutEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/CallbackEndpoint.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/CallbackEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/ClaimAllowlistFilter.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/ClaimAllowlistFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpoint.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpoint.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/ReservedPathRegistry.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/ReservedPathRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpoint.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/reserved/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/BffRuntime.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/BffRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/JsonWriter.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/JsonWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/runtime/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBinding.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionBinding.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionCookieCodec.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionCookieCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionRecord.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionStore.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/SessionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/bff/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/ConfigLogMessages.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/ConfigLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/NeutralTlsConfigSource.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/NeutralTlsConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/RouteTableBuilder.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/RouteTableBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigError.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoadException.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/ConfigLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/load/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AccessLevel.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AccessLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorType.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AnchorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AssetDefaultsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AuthConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/AuthConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EdgeHardeningConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EdgeHardeningConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EndpointConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/EndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardedConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ForwardedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/GatewayConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/GatewayConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/HttpMethod.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/IssuerConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/IssuerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ManagementConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ManagementConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/MatchConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/MatchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Metadata.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/OidcConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/OidcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Protocol.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RateLimitConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RateLimitConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Require.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/Require.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedAsset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedTopology.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedUpstream.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/ResolvedUpstream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteTable.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/RouteTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityConfigurations.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityConfigurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityDefaultsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityFilterConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityFilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityHeadersConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityHeadersConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityProfile.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/SecurityProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TlsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TlsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TokenValidationConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/TokenValidationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamDefaultsConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/UpstreamDefaultsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/WebSocketConfig.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/WebSocketConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolver.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/topology/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/ValidationRule.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/ValidationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/config/validation/rule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/DispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/DispatchStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningOptions.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapper.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/ResponseStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssembler.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapper.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/edge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventCategory.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventType.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayEventCounter.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayException.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/GatewayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/events/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/TcpPeerGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/TcpPeerGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/forward/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/ConnectionHeaders.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/ConnectionHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuard.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/FramingGate.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/FramingGate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PassthroughHostGuardStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PassthroughHostGuardStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PipelineRequest.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/PipelineRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStage.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/pipeline/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/BffRuntimeProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/BffRuntimeProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflection.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/GatewayReadinessCheck.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/GatewayReadinessCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetrics.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/TokenClientDslJsonReflection.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/TokenClientDslJsonReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/quarkus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/HttpProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/HttpProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessorRegistry.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/ProtocolProcessorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteMatcher.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteRuntime.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/RouteRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessor.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/routing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/ClientHelloSniParser.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/ClientHelloSniParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/ManagementPlainHttpAudit.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/ManagementPlainHttpAudit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/MtlsServerCustomizer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/MtlsServerCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/PassthroughRelay.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/PassthroughRelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/SniFrontListener.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/SniFrontListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/TlsEdgeProducer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/TlsEdgeProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/TlsServerCustomizer.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/TlsServerCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/package-info.java
+++ b/api-sheriff/src/main/java/de/cuioss/sheriff/gateway/tls/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/LogMessagesCatalogueTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/LogMessagesCatalogueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/FrameworkAgnosticArchTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/FrameworkAgnosticArchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/NativeRuntimeInitRegistrationArchTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/NativeRuntimeInitRegistrationArchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/NoStoredOptionalArchTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/NoStoredOptionalArchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/NullableFieldSpecimen.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/NullableFieldSpecimen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/OptionalFieldSpecimen.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/OptionalFieldSpecimen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/StaticSecureRandomSpecimen.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/arch/specimen/StaticSecureRandomSpecimen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetResponseEnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetSourceServedTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/AssetSourceServedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/DirectoryAssetSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/PathConfinementTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/PathConfinementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceHttpFetcherTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceHttpFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/asset/UpstreamAssetSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/AuthenticationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/JwksTrustProfileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/MountedTlsMapKeyTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/MountedTlsMapKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TestTlsConfigurationRegistry.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TestTlsConfigurationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/auth/TokenValidatorProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/CookieKeyMaterialTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/CookieKeyMaterialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/CookieSessionBindingTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/CookieSessionBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionCookieCodecTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionCookieCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionPayloadTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/cookie/SealedSessionPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/csrf/CsrfDefenceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/csrf/CsrfDefenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/login/LoginFlowTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/login/LoginFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/login/QueryResponseModeAuthorizationRequestBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/login/QueryResponseModeAuthorizationRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/logout/LogoutTokenValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/logout/LogoutTokenValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/logout/RpInitiatedLogoutTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/logout/RpInitiatedLogoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/pending/BindingCookieCodecTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/pending/BindingCookieCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationStoreTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/pending/PendingAuthorizationStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/StepUpCoordinatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/StepUpCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/refresh/TokenRefreshCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/BackchannelLogoutEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/BackchannelLogoutEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/CallbackEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/CallbackEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/ClaimAllowlistFilterTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/ClaimAllowlistFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LoginInitiationEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/LogoutEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/ReservedPathRegistryTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/ReservedPathRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpointTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/reserved/UserInfoEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/JsonWriterTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/JsonWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/runtime/SessionAuthenticationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/InMemorySessionStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBindingTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/ServerSessionBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/SessionCookieCodecTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/bff/session/SessionCookieCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/BuildGateCoverageContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/DocumentedSetsContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/NeutralTlsConfigSourceTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/NeutralTlsConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/RouteTableBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/SingleSourceTlsContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/SingleSourceTlsContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/ConfigLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/load/EnvSecretResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/ConfigModelContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/SecurityProfileTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/model/SecurityProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolverTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/topology/TopologyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorRouteDisjointnessTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorRouteDisjointnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/config/validation/ConfigValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/DispatchStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/EdgeHardeningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgePipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteBffWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GatewayEdgeRouteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcDispatchStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapperTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/GrpcStatusMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ReservedBodyCeilingTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ReservedBodyCeilingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/ResponseStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssemblerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/RouteRuntimeAssemblerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/StreamAwareRetryGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapperTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/UpstreamFailureMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/edge/WebSocketRelayStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/EventTypeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/EventTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/GatewayEventCounterTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/events/GatewayEventCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/ForwardPolicyStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/TcpPeerGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/forward/TcpPeerGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/http/ConnectionHeadersTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/http/ConnectionHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/BasicChecksStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuardTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/CanonicalPathGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/FramingGateTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/FramingGateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/OriginValidationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/PassthroughHostGuardStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/PassthroughHostGuardStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/RouteSelectionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/SecurityHeadersStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/ThoroughChecksStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStageTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/pipeline/VerbGateStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/BffRuntimeProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/BffRuntimeProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigFailFastTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigFailFastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflectionTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigModelReflectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ConfigProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/CookieModeBootTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/CookieModeBootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/DefaultProfileReadinessTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/DefaultProfileReadinessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ExtensionUnqualifiedBeanExclusionTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ExtensionUnqualifiedBeanExclusionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetricsTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/SheriffMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ShippedApplicationPropertiesTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/quarkus/ShippedApplicationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/GrpcProtocolProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/RouteRuntimeTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/RouteRuntimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessorTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/routing/WebSocketProtocolProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/ClientHelloSniParserTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/ClientHelloSniParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/ManagementPlainHttpAuditTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/ManagementPlainHttpAuditTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/MtlsServerCustomizerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/MtlsServerCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/PassthroughRelayTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/PassthroughRelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/SniFrontListenerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/SniFrontListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/TlsEdgeProducerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/TlsEdgeProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/TlsServerCustomizerTest.java
+++ b/api-sheriff/src/test/java/de/cuioss/sheriff/gateway/tls/TlsServerCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriter.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverter.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkLogMessages.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6ResultPostProcessor.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/K6ResultPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/PassthroughBaselineComparator.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/PassthroughBaselineComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/package-info.java
+++ b/benchmarks/src/main/java/de/cuioss/sheriff/gateway/k6/benchmark/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriterTest.java
+++ b/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/ComparisonSummaryWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverterTest.java
+++ b/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/K6BenchmarkConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/PassthroughBaselineComparatorTest.java
+++ b/benchmarks/src/test/java/de/cuioss/sheriff/gateway/k6/benchmark/PassthroughBaselineComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoService.java
+++ b/integration-tests/src/main/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ApiSheriffIntegrationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ApiSheriffIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/AssetContentTypeActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/AssetContentTypeActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BaseIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerSecurityFilterInteractionIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerSecurityFilterInteractionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BearerValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BenchmarkRealmCredentialConsistencyTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BenchmarkRealmCredentialConsistencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieBackchannelDisabledIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieBackchannelDisabledIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieSessionIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieSessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieStatelessnessIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCookieStatelessnessIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCsrfIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffCsrfIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffKeycloakLoginFlow.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffKeycloakLoginFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffLoginInitiationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffLoginInitiationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffLogoutIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffLogoutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffSessionLoginIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffSessionLoginIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffSessionMediationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffSessionMediationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffUserInfoIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BffUserInfoIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BodyLimitActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/BodyLimitActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/CipherSuiteFixtureWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/CipherSuiteFixtureWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ConfigLoadedIntegrationIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ConfigLoadedIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DeclaredLimitBoundaryIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DeclaredLimitBoundaryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DescriptorInventoryWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DirectoryAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/DirectoryAssetServingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/EgressAllowlistActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ErrorContractIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ErrorContractIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GetWithBodyActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GetWithBodyActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GetWithBodyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GetWithBodyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GracefulShutdownIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GracefulShutdownIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GrpcProxyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/GrpcProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/HostSmuggleGuardIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/HostSmuggleGuardIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageLabelActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageLabelActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageLabelInspector.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageLabelInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageMetadataIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageMetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageMetadataJfrIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ImageMetadataJfrIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ItProfileConfigBindingWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ItProfileConfigBindingWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/LargeBodyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/LargeBodyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ManagementPlainHttpActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ManagementPlainHttpActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ManagementPlainHttpOptOutIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/ManagementPlainHttpOptOutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MetricsIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MtlsHandshakeIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/MtlsHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PassthroughFaultIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PassthroughFaultIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PipelineVerbIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/PipelineVerbIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/SecurityProfileModeIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/SecurityProfileModeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/TlsEdgeActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/TlsEdgeActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/TlsPassthroughIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/TlsPassthroughIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/UpstreamAssetServingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WebSocketProxyIT.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WebSocketProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WsAdmissionActivationWiringTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/WsAdmissionActivationWiringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoServiceTest.java
+++ b/integration-tests/src/test/java/de/cuioss/sheriff/gateway/integration/grpc/GrpcEchoServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>api-sheriff-parent</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <!-- Must be declared: <inceptionYear> is inherited, and the license plugin binds
+         the copyright ${year} to it. Without this, this project would report
+         cui-parent-pom's 2022 and restamp every header on each -Ppre-commit run. -->
+    <inceptionYear>2025</inceptionYear>
     <name>API Sheriff Parent</name>
     <description>An API-Gateway focused on Security and a lightweight approach.
         The module provides robust API gateway capabilities with comprehensive security features,
@@ -456,35 +460,6 @@
                                 <recipe>org.openrewrite.staticanalysis.SimplifyBooleanExpression</recipe>
                                 <recipe>org.openrewrite.staticanalysis.UnnecessaryParentheses</recipe>
                             </activeRecipes>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <!--
-                            Pins the license header's copyright year to 2026.
-
-                            DO NOT DELETE when bumping cui-java-parent. The parent's
-                            pre-commit profile carries the comment "No <year> override:
-                            mycila license-maven-plugin defaults to the current year" and
-                            omits <year> on that basis. That comment is FALSE: mycila
-                            resolves ${year} from the project's <inceptionYear>, not from
-                            the system clock, and no <inceptionYear> is declared anywhere
-                            in this project or its parent chain (cui-java-parent ->
-                            cui-java-bom -> cui-parent-pom). With neither a <year> override
-                            nor an <inceptionYear>, the year does not track the current
-                            year; it regresses to the stale 2022 value, which is how
-                            every header in this repository came to read 2022.
-
-                            Only <year> is overridden here; owner (CUI-OpenSource-Software)
-                            and email (info@cuioss.de) continue to be inherited from the
-                            parent, since Maven merges child <properties> into the parent's
-                            plugin configuration rather than replacing the whole block.
-                        -->
-                        <groupId>com.mycila</groupId>
-                        <artifactId>license-maven-plugin</artifactId>
-                        <configuration>
-                            <properties>
-                                <year>2026</year>
-                            </properties>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Found during the final verification sweep of the org-wide `inceptionYear` rollout. This repo was recorded as already done — it is not. Its three `inceptionYear` matches are all inside a **comment**; there is no declaration.

## What was here

A local workaround: `<year>2026</year>` pinned in this repo's own `pre-commit` profile. Whoever wrote it had diagnosed the parent's false *"defaults to the current year"* comment independently and correctly, and the fix worked. But:

- it **hardcodes a year that goes stale every January**
- it produced **`© 2026`** headers in a project whose first commit is **2025**
- it overrides the `-present` form every other repo now uses

## What replaces it

`<inceptionYear>2025</inceptionYear>`, the same declaration the other 17 repos carry. The parent now emits `<year>${project.inceptionYear}-present</year>`, so the override is both unnecessary and actively wrong.

Headers go **`© 2026` → `© 2025-present`**.

## Verification

The gate ran twice: the second run rewrote nothing and left the same **324** files. Every `.java` header in the tree now reads `© 2025-present`, no stragglers.

`CLAUDE.md` mandates the plan-marshall executor for Maven. It fails in my environment with `ModuleNotFoundError: No module named 'plan_logging'`, so this was verified with the `./mvnw` wrapper the executor itself invokes — worth knowing separately, since it means the documented build path is currently broken outside CI.