### PR TITLE
ci: raise the integration-test timeout to 35 minutes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,11 @@ jobs:
   integration-tests:
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@146d2d377eea7ffae0c73f06df8087a0948a534a # v0.22.0
     with:
+      # This job's own history sits at ~16 minutes (15m33s - 16m39s over the last
+      # four green runs), against the reusable workflow's 20-minute default. ~20%
+      # headroom means ordinary variance in the native build or container pull
+      # cancels the job, which reads as a test failure rather than a timeout.
+      timeout-minutes: 35
       report-name: integration-tests
       maven-args-input: |
         verify -Pintegration-tests -pl integration-tests -am


### PR DESCRIPTION
## What happened

[#227](https://github.com/cuioss/API-Sheriff/pull/227) reported `integration-tests / test` **failed**. It didn't — it was **cancelled at 20m19s** by the job timeout, after all **1873 tests had already passed**.

The giveaway is in the conclusion job's own output:

```
if [[ "cancelled" == "failure" || "cancelled" == "cancelled" ]]; then
##[error]test job failed or was cancelled
```

and the runner tearing down live processes rather than a build finishing:

```
Terminate orphan process: pid (9048) (start-integration-container.sh)
Terminate orphan process: pid (9711) (docker-compose)
```

## Why it is not specific to that PR

This job runs close to the cap. Last four green runs:

| branch | duration |
|---|---|
| `main` | 16m18s |
| `gh-readonly-queue/main/pr-226` | 15m46s |
| `chore/update-org-workflows-v0.22.0` | 15m33s |
| `chore/update-org-workflows-v0.21.0` | 16m39s |

Against `timeout-minutes: 20` that is ~20% headroom, so ordinary variance in the native build or the container pull is enough to cancel it. #227 happened to be the run that crossed the line; any PR could be next.

## Fix

`reusable-maven-integration-tests.yml` already exposes a `timeout-minutes` input (default 20) — this caller simply never set it. Setting **35** gives roughly double the observed runtime.

This is deliberately a separate PR from #227 so a CI-capacity change is not buried in a copyright-header commit. Once this lands, #227 gets updated from `main` and re-run.